### PR TITLE
[FEAT] 메인 페이지 레이아웃 개선 및 주간 일정 섹션 UI 개선

### DIFF
--- a/components/home/HomeCard.tsx
+++ b/components/home/HomeCard.tsx
@@ -10,12 +10,7 @@ type HomeCardProps = {
   className?: string;
 };
 
-export default function HomeCard({
-  title,
-  actionLabel,
-  children,
-  className,
-}: HomeCardProps) {
+export default function HomeCard({ title, actionLabel, children, className }: HomeCardProps) {
   return (
     <Card className={className}>
       <Header>
@@ -31,7 +26,7 @@ const cardShell = css`
   background-color: ${colors.white};
   border: 0.0625rem solid ${colors.border};
   border-radius: ${radii.radius30};
-  padding: ${spacing.space33};
+  padding: ${spacing.space28};
 `;
 
 const Card = styled.section`

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -6,32 +6,37 @@ import LoginCard from "@/components/home/LoginCard";
 import MeetingMinutesCard from "@/components/home/MeetingMinutesCard";
 import NoticeCard from "@/components/home/NoticeCard";
 import WeeklyScheduleCard from "@/components/home/WeeklyScheduleCard";
-import {
-  eventPhotos,
-  meetingMinutes,
-  notices,
-  weeklySchedule,
-} from "@/mocks/home";
+import { eventPhotos, meetingMinutes, notices, weeklySchedule } from "@/mocks/home";
 import { colors, layout, spacing } from "@/styles/tokens";
 
 export default function HomePage() {
   return (
     <Main>
-      <ContentGrid>
-        <LoginArea>
-          <LoginCard />
-        </LoginArea>
-        <ScheduleArea>
-          <WeeklyScheduleCard schedule={weeklySchedule} />
-        </ScheduleArea>
-        <NoticeArea>
-          <NoticeCard notices={notices} />
-        </NoticeArea>
-        <RightStack>
-          <MeetingMinutesCard meetingMinutes={meetingMinutes} />
-          <EventPhotoCard photos={eventPhotos} />
-        </RightStack>
-      </ContentGrid>
+      <Content>
+        <TopRow>
+          <LoginArea>
+            <LoginCard />
+          </LoginArea>
+
+          <ScheduleArea>
+            <WeeklyScheduleCard schedule={weeklySchedule} />
+          </ScheduleArea>
+        </TopRow>
+
+        <BottomGrid>
+          <NoticeArea>
+            <NoticeCard notices={notices} />
+          </NoticeArea>
+
+          <MeetingArea>
+            <MeetingMinutesCard meetingMinutes={meetingMinutes} />
+          </MeetingArea>
+
+          <EventArea>
+            <EventPhotoCard photos={eventPhotos} />
+          </EventArea>
+        </BottomGrid>
+      </Content>
     </Main>
   );
 }
@@ -41,42 +46,46 @@ const Main = styled.main`
   background-color: ${colors.background};
 `;
 
-const ContentGrid = styled.div`
-  display: grid;
-  grid-template-columns: minmax(18rem, 0.78fr) minmax(0, 1.22fr);
-  grid-template-areas:
-    "login schedule"
-    "notice right";
-  gap: ${spacing.space24};
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space40};
   max-width: ${layout.maxWidth};
   margin: 0 auto;
   padding: ${spacing.space40} ${spacing.space20} ${spacing.space47};
+`;
 
-  @media (max-width: ${layout.breakpointTablet}) {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "login"
-      "schedule"
-      "notice"
-      "right";
-  }
+const TopRow = styled.div`
+  display: flex;
+  min-height: 20rem;
+  gap: ${spacing.space24};
+`;
+
+const BottomGrid = styled.div`
+  display: grid;
+  grid-template-columns: 420px minmax(0, 1fr);
+  grid-template-areas:
+    "notice meeting"
+    "notice event";
+  gap: ${spacing.space24};
 `;
 
 const LoginArea = styled.div`
-  grid-area: login;
+  height: 100%;
 `;
 
 const ScheduleArea = styled.div`
-  grid-area: schedule;
+  height: 100%;
 `;
 
 const NoticeArea = styled.div`
   grid-area: notice;
 `;
 
-const RightStack = styled.div`
-  grid-area: right;
-  display: grid;
-  gap: ${spacing.space24};
-  align-content: start;
+const MeetingArea = styled.div`
+  grid-area: meeting;
+`;
+
+const EventArea = styled.div`
+  grid-area: event;
 `;

--- a/components/home/LoginCard.tsx
+++ b/components/home/LoginCard.tsx
@@ -19,19 +19,23 @@ export default function LoginCard() {
 }
 
 const Card = styled(HomeCard)`
-  max-width: 420px;
+  min-width: 400px;
   background-color: ${colors.background};
-`;
-
-const Form = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${spacing.space16};
 `;
 
+const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space40};
+`;
+
 const InputGroup = styled.div`
-  display: grid;
-  gap: ${spacing.space8};
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
 `;
 
 const Input = styled.input`
@@ -58,7 +62,7 @@ const Input = styled.input`
 
 const SubmitButton = styled.button`
   width: 100%;
-  height: 3.25rem;
+  height: 3.5rem;
   border: 0;
   border-radius: ${radii.radius12};
   background-color: ${colors.point};

--- a/components/home/WeeklyScheduleCard.tsx
+++ b/components/home/WeeklyScheduleCard.tsx
@@ -20,45 +20,41 @@ export default function WeeklyScheduleCard({ schedule }: WeeklyScheduleCardProps
 
   return (
     <Card title="주간 일정" actionLabel="전체일정 보기">
-      <ScheduleGrid>
+      <Schedule>
         {schedule.map((daySchedule, index) => {
           const isHighlighted = index === todayIndex;
 
           return (
             <DayColumn key={daySchedule.day} $highlighted={isHighlighted}>
-              <DayLabel>{daySchedule.day}</DayLabel>
+              <DayLabel $highlighted={isHighlighted}>{daySchedule.day}</DayLabel>
               <Divider />
               <ItemList>
-                {daySchedule.items.map((item) => (
+                {daySchedule.items.slice(0, 2).map((item) => (
                   <Item key={`${daySchedule.day}-${item.time}-${item.title}`}>
                     <Time>{item.time}</Time>
                     <ItemTitle>{item.title}</ItemTitle>
+                    <Divider />
                   </Item>
                 ))}
-                {index < schedule.length - 1 ? <MoreText>...</MoreText> : null}
+                {daySchedule.items.length > 2 && <MoreText>...</MoreText>}
+                <Divider />
               </ItemList>
             </DayColumn>
           );
         })}
-      </ScheduleGrid>
+      </Schedule>
     </Card>
   );
 }
 
 const Card = styled(HomeCard)`
+  width: 100%;
   height: 100%;
+  border: none;
 `;
 
-const ScheduleGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: ${spacing.space16};
-
-  @media (max-width: 80rem) {
-    grid-template-columns: repeat(7, minmax(8rem, 1fr));
-    overflow-x: auto;
-    padding-bottom: ${spacing.space8};
-  }
+const Schedule = styled.div`
+  display: flex;
 `;
 
 const DayColumn = styled.article<{ $highlighted: boolean }>`
@@ -69,8 +65,8 @@ const DayColumn = styled.article<{ $highlighted: boolean }>`
   background-color: ${colors.white};
 `;
 
-const DayLabel = styled.h3`
-  color: ${colors.muted};
+const DayLabel = styled.h3<{ $highlighted: boolean }>`
+  color: ${({ $highlighted }) => ($highlighted ? colors.point : colors.muted)};
   font-size: ${typography.fontSize14};
   font-weight: 600;
   line-height: ${typography.lineHeight130};
@@ -79,17 +75,15 @@ const DayLabel = styled.h3`
 
 const Divider = styled.div`
   height: 0.0625rem;
-  margin: ${spacing.space12} 0 ${spacing.space12};
+  margin: ${spacing.space4} 0 ${spacing.space4};
   background-color: ${colors.border};
 `;
 
-const ItemList = styled.div`
-  display: grid;
-  gap: ${spacing.space12};
-`;
+const ItemList = styled.div``;
 
 const Item = styled.div`
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.25rem;
 `;
 
@@ -100,14 +94,10 @@ const Time = styled.span`
 `;
 
 const ItemTitle = styled.span`
-  display: -webkit-box;
-  overflow: hidden;
   color: ${colors.text};
   font-size: ${typography.fontSize14};
   font-weight: 500;
-  line-height: ${typography.lineHeight150};
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  line-height: ${typography.lineHeight130};
 `;
 
 const MoreText = styled.span`

--- a/components/home/WeeklyScheduleCard.tsx
+++ b/components/home/WeeklyScheduleCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dayjs from "dayjs";
 import styled from "styled-components";
 import HomeCard from "@/components/home/HomeCard";
 import { colors, radii, spacing, typography } from "@/styles/tokens";
@@ -9,14 +10,19 @@ type WeeklyScheduleCardProps = {
   schedule: WeeklyScheduleDay[];
 };
 
-export default function WeeklyScheduleCard({
-  schedule,
-}: WeeklyScheduleCardProps) {
+const getMondayBasedIndex = (date = dayjs()) => {
+  const d = date.day();
+  return d === 0 ? 6 : d - 1;
+};
+
+export default function WeeklyScheduleCard({ schedule }: WeeklyScheduleCardProps) {
+  const todayIndex = getMondayBasedIndex();
+
   return (
     <Card title="주간 일정" actionLabel="전체일정 보기">
       <ScheduleGrid>
         {schedule.map((daySchedule, index) => {
-          const isHighlighted = daySchedule.day === "토";
+          const isHighlighted = index === todayIndex;
 
           return (
             <DayColumn key={daySchedule.day} $highlighted={isHighlighted}>
@@ -58,8 +64,7 @@ const ScheduleGrid = styled.div`
 const DayColumn = styled.article<{ $highlighted: boolean }>`
   min-width: 0;
   padding: ${spacing.space16};
-  border: 0.0625rem solid
-    ${({ $highlighted }) => ($highlighted ? colors.point : colors.white)};
+  border: 0.0625rem solid ${({ $highlighted }) => ($highlighted ? colors.point : colors.white)};
   border-radius: ${radii.radius15};
   background-color: ${colors.white};
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "geumjeongyahak_frontend",
       "version": "0.1.0",
       "dependencies": {
+        "dayjs": "^1.11.20",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -2779,6 +2780,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "dayjs": "^1.11.20",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/styles/tokens.ts
+++ b/styles/tokens.ts
@@ -8,6 +8,7 @@ export const colors = {
 };
 
 export const spacing = {
+  space4: "0.25rem", // 4px
   space8: "0.5rem", // 8px
   space12: "0.75rem", // 12px
   space16: "1rem", // 16px


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 메인 페이지의 레이아웃을 개선하였습니다.
- 전체가 grid로 되어있던 기존의 레이아웃을 2줄로 나누어 윗줄을 `TopRow`, 아래줄을 `BottomGrid`로 명명하였습니다.
- `TopRow`는 2개의 카드가 가로로 배치되어있는 형태이기 때문에 **Flex**로 레이아웃을 구현하였습니다.
- `BottomGrid`는 한 줄에 3개의 카드가 그리드로 배치되어있는 형태로 **Grid**로 레이아웃을 구현하였습니다.

<img width="1332" height="662" alt="스크린샷 2026-04-06 오전 12 47 49" src="https://github.com/user-attachments/assets/c7e25e83-e2d2-4a58-82c3-b3c6382cf554" />

2. `WeeklyScheduleCard`를 리팩토링하여 요구조건에 맞게 구현하였습니다.
- `day.js` 라이브러리를 활용하여 현재 날짜의 요일을 구하고, 구한 요일을 월요일 기준 인덱스로 변환하는 유틸 함수를 추가하였습니다.
<img width="1379" height="384" alt="스크린샷 2026-04-06 오전 12 38 43" src="https://github.com/user-attachments/assets/d80d3270-10ee-4ebc-b544-971264ac77f4" />


## 📄 의존성 추가/변경 사항

1. day.js@1.11.20 추가

## 🔍 관련 이슈

Closes #9

## 💬 기타 사항

- 하단의 3개의 카드에 대해서는 레이아웃을 개선하고 세부 구현은 진행하지 않았습니다.

## 📂 참고 자료
- `Day.js`라이브러리 관련 문서 : https://day.js.org/en/