### PR TITLE
[FEAT] 로그인 및 회원 가입 API 연동

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,123 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# Project AGENTS.md
+
+## 주의
+이 프로젝트는 Next.js 16 기반이다.
+기존 학습 데이터 기준의 오래된 App Router 관습이나 예제를 그대로 적용하지 말고,
+필요한 경우 `node_modules/next/dist/docs/`의 관련 가이드를 먼저 확인한다.
+deprecation 경고와 현재 버전 문서를 우선한다.
+
+## 프로젝트 개요
+이 저장소는 Next.js App Router + TypeScript + React 기반 프론트엔드 프로젝트다.
+스타일링은 `styled-components`를 사용하며, 테스트는 Vitest + jsdom + MSW 기반 흐름을 갖고 있다.
+
+## 기술 스택
+- Next.js 16.2.1
+- React 19.2.4
+- TypeScript (strict mode)
+- styled-components
+- axios
+- dayjs
+- ESLint 9 + `eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`
+- Prettier
+- Vitest + jsdom
+- MSW
+- Tailwind CSS 4는 설치되어 있으나, 실제 스타일 작업은 기존 코드 패턴을 먼저 확인하고 styled-components 중심 흐름을 우선한다.
+
+## 실행 / 검증 명령어
+- 개발 서버: `npm run dev`
+- 빌드: `npm run build`
+- 실행: `npm run start`
+- 린트: `npm run lint`
+- 테스트: `npm run test`
+- 테스트 watch: `npm run test:watch`
+
+작업 후 의미 있는 변경이 있으면 최소한 `lint`와 관련 테스트를 우선 확인한다.
+
+## 경로 / 구조 규칙
+프로젝트의 주요 구조는 아래를 기준으로 이해한다.
+
+- `app/`: App Router 기반 라우트 엔트리
+- `app/(admin)`, `app/(public)`, `app/staff`: 라우트 그룹 및 주요 화면 구역
+- `components/`: UI 컴포넌트
+  - `components/common`: 공용 컴포넌트
+  - `components/home`: 홈 전용 컴포넌트
+  - `components/layout`: 레이아웃 관련 컴포넌트
+- `api/`: API 계층
+  - `auth`, `classroom`, `department`, `lesson`, `request`, `student`, `subject`, `user` 등 도메인 단위 분리
+  - `client`는 공통 API 클라이언트 계층으로 간주하고 먼저 재사용 가능성을 확인한다.
+- `lib/`: 런타임/프레임워크 연동 유틸
+  - 현재 `styled-components-registry.tsx`가 존재하므로 styled-components 관련 설정은 이 흐름을 존중한다.
+- `styles/`: 전역 스타일 자원
+  - 현재 `tokens.ts`가 존재하므로 spacing, color, typography, radius, shadow 등은 가능하면 토큰을 먼저 확인한다.
+- `mocks/`: mock 데이터 및 MSW 관련 구성
+- `test/`: 테스트 설정
+- `types/`: 타입 정의
+
+## import 규칙
+- 경로 alias `@/*`를 우선 사용한다.
+- 깊은 상대경로(`../../../`) 남발보다 alias를 우선 고려한다.
+- 단, 이미 파일 근처 상대경로가 더 자연스러운 영역이면 기존 패턴을 따른다.
+
+## 라우트 / 페이지 작업 규칙
+- 새 페이지 작업은 `app/` 하위의 기존 라우트 그룹 구조를 먼저 따른다.
+- `(admin)`, `(public)`, `staff` 중 어느 맥락에 속하는 화면인지 먼저 판단한다.
+- 페이지는 가능한 한 얇게 유지하고, 반복 UI나 복잡한 화면 블록은 `components/`로 분리한다.
+- 특정 페이지 문맥에 강하게 묶인 것은 페이지 전용 컴포넌트로 두고, 여러 페이지에서 재사용 가능성이 높을 때만 `components/common` 이동을 고려한다.
+
+## 컴포넌트 규칙
+- `components/common`은 진짜 공용일 때만 사용한다.
+- 페이지 전용 문맥이 강한 UI를 성급하게 공용화하지 않는다.
+- 반복 카드, 패널, 툴바, 메뉴 그룹, 상태 배지 등은 먼저 분리 후보로 본다.
+- 하나의 컴포넌트에 layout, interaction, API fetching을 모두 몰아넣지 않는다.
+
+## 스타일링 규칙
+- 이 프로젝트에서는 `styled-components` 흐름을 우선한다.
+- 새 UI 구현 시 inline style보다 기존 styled-components 패턴을 먼저 따른다.
+- 디자인 값은 가능하면 `styles/tokens.ts` 등 기존 토큰에서 먼저 찾는다.
+- 임시 margin 보정, 위치 땜질, 매직 넘버 중심 수정은 피한다.
+- 구조 문제를 스타일로 덮지 말고, 먼저 레이아웃 구조를 정리한다.
+
+## API 작업 규칙
+- API 관련 작업은 반드시 `api/` 하위 기존 도메인 구조를 먼저 확인한 뒤 맞는 위치에 추가한다.
+- 새 API 호출을 페이지/컴포넌트 안에서 직접 만들기보다, 기존 `api/client` 및 도메인별 계층 재사용을 우선 검토한다.
+- 응답 타입, 요청 타입, 에러 처리 방식은 기존 패턴에 맞춘다.
+- UI에는 `loading`, `empty`, `success`, `error` 상태를 명시적으로 반영한다.
+- mock 기반 UI가 있으면 실제 API 연동으로 자연스럽게 치환한다.
+
+## 테스트 규칙
+- 테스트 도구는 기존 Vitest + jsdom + MSW 흐름을 우선 사용한다.
+- 테스트 설정은 `test/setup.ts`와 `mocks/` 구조를 먼저 확인한 뒤 맞춰서 작성한다.
+- 중요한 변경에는 최소한 아래를 우선 고려한다.
+  - 렌더링 테스트
+  - 핵심 상호작용 테스트
+  - API 성공/실패 또는 상태 분기 테스트
+- 기존 테스트 패턴과 어긋나는 독자적 테스트 체계를 새로 만들지 않는다.
+
+## 린트 / 포맷팅 규칙
+- ESLint는 Next core-web-vitals + TypeScript 규칙을 따른다.
+- Prettier 규칙은 저장소의 `.prettierrc`를 그대로 따른다.
+- 의미 없는 스타일 변경만 대량으로 섞지 않는다.
+- 기능 변경 PR에서 구조 정리와 포맷팅을 과도하게 함께 섞지 않는다.
+
+## 작업 우선순위
+항상 아래 순서를 우선한다.
+
+1. 현재 라우트/도메인 맥락 파악
+2. 기존 구조와 공용 계층 재사용 가능성 확인
+3. 정적 UI 구조 안정화
+4. 상호작용 추가
+5. API 연동
+6. 테스트 및 리팩터링
+
+## 금지 사항
+- Next.js 구버전 관습을 현재 프로젝트에 그대로 적용하기
+- `app/` 구조를 무시하고 임의 위치에 페이지를 추가하기
+- 공용 컴포넌트 기준 없이 `components/common`에 무분별하게 넣기
+- `api/` 계층을 우회해서 페이지 안에 직접 API 호출을 난립시키기
+- 기존 styled-components / tokens 흐름을 무시하고 임시 스타일만 덧붙이기
+- 성공 상태만 구현하고 loading / empty / error 상태를 생략하기
+- 기존 테스트 체계를 무시하고 임시 검증 코드만 추가하기

--- a/api/client/tokenStorage.test.ts
+++ b/api/client/tokenStorage.test.ts
@@ -4,10 +4,11 @@
  */
 import "../../test/setup";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   ACCESS_TOKEN_STORAGE_KEY,
+  AUTH_TOKEN_CHANGE_EVENT,
   REFRESH_TOKEN_STORAGE_KEY,
   clearTokens,
   getAccessToken,
@@ -67,5 +68,18 @@ describe("tokenStorage", () => {
 
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+  });
+
+  it("notifies listeners when token state changes", () => {
+    const listener = vi.fn();
+
+    window.addEventListener(AUTH_TOKEN_CHANGE_EVENT, listener);
+
+    setTokens("access-token", "refresh-token");
+    clearTokens();
+
+    window.removeEventListener(AUTH_TOKEN_CHANGE_EVENT, listener);
+
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 });

--- a/api/client/tokenStorage.ts
+++ b/api/client/tokenStorage.ts
@@ -1,5 +1,6 @@
 export const ACCESS_TOKEN_STORAGE_KEY = "geumjeongyahak.accessToken";
 export const REFRESH_TOKEN_STORAGE_KEY = "geumjeongyahak.refreshToken";
+export const AUTH_TOKEN_CHANGE_EVENT = "geumjeongyahak:auth-token-change";
 
 function getStorage() {
   if (typeof window === "undefined") {
@@ -7,6 +8,14 @@ function getStorage() {
   }
 
   return window.localStorage;
+}
+
+function notifyTokenChange() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(AUTH_TOKEN_CHANGE_EVENT));
 }
 
 export function getAccessToken() {
@@ -19,26 +28,36 @@ export function getRefreshToken() {
 
 export function setAccessToken(accessToken: string) {
   getStorage()?.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  notifyTokenChange();
 }
 
 export function setRefreshToken(refreshToken: string) {
   getStorage()?.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  notifyTokenChange();
 }
 
 export function removeAccessToken() {
   getStorage()?.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  notifyTokenChange();
 }
 
 export function removeRefreshToken() {
   getStorage()?.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+  notifyTokenChange();
 }
 
 export function setTokens(accessToken: string, refreshToken: string) {
-  setAccessToken(accessToken);
-  setRefreshToken(refreshToken);
+  const storage = getStorage();
+
+  storage?.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  storage?.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  notifyTokenChange();
 }
 
 export function clearTokens() {
-  removeAccessToken();
-  removeRefreshToken();
+  const storage = getStorage();
+
+  storage?.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  storage?.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+  notifyTokenChange();
 }

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,5 +1,6 @@
-import PageTemplate from "@/components/common/PageTemplate";
+import LoginForm from "@/components/auth/LoginForm";
 
 export default function Page() {
-  return <PageTemplate title="로그인" description="로그인 페이지입니다." />;
+  return <LoginForm />;
 }
+

--- a/app/(public)/mypage/page.tsx
+++ b/app/(public)/mypage/page.tsx
@@ -1,0 +1,6 @@
+import MyPage from "@/components/auth/MyPage";
+
+export default function Page() {
+  return <MyPage />;
+}
+

--- a/app/(public)/register/page.tsx
+++ b/app/(public)/register/page.tsx
@@ -1,5 +1,6 @@
-import PageTemplate from "@/components/common/PageTemplate";
+import RegisterForm from "@/components/auth/RegisterForm";
 
 export default function Page() {
-  return <PageTemplate title="신규 등록" description="신규 등록 페이지입니다." />;
+  return <RegisterForm />;
 }
+

--- a/components/auth/AuthFormParts.tsx
+++ b/components/auth/AuthFormParts.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import styled from "styled-components";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+type StatusProps = {
+  $tone?: "default" | "error";
+  $visible?: boolean;
+};
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space24};
+`;
+
+export const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space16};
+`;
+
+export const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space8};
+`;
+
+export const Label = styled.label`
+  color: #4d5848;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  height: 3.25rem;
+  padding: 0 ${spacing.space16};
+  color: ${colors.text};
+  background-color: #fbfdf9;
+  border: 1px solid ${colors.border};
+  border-radius: 8px;
+  font-size: ${typography.fontSize16};
+  line-height: ${typography.lineHeight150};
+  outline: none;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+
+  &::placeholder {
+    color: ${colors.muted};
+  }
+
+  &:focus {
+    border-color: ${colors.point};
+    background-color: ${colors.white};
+    box-shadow: 0 0 0 0.1875rem rgba(136, 205, 90, 0.18);
+  }
+`;
+
+export const Status = styled.p<StatusProps>`
+  min-height: 1.375rem;
+  color: ${({ $tone }) => ($tone === "error" ? "#d97b7b" : "#52604c")};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
+  visibility: ${({ $visible }) => ($visible ? "visible" : "hidden")};
+`;
+
+export const SubmitButton = styled.button`
+  width: 100%;
+  height: 3.5rem;
+  border: 0;
+  border-radius: 8px;
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize16};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-0.0625rem);
+    box-shadow: 0 0.75rem 1.5rem rgba(93, 153, 54, 0.2);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+`;

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Link from "next/link";
+import styled from "styled-components";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+
+type AuthShellProps = {
+  switchLabel: string;
+  switchHref: string;
+  switchText: string;
+  children: React.ReactNode;
+};
+
+export default function AuthShell({
+  switchLabel,
+  switchHref,
+  switchText,
+  children,
+}: AuthShellProps) {
+  return (
+    <Main>
+      <Content>
+        <Panel>
+          {children}
+          <SwitchArea>
+            <SwitchText>{switchText}</SwitchText>
+            <SwitchLink href={switchHref}>{switchLabel}</SwitchLink>
+          </SwitchArea>
+        </Panel>
+      </Content>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background:
+    linear-gradient(180deg, rgba(136, 205, 90, 0.12), rgba(248, 248, 248, 0) 28rem),
+    ${colors.background};
+`;
+
+const Content = styled.div`
+  width: 100%;
+  max-width: 30rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  padding: ${spacing.space32} ${spacing.space20};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    min-height: auto;
+    padding-top: ${spacing.space40};
+    padding-bottom: ${spacing.space40};
+  }
+`;
+
+const Panel = styled.section`
+  width: 100%;
+  padding: ${spacing.space28};
+  background-color: ${colors.white};
+  border: 1px solid rgba(34, 34, 34, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 1rem 2rem rgba(34, 34, 34, 0.06);
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    padding: ${spacing.space24};
+  }
+`;
+
+const SwitchArea = styled.div`
+  margin-top: ${spacing.space24};
+  padding-top: ${spacing.space20};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space8};
+  border-top: 1px solid ${colors.border};
+`;
+
+const SwitchText = styled.span`
+  color: #64705f;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const SwitchLink = styled(Link)`
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+`;

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { login } from "@/api/auth/auth.api";
+import {
+  Field,
+  FieldGroup,
+  Form,
+  Input,
+  Label,
+  Status,
+  SubmitButton,
+} from "@/components/auth/AuthFormParts";
+import AuthShell from "@/components/auth/AuthShell";
+
+type LoginFormState = {
+  username: string;
+  password: string;
+};
+
+const initialState: LoginFormState = {
+  username: "",
+  password: "",
+};
+
+export default function LoginForm() {
+  const router = useRouter();
+  const [form, setForm] = useState(initialState);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit = form.username.trim().length > 0 && form.password.length > 0;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage("");
+
+    try {
+      await login({
+        username: form.username.trim(),
+        password: form.password,
+      });
+      setStatusMessage("로그인되었습니다. 잠시 후 메인으로 이동합니다.");
+      router.replace("/");
+    } catch {
+      setStatusMessage("입력하신 정보를 다시 확인해주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell
+      switchText="아직 계정이 없나요?"
+      switchLabel="회원가입"
+      switchHref="/register"
+    >
+      <Form onSubmit={handleSubmit} aria-label="로그인 폼">
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="login-username">아이디</Label>
+            <Input
+              id="login-username"
+              name="username"
+              type="text"
+              autoComplete="username"
+              placeholder="아이디를 입력하세요"
+              value={form.username}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, username: event.target.value }))
+              }
+              required
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="login-password">비밀번호</Label>
+            <Input
+              id="login-password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              placeholder="비밀번호를 입력하세요"
+              value={form.password}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, password: event.target.value }))
+              }
+              required
+            />
+          </Field>
+        </FieldGroup>
+
+        <Status
+          role="status"
+          aria-live="polite"
+          $tone={statusMessage.startsWith("입력") ? "error" : "default"}
+          $visible={Boolean(statusMessage)}
+        >
+          {statusMessage}
+        </Status>
+
+        <SubmitButton type="submit" disabled={!canSubmit || isSubmitting}>
+          {isSubmitting ? "로그인 중" : "로그인"}
+        </SubmitButton>
+      </Form>
+    </AuthShell>
+  );
+}

--- a/components/auth/MyPage.tsx
+++ b/components/auth/MyPage.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+
+export default function MyPage() {
+  const router = useRouter();
+  const { status, user, signOut } = useAuthSession();
+
+  const displayName = user?.name ?? "회원";
+  const identifier = user?.username ?? user?.email ?? "확인 가능한 계정 정보가 없습니다.";
+
+  async function handleLogout() {
+    await signOut();
+    router.replace("/");
+  }
+
+  return (
+    <Main>
+      <Content>
+        <HeaderBlock>
+          <Eyebrow>마이페이지</Eyebrow>
+          <Title>내 정보</Title>
+        </HeaderBlock>
+
+        <Panel aria-live="polite">
+          {status === "loading" ? (
+            <StatusSlot>
+              <LoadingSpinner label="회원 정보 확인 중" />
+            </StatusSlot>
+          ) : null}
+
+          {status === "unauthenticated" ? (
+            <StatusSlot>
+              <StateGroup>
+                <StateText>로그인이 필요한 페이지입니다.</StateText>
+                <PrimaryLink href="/login">로그인</PrimaryLink>
+              </StateGroup>
+            </StatusSlot>
+          ) : null}
+
+          {status === "error" ? (
+            <StatusSlot>
+              <StateGroup>
+                <StateText>회원 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.</StateText>
+                <SecondaryButton type="button" onClick={handleLogout}>
+                  로그아웃
+                </SecondaryButton>
+              </StateGroup>
+            </StatusSlot>
+          ) : null}
+
+          {status === "authenticated" ? (
+            <>
+              <SectionTitle>내 정보</SectionTitle>
+              <ProfileList>
+                <ProfileItem>
+                  <ProfileLabel>이름</ProfileLabel>
+                  <ProfileValue>{displayName}</ProfileValue>
+                </ProfileItem>
+                <ProfileItem>
+                  <ProfileLabel>아이디</ProfileLabel>
+                  <ProfileValue>{identifier}</ProfileValue>
+                </ProfileItem>
+                <ProfileItem>
+                  <ProfileLabel>이메일</ProfileLabel>
+                  <ProfileValue>{user?.email ?? "등록된 이메일이 없습니다."}</ProfileValue>
+                </ProfileItem>
+                <ProfileItem>
+                  <ProfileLabel>전화번호</ProfileLabel>
+                  <ProfileValue>{user?.phoneNumber ?? "등록된 전화번호가 없습니다."}</ProfileValue>
+                </ProfileItem>
+              </ProfileList>
+              <ActionRow>
+                <PrimaryLink href="/">메인으로</PrimaryLink>
+                <SecondaryButton type="button" onClick={handleLogout}>
+                  로그아웃
+                </SecondaryButton>
+              </ActionRow>
+            </>
+          ) : null}
+        </Panel>
+      </Content>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.background};
+`;
+
+const Content = styled.div`
+  width: 100%;
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: ${spacing.space40} ${spacing.space20};
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space24};
+`;
+
+const HeaderBlock = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space4};
+`;
+
+const Eyebrow = styled.p`
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const Title = styled.h1`
+  color: ${colors.text};
+  font-size: ${typography.fontSize32};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const Panel = styled.section`
+  min-height: 23.25rem;
+  padding: ${spacing.space28};
+  border: 1px solid ${colors.border};
+  border-radius: 8px;
+  background-color: ${colors.white};
+  box-shadow: 0 1rem 2rem rgba(34, 34, 34, 0.06);
+  display: flex;
+  flex-direction: column;
+`;
+
+const SectionTitle = styled.h2`
+  color: ${colors.text};
+  font-size: ${typography.fontSize24};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  margin-bottom: ${spacing.space20};
+`;
+
+const ProfileList = styled.dl`
+  display: grid;
+  gap: ${spacing.space16};
+`;
+
+const ProfileItem = styled.div`
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr);
+  gap: ${spacing.space16};
+  padding-bottom: ${spacing.space16};
+  border-bottom: 1px solid ${colors.border};
+
+  &:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+`;
+
+const ProfileLabel = styled.dt`
+  color: #64705f;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight150};
+`;
+
+const ProfileValue = styled.dd`
+  min-width: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight150};
+  overflow-wrap: anywhere;
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  margin-top: ${spacing.space28};
+`;
+
+const StateGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space16};
+`;
+
+const StatusSlot = styled.div`
+  min-height: 19.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StateText = styled.p`
+  color: #52604c;
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight150};
+`;
+
+const PrimaryLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0 ${spacing.space20};
+  border-radius: 8px;
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+`;
+
+const SecondaryButton = styled.button`
+  min-height: 2.75rem;
+  padding: 0 ${spacing.space20};
+  border: 1px solid ${colors.border};
+  border-radius: 8px;
+  background-color: ${colors.white};
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${colors.point};
+    color: ${colors.point};
+  }
+`;

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { signup } from "@/api/auth/auth.api";
+import {
+  Field,
+  FieldGroup,
+  Form,
+  Input,
+  Label,
+  Status,
+  SubmitButton,
+} from "@/components/auth/AuthFormParts";
+import AuthShell from "@/components/auth/AuthShell";
+import { formatPhoneNumber } from "@/utils/phoneNumber";
+
+type RegisterFormState = {
+  username: string;
+  password: string;
+  name: string;
+  email: string;
+  phoneNumber: string;
+};
+
+const initialState: RegisterFormState = {
+  username: "",
+  password: "",
+  name: "",
+  email: "",
+  phoneNumber: "",
+};
+
+export default function RegisterForm() {
+  const router = useRouter();
+  const [form, setForm] = useState(initialState);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit =
+    form.username.trim().length > 0 &&
+    form.password.length >= 6 &&
+    form.name.trim().length > 0;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage("");
+
+    try {
+      await signup({
+        username: form.username.trim(),
+        password: form.password,
+        name: form.name.trim(),
+        email: form.email.trim() || undefined,
+        phoneNumber: form.phoneNumber.trim() || undefined,
+      });
+      setStatusMessage("회원가입이 완료되었습니다. 잠시 후 메인으로 이동합니다.");
+      router.replace("/");
+    } catch {
+      setStatusMessage("회원가입 정보를 확인해 주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthShell
+      switchText="이미 계정이 있나요?"
+      switchLabel="로그인"
+      switchHref="/login"
+    >
+      <Form onSubmit={handleSubmit} aria-label="회원가입 폼">
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="register-username">아이디</Label>
+            <Input
+              id="register-username"
+              name="username"
+              type="text"
+              autoComplete="username"
+              placeholder="사용할 아이디"
+              value={form.username}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, username: event.target.value }))
+              }
+              required
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="register-password">비밀번호</Label>
+            <Input
+              id="register-password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              placeholder="6자 이상 입력"
+              value={form.password}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, password: event.target.value }))
+              }
+              required
+              minLength={6}
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="register-name">이름</Label>
+            <Input
+              id="register-name"
+              name="name"
+              type="text"
+              autoComplete="name"
+              placeholder="이름"
+              value={form.name}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="register-email">이메일</Label>
+            <Input
+              id="register-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="선택 입력"
+              value={form.email}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, email: event.target.value }))
+              }
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="register-phone">전화번호</Label>
+            <Input
+              id="register-phone"
+              name="phoneNumber"
+              type="tel"
+              autoComplete="tel"
+              inputMode="numeric"
+              placeholder="010-0000-0000"
+              value={form.phoneNumber}
+              onChange={(event) =>
+                setForm((current) => ({
+                  ...current,
+                  phoneNumber: formatPhoneNumber(event.target.value),
+                }))
+              }
+            />
+          </Field>
+        </FieldGroup>
+
+        <Status
+          role="status"
+          aria-live="polite"
+          $tone={statusMessage.startsWith("회원가입 정보") ? "error" : "default"}
+          $visible={Boolean(statusMessage)}
+        >
+          {statusMessage}
+        </Status>
+
+        <SubmitButton type="submit" disabled={!canSubmit || isSubmitting}>
+          {isSubmitting ? "가입 중" : "회원가입"}
+        </SubmitButton>
+      </Form>
+    </AuthShell>
+  );
+}

--- a/components/common/LoadingSpinner.tsx
+++ b/components/common/LoadingSpinner.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import styled from "styled-components";
+import { colors } from "@/styles/tokens";
+
+type LoadingSpinnerProps = {
+  label?: string;
+};
+
+export default function LoadingSpinner({ label = "로딩 중" }: LoadingSpinnerProps) {
+  return <Spinner role="status" aria-label={label} />;
+}
+
+const Spinner = styled.span`
+  display: inline-block;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0.25rem solid rgba(136, 205, 90, 0.22);
+  border-top-color: ${colors.point};
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;

--- a/components/home/LoginCard.tsx
+++ b/components/home/LoginCard.tsx
@@ -1,18 +1,121 @@
 "use client";
 
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import { login } from "@/api/auth/auth.api";
+import { Input as AuthInput } from "@/components/auth/AuthFormParts";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import HomeCard from "@/components/home/HomeCard";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { colors, radii, spacing, typography } from "@/styles/tokens";
 
+type LoginFormState = {
+  username: string;
+  password: string;
+};
+
+const initialLoginForm: LoginFormState = {
+  username: "",
+  password: "",
+};
+
 export default function LoginCard() {
+  const router = useRouter();
+  const { status, user, signOut } = useAuthSession();
+  const [form, setForm] = useState(initialLoginForm);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const displayName = user?.name ?? "회원";
+  const canSubmit = form.username.trim().length > 0 && form.password.length > 0;
+
+  async function handleLogout() {
+    await signOut();
+    router.replace("/");
+  }
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+
+    try {
+      await login({
+        username: form.username.trim(),
+        password: form.password,
+      });
+      setForm(initialLoginForm);
+    } catch {
+      setErrorMessage("입력하신 정보를 다시 확인해주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (status === "loading") {
+    return (
+      <Card title="로그인">
+        <PendingContent aria-label="로그인 상태 확인 중" aria-live="polite">
+          <LoadingSpinner label="로그인 상태 확인 중" />
+        </PendingContent>
+      </Card>
+    );
+  }
+
+  if (status === "authenticated") {
+    return (
+      <Card title="로그인">
+        <SignedInContent>
+          <WelcomeGroup>
+            <WelcomeTitle>어서오세요, {displayName}님!</WelcomeTitle>
+            <WelcomeText>오늘도 수업과 운영 일정을 확인해 주세요.</WelcomeText>
+          </WelcomeGroup>
+          <ActionRow>
+            <PrimaryLink href="/mypage">마이페이지</PrimaryLink>
+            <SecondaryButton type="button" onClick={handleLogout}>
+              로그아웃
+            </SecondaryButton>
+          </ActionRow>
+        </SignedInContent>
+      </Card>
+    );
+  }
+
   return (
     <Card title="로그인">
-      <Form aria-label="로그인 목업 폼">
+      <Form aria-label="로그인 폼" onSubmit={handleLogin}>
         <InputGroup>
-          <Input type="text" placeholder="아이디" />
-          <Input type="password" placeholder="비밀번호" />
+          <Input
+            type="text"
+            placeholder="아이디"
+            autoComplete="username"
+            value={form.username}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, username: event.target.value }))
+            }
+          />
+          <Input
+            type="password"
+            placeholder="비밀번호"
+            autoComplete="current-password"
+            value={form.password}
+            onChange={(event) =>
+              setForm((current) => ({ ...current, password: event.target.value }))
+            }
+          />
         </InputGroup>
-        <SubmitButton type="button">로그인</SubmitButton>
+        <ErrorText role="status" aria-live="polite" $visible={Boolean(errorMessage)}>
+          {errorMessage}
+        </ErrorText>
+        <SubmitButton type="submit" disabled={!canSubmit || isSubmitting}>
+          {isSubmitting ? "로그인 중" : "로그인"}
+        </SubmitButton>
       </Form>
     </Card>
   );
@@ -27,7 +130,8 @@ const Card = styled(HomeCard)`
   gap: ${spacing.space16};
 `;
 
-const Form = styled.div`
+const Form = styled.form`
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: ${spacing.space40};
@@ -39,25 +143,24 @@ const InputGroup = styled.div`
   gap: ${spacing.space12};
 `;
 
-const Input = styled.input`
-  width: 100%;
-  height: 3.25rem;
-  padding: 0 ${spacing.space16};
-  background-color: ${colors.white};
-  border: 1px solid ${colors.border};
-  border-radius: ${radii.radius12};
-  color: ${colors.text};
+const ErrorText = styled.p<{ $visible: boolean }>`
+  position: absolute;
+  top: calc(7.25rem + ${spacing.space8});
+  left: 0;
+  right: 0;
+  min-height: 1.375rem;
+  color: #d97b7b;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
+  visibility: ${({ $visible }) => ($visible ? "visible" : "hidden")};
+`;
+
+const Input = styled(AuthInput)`
   font-family: ${typography.fontFamily};
-  font-size: ${typography.fontSize16};
-  outline: none;
-  transition: all 0.3s ease-in-out;
 
   &:focus::placeholder {
     color: transparent;
-  }
-
-  &::placeholder {
-    color: ${colors.muted};
   }
 `;
 
@@ -68,8 +171,88 @@ const SubmitButton = styled.button`
   border-radius: ${radii.radius12};
   background-color: ${colors.point};
   color: ${colors.white};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: ${typography.fontFamily};
   font-size: ${typography.fontSize16};
-  font-weight: 600;
+  font-weight: 700;
+  text-decoration: none;
   cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+`;
+
+const SignedInContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space40};
+`;
+
+const PendingContent = styled.div`
+  min-height: 12.125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const WelcomeGroup = styled.div`
+  min-height: 7.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: ${spacing.space12};
+`;
+
+const WelcomeTitle = styled.p`
+  color: ${colors.text};
+  font-size: ${typography.fontSize24};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const WelcomeText = styled.p`
+  color: #5f6b5a;
+  font-size: ${typography.fontSize16};
+  line-height: ${typography.lineHeight150};
+`;
+
+const ActionRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${spacing.space12};
+`;
+
+const PrimaryLink = styled(Link)`
+  min-height: 3.5rem;
+  border-radius: ${radii.radius12};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+`;
+
+const SecondaryButton = styled.button`
+  min-height: 3.5rem;
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${colors.point};
+    color: ${colors.point};
+  }
 `;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,12 +2,22 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { headerMenus } from "@/mocks/home";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function Header() {
+  const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { status, signOut } = useAuthSession();
+  const isAuthenticated = status === "authenticated";
+
+  async function handleLogout() {
+    await signOut();
+    router.replace("/");
+  }
 
   return (
     <HeaderContainer
@@ -17,7 +27,7 @@ export default function Header() {
       <HeaderWrapper>
         <Inner>
           <LogoArea href="/">
-            <Logo src="/logo.svg" alt="금정열린배움터 로고" />
+            <Logo src="/logo.svg" alt="금정야학 로고" />
           </LogoArea>
 
           <Nav>
@@ -31,7 +41,18 @@ export default function Header() {
           </Nav>
 
           <AuthArea>
-            <AuthLink href="/login">로그인</AuthLink>
+            {status === "loading" ? (
+              <AuthPlaceholder aria-hidden="true" />
+            ) : isAuthenticated ? (
+              <>
+                <AuthLink href="/mypage">마이페이지</AuthLink>
+                <LogoutButton type="button" onClick={handleLogout}>
+                  로그아웃
+                </LogoutButton>
+              </>
+            ) : (
+              <AuthLink href="/login">로그인</AuthLink>
+            )}
           </AuthArea>
         </Inner>
       </HeaderWrapper>
@@ -74,10 +95,10 @@ const HeaderWrapper = styled.header`
 `;
 
 const Inner = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: ${spacing.space24};
+  justify-content: center;
   width: 100%;
   max-width: ${layout.maxWidth};
   min-height: ${layout.headerHeight};
@@ -93,9 +114,18 @@ const Inner = styled.div`
 `;
 
 const LogoArea = styled(Link)`
+  position: absolute;
+  left: ${spacing.space20};
+  top: 50%;
+  transform: translateY(-50%);
   flex-shrink: 0;
   display: flex;
   align-items: center;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    position: static;
+    transform: none;
+  }
 `;
 
 const Logo = styled.img`
@@ -105,7 +135,6 @@ const Logo = styled.img`
 `;
 
 const Nav = styled.nav`
-  flex: 1;
   display: flex;
   justify-content: center;
 
@@ -149,15 +178,52 @@ const NavLink = styled(Link)`
 `;
 
 const AuthArea = styled.div`
-  flex-shrink: 0;
+  position: absolute;
+  right: ${spacing.space20};
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space12};
+  width: 11.5rem;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    position: static;
+    transform: none;
+    flex-shrink: 0;
+  }
+`;
+
+const AuthPlaceholder = styled.span`
+  display: block;
+  width: 100%;
+  min-height: 1.125rem;
 `;
 
 const AuthLink = styled(Link)`
   color: ${colors.muted};
   font-size: ${typography.fontSize14};
-  font-weight: 500;
+  font-weight: 700;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${colors.point};
+  }
+`;
+
+const LogoutButton = styled.button`
+  border: 0;
+  background-color: transparent;
+  color: ${colors.muted};
+  padding: 0;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+  white-space: nowrap;
 
   &:hover {
     color: ${colors.point};

--- a/hooks/useAuthSession.ts
+++ b/hooks/useAuthSession.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { logout as requestLogout } from "@/api/auth/auth.api";
+import {
+  AUTH_TOKEN_CHANGE_EVENT,
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+} from "@/api/client/tokenStorage";
+import { getCurrentUser } from "@/api/user/user.api";
+import type { UserResponseDto } from "@/api/user/user.dto";
+
+export type AuthSessionStatus =
+  | "loading"
+  | "authenticated"
+  | "unauthenticated"
+  | "error";
+
+type AuthSessionState = {
+  status: AuthSessionStatus;
+  user: UserResponseDto | null;
+};
+
+const initialState: AuthSessionState = {
+  status: "loading",
+  user: null,
+};
+
+function hasStoredToken() {
+  return Boolean(getAccessToken() || getRefreshToken());
+}
+
+export function useAuthSession() {
+  const [state, setState] = useState<AuthSessionState>(initialState);
+
+  const refreshSession = useCallback(async () => {
+    if (!hasStoredToken()) {
+      setState({ status: "unauthenticated", user: null });
+      return;
+    }
+
+    setState((current) => ({
+      status: current.status === "authenticated" ? "authenticated" : "loading",
+      user: current.user,
+    }));
+
+    try {
+      const user = await getCurrentUser();
+      setState({ status: "authenticated", user });
+    } catch {
+      setState({ status: hasStoredToken() ? "error" : "unauthenticated", user: null });
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const refreshToken = getRefreshToken();
+
+    if (!refreshToken) {
+      clearTokens();
+      setState({ status: "unauthenticated", user: null });
+      return;
+    }
+
+    try {
+      await requestLogout({ refreshToken });
+    } catch {
+      clearTokens();
+    } finally {
+      setState({ status: "unauthenticated", user: null });
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshSession();
+
+    function handleTokenChange() {
+      refreshSession();
+    }
+
+    window.addEventListener(AUTH_TOKEN_CHANGE_EVENT, handleTokenChange);
+    window.addEventListener("storage", handleTokenChange);
+
+    return () => {
+      window.removeEventListener(AUTH_TOKEN_CHANGE_EVENT, handleTokenChange);
+      window.removeEventListener("storage", handleTokenChange);
+    };
+  }, [refreshSession]);
+
+  return {
+    ...state,
+    refreshSession,
+    signOut,
+  };
+}
+

--- a/mocks/handlers/user.handlers.ts
+++ b/mocks/handlers/user.handlers.ts
@@ -50,7 +50,7 @@ export const userHandlers: RequestHandler[] = [
       return HttpResponse.json({ message: "Invalid user payload" }, { status: 400 });
     }
 
-    return HttpResponse.json({ id: 2, ...USER_DETAIL_RESPONSE, ...body });
+    return HttpResponse.json({ ...USER_DETAIL_RESPONSE, ...body, id: 2 });
   }),
   http.get(`${API_BASE_URL}/api/v1/users/me`, ({ request }) => {
     return unauthorizedWhenNeeded(request) ?? HttpResponse.json(USER_DETAIL_RESPONSE);

--- a/utils/phoneNumber.test.ts
+++ b/utils/phoneNumber.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPhoneNumber, getPhoneNumberDigits } from "./phoneNumber";
+
+describe("phoneNumber", () => {
+  it("removes non-numeric input and limits phone number digits", () => {
+    expect(getPhoneNumberDigits("010-abcd-1234-5678-999")).toBe("01012345678");
+  });
+
+  it("formats mobile phone numbers while typing", () => {
+    expect(formatPhoneNumber("010")).toBe("010");
+    expect(formatPhoneNumber("0101")).toBe("010-1");
+    expect(formatPhoneNumber("0101234")).toBe("010-1234");
+    expect(formatPhoneNumber("01012345678")).toBe("010-1234-5678");
+  });
+
+  it("formats Seoul area numbers with the 02 prefix", () => {
+    expect(formatPhoneNumber("02")).toBe("02");
+    expect(formatPhoneNumber("02123")).toBe("02-123");
+    expect(formatPhoneNumber("021234567")).toBe("02-123-4567");
+    expect(formatPhoneNumber("0212345678")).toBe("02-1234-5678");
+  });
+
+  it("keeps deletion-friendly partial values", () => {
+    expect(formatPhoneNumber("010-1234-")).toBe("010-1234");
+    expect(formatPhoneNumber("010-")).toBe("010");
+  });
+});
+

--- a/utils/phoneNumber.ts
+++ b/utils/phoneNumber.ts
@@ -1,0 +1,34 @@
+export function getPhoneNumberDigits(value: string) {
+  return value.replace(/\D/g, "").slice(0, 11);
+}
+
+export function formatPhoneNumber(value: string) {
+  const digits = getPhoneNumberDigits(value);
+
+  if (digits.startsWith("02")) {
+    if (digits.length <= 2) {
+      return digits;
+    }
+
+    if (digits.length <= 5) {
+      return `${digits.slice(0, 2)}-${digits.slice(2)}`;
+    }
+
+    if (digits.length <= 9) {
+      return `${digits.slice(0, 2)}-${digits.slice(2, 5)}-${digits.slice(5)}`;
+    }
+
+    return `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+
+  if (digits.length <= 3) {
+    return digits;
+  }
+
+  if (digits.length <= 7) {
+    return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  }
+
+  return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+}
+


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

  1. 로그인 / 회원가입 페이지 구현                                                                                                                  
     - 기존 placeholder 페이지를 실제 로그인 / 회원가입 폼으로 교체했습니다.                                                                        
     -  `api/auth`의 `login`, `signup` API를 연동하여 실제 로그인 및 회원가입 기능이 동작하도록 구현했습니다.                                                                       
     - 로그인 실패 시 에러 문구를 표시하도록 처리했습니다.                                                        
     - 회원가입 페이지에서 전화번호 입력 시, 숫자 필터링 및 자동 하이픈 포맷팅을 적용했습니다.
     
     <img width="1900" height="866" alt="스크린샷 2026-04-20 180627" src="https://github.com/user-attachments/assets/1a42dcd9-b56e-44c6-b83c-f377c1504182" />
     <img width="1859" height="846" alt="ChatGPT Image 2026년 4월 20일 오후 06_19_07" src="https://github.com/user-attachments/assets/6b422f19-4333-4907-8064-d9d04b164d74" />


  2. 인증 세션 유지 흐름 보완                                                                                                                       
     - token 저장/삭제 시 auth token 변경 이벤트를 발생시키도록 `tokenStorage`를 보완했습니다.                                                      
     - `useAuthSession` hook을 추가해 저장된 access / refresh token 기반으로 현재 사용자 정보를 복원합니다.                                         
     - 인증 상태는 `loading`, `authenticated`, `unauthenticated`, `error`로 분기합니다.                                                             
     - 로그아웃 시 기존 logout API 흐름을 사용하고 토큰/세션 정리 후 메인으로 이동하도록 처리하였습니다.                              
                                                                                                                                                    
  3. 메인 로그인 카드 동작 변경                                                                                                                     
     - 메인 화면의 로그인 카드 컴포넌트에 로그인 기능을 추가하였습니다.
     - 새로고침 시 로그인 상태 확인 중에는 카드 안에 spinner를 표시합니다.                                                                      
     - 로그인 후 카드 안에는 사용자 환영 문구, 마이페이지, 로그아웃 버튼을 표시합니다.
     
     <p>
         <img width="250" alt="스크린샷 2026-04-20 175454" src="https://github.com/user-attachments/assets/157ad3e7-07c7-4f2e-96f5-915b39a37915" />
          <img width="250" alt="스크린샷 2026-04-20 175508" src="https://github.com/user-attachments/assets/cdeeb50e-4dff-4357-a8b3-c77b1f80692a" />
     </p>                                               
                                                                                                                                                    
  4. 헤더 인증 상태 UI 반영                                                                                                                         
     - 로그인 전에는 `로그인`, 로그인 후에는 `마이페이지`, `로그아웃`을 표시합니다.                                                                                                           
                 
     <img width="285" height="64" alt="스크린샷 2026-04-20 181012" src="https://github.com/user-attachments/assets/73e9f47c-2d56-420c-9341-66fbf14f93cf" />
                                                                                                                                   
  5. 마이페이지 추가                                                                                                                                
     - `/mypage` 페이지를 추가했습니다.                                                                                                             
     - 현재 로그인된 사용자 정보를 조회해 이름, 아이디, 이메일, 전화번호를 표시합니다.                                                  
     - 새로고침 시 사용자 정보 로딩 중에는 슬롯 안에 spinner를 표시합니다.                                                 
     - 마이페이지에서 로그아웃 시 메인 페이지로 이동하도록 처리하였습니다.     

     <img width="1859" height="846" alt="ChatGPT Image 2026년 4월 20일 오후 06_21_58" src="https://github.com/user-attachments/assets/b507ea84-7816-493e-9352-61196cb2fecf" />

## 🔍 관련 이슈

Closes #12 

## 💬 기타 사항

API 연동을 목적으로 임시 구성한 UI 컴포넌트로, 추후 디자인 시안에 따라 변경될 수 있습니다.

## 📂 참고 자료

> N/A
