### PR TITLE
[REFACTOR] 게시판 공통 UI 분리

### DIFF
--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -1,212 +1,73 @@
-"use client";
+import { redirect } from "next/navigation";
+import StaffRequestBoard, {
+  type StaffRequestBoardRow,
+} from "@/components/staff/StaffRequestBoard";
 
-import styled from "styled-components";
-import { useRouter } from "next/navigation";
-import { spacing, typography } from "@/styles/tokens";
+const ITEMS_PER_PAGE = 10;
+const CURRENT_AUTHOR = "김민지";
 
-const mockRows = Array.from({ length: 9 }, (_, index) => ({
+const absenceRequests = Array.from({ length: 23 }, (_, index) => ({
   id: index + 1,
-  no: "01",
-  className: "개나리반",
-  title: "개나리반 수학 수업 결강 신청합니다",
-  author: "작성자",
-  date: "00.00.00",
-  status: "대기 중",
+  className: `${["개나리", "해바라기", "민들레"][index % 3]}반`,
+  title: `${index + 1}회차 수업 결강 신청합니다`,
+  author: index % 2 === 0 ? CURRENT_AUTHOR : "박서준",
+  date: `26.04.${String((index % 28) + 1).padStart(2, "0")}`,
+  status: index % 3 === 0 ? "승인 완료" : "대기 중",
 }));
 
-export default function Page() {
-  const router = useRouter();
+type PageProps = {
+  searchParams?: Promise<{
+    page?: string;
+    mineOnly?: string;
+  }>;
+};
 
-  const handleCreateAbsenceNote = () => {
-    router.push("/staff/class/absence/new");
-  };
-
-  const handleMoveToAbsenceDetail = (postId: number) => {
-    router.push(`/staff/class/absence/${postId}`);
-  };
-
-  return (
-    <div className="flex min-h-screen">
-      <main className="flex-1 p-20">
-        <HeaderRow>
-          <Title>수업 결강</Title>
-          <WriteButton type="button" onClick={handleCreateAbsenceNote}>
-            수업 결강 신청하기
-          </WriteButton>
-        </HeaderRow>
-
-        <TableSection>
-          <Table>
-            <thead>
-              <tr>
-                <Th width="72px">no.</Th>
-                <Th width="120px">반</Th>
-                <Th>제목</Th>
-                <Th width="140px">작성자</Th>
-                <Th width="140px">작성일</Th>
-                <Th width="140px">신청 현황</Th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {mockRows.map((row) => (
-                <Tr key={row.id} onClick={() => handleMoveToAbsenceDetail(row.id)}>
-                  <Td width="72px">{row.no}</Td>
-                  <Td width="120px">{row.className}</Td>
-                  <TitleTd>{row.title}</TitleTd>
-                  <Td width="140px">{row.author}</Td>
-                  <Td width="140px">{row.date}</Td>
-                  <Td width="140px">{row.status}</Td>
-                </Tr>
-              ))}
-            </tbody>
-          </Table>
-        </TableSection>
-
-        <BottomRow>
-          <ToggleArea>
-            <ToggleLabel>내가 작성한 신청서만 보기</ToggleLabel>
-            <ToggleButton type="button" aria-label="내 신청서만 보기">
-              <ToggleThumb />
-            </ToggleButton>
-          </ToggleArea>
-        </BottomRow>
-      </main>
-    </div>
-  );
+function mapRows(items: typeof absenceRequests, page: number): StaffRequestBoardRow[] {
+  return items.map((item, index) => ({
+    id: item.id,
+    no: String((page - 1) * ITEMS_PER_PAGE + index + 1).padStart(2, "0"),
+    className: item.className,
+    title: item.title,
+    author: item.author,
+    date: item.date,
+    status: item.status,
+    detailHref: `/staff/class/absence/${item.id}`,
+  }));
 }
 
-const Container = styled.main`
-  min-height: 100vh;
-  padding: 40px 56px 48px;
-`;
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const rawPage = resolvedSearchParams?.page;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const parsedPage = rawPage ? Number(rawPage) : 1;
+  const filteredRequests = mineOnly
+    ? absenceRequests.filter((request) => request.author === CURRENT_AUTHOR)
+    : absenceRequests;
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
+  const isInvalidPage =
+    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
-const HeaderRow = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: ${spacing.space32};
-`;
-
-const Title = styled.h1`
-  font-size: ${typography.fontSize24};
-  font-weight: 700;
-  margin: 0;
-`;
-
-const WriteButton = styled.button`
-  padding: 14px ${spacing.space24};
-  border: none;
-  background: #e9e9e9;
-  font-size: ${typography.fontSize16};
-  font-weight: 500;
-  cursor: pointer;
-`;
-
-const TableSection = styled.section`
-  width: 100%;
-`;
-
-const Table = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-`;
-
-const Th = styled.th<{ width?: string }>`
-  width: ${({ width }) => width ?? "auto"};
-  padding: 0 ${spacing.space20} 14px;
-  border-bottom: 1px solid #a8a8a8;
-  font-size: ${typography.fontSize16};
-  font-weight: 700;
-  text-align: center;
-`;
-
-const Tr = styled.tr`
-  border-bottom: 1px solid #a8a8a8;
-  cursor: pointer;
-
-  &:hover {
-    background: #f7f7f7;
+  if (isInvalidPage) {
+    redirect(mineOnly ? "/staff/class/absence?mineOnly=1" : "/staff/class/absence");
   }
-`;
 
-const Td = styled.td<{ width?: string }>`
-  width: ${({ width }) => width ?? "auto"};
-  padding: 14px ${spacing.space20};
-  font-size: ${typography.fontSize14};
-  text-align: center;
-  white-space: nowrap;
-`;
+  const startIndex = (parsedPage - 1) * ITEMS_PER_PAGE;
+  const rows = mapRows(
+    filteredRequests.slice(startIndex, startIndex + ITEMS_PER_PAGE),
+    parsedPage,
+  );
 
-const TitleTd = styled.td`
-  padding: 14px ${spacing.space20};
-  font-size: ${typography.fontSize14};
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const BottomRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: ${spacing.space46};
-`;
-
-const ToggleArea = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-`;
-
-const ToggleLabel = styled.span`
-  font-size: ${typography.fontSize14};
-`;
-
-const ToggleButton = styled.button`
-  position: relative;
-  width: 48px;
-  height: 28px;
-  border: none;
-  border-radius: 999px;
-  background: #d9d9d9;
-  cursor: pointer;
-  padding: 0;
-`;
-
-const ToggleThumb = styled.span`
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: #6d6d6d;
-`;
-
-const Pagination = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin: 0 auto;
-`;
-
-const ArrowButton = styled.button`
-  border: none;
-  background: transparent;
-  font-size: 18px;
-  cursor: pointer;
-  color: #666;
-`;
-
-const PageNumber = styled.button<{ $active?: boolean }>`
-  border: none;
-  background: transparent;
-  padding: 0;
-  font-size: ${typography.fontSize16};
-  cursor: pointer;
-  color: ${({ $active }) => ($active ? "#111" : "#9a9a9a")};
-  font-weight: ${({ $active }) => ($active ? 700 : 400)};
-`;
+  return (
+    <StaffRequestBoard
+      title="수업 결강"
+      writeLabel="수업 결강 신청하기"
+      writeHref="/staff/class/absence/new"
+      listPath="/staff/class/absence"
+      rows={rows}
+      currentPage={parsedPage}
+      totalPages={totalPages}
+      mineOnly={mineOnly}
+      emptyMessage="결강 신청 내역이 없습니다."
+    />
+  );
+}

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -1,212 +1,73 @@
-"use client";
+import { redirect } from "next/navigation";
+import StaffRequestBoard, {
+  type StaffRequestBoardRow,
+} from "@/components/staff/StaffRequestBoard";
 
-import styled from "styled-components";
-import { useRouter } from "next/navigation";
-import { spacing, typography } from "@/styles/tokens";
+const ITEMS_PER_PAGE = 10;
+const CURRENT_AUTHOR = "김민지";
 
-const mockRows = Array.from({ length: 9 }, (_, index) => ({
+const exchangeRequests = Array.from({ length: 27 }, (_, index) => ({
   id: index + 1,
-  no: "01",
-  className: "개나리반",
-  title: "개나리반 수학 수업 교환 신청합니다",
-  author: "작성자",
-  date: "00.00.00",
-  status: "대기 중",
+  className: `${["개나리", "해바라기", "민들레"][index % 3]}반`,
+  title: `${index + 1}회차 수업 교환 신청합니다`,
+  author: index % 2 === 0 ? CURRENT_AUTHOR : "최유진",
+  date: `26.04.${String((index % 28) + 1).padStart(2, "0")}`,
+  status: index % 4 === 0 ? "승인 완료" : "대기 중",
 }));
 
-export default function Page() {
-  const router = useRouter();
+type PageProps = {
+  searchParams?: Promise<{
+    page?: string;
+    mineOnly?: string;
+  }>;
+};
 
-  const handleCreateExchangeNote = () => {
-    router.push("/staff/class/exchange/new");
-  };
-
-  const handleMoveToExchangeDetail = (postId: number) => {
-    router.push(`/staff/class/exchange/${postId}`);
-  };
-
-  return (
-    <div className="flex min-h-screen">
-      <main className="flex-1 p-20">
-        <HeaderRow>
-          <Title>수업 교환</Title>
-          <WriteButton type="button" onClick={handleCreateExchangeNote}>
-            수업 교환 신청하기
-          </WriteButton>
-        </HeaderRow>
-
-        <TableSection>
-          <Table>
-            <thead>
-              <tr>
-                <Th width="72px">no.</Th>
-                <Th width="120px">반</Th>
-                <Th>제목</Th>
-                <Th width="140px">작성자</Th>
-                <Th width="140px">작성일</Th>
-                <Th width="140px">신청 현황</Th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {mockRows.map((row) => (
-                <Tr key={row.id} onClick={() => handleMoveToExchangeDetail(row.id)}>
-                  <Td width="72px">{row.no}</Td>
-                  <Td width="120px">{row.className}</Td>
-                  <TitleTd>{row.title}</TitleTd>
-                  <Td width="140px">{row.author}</Td>
-                  <Td width="140px">{row.date}</Td>
-                  <Td width="140px">{row.status}</Td>
-                </Tr>
-              ))}
-            </tbody>
-          </Table>
-        </TableSection>
-
-        <BottomRow>
-          <ToggleArea>
-            <ToggleLabel>내가 작성한 신청서만 보기</ToggleLabel>
-            <ToggleButton type="button" aria-label="내 신청서만 보기">
-              <ToggleThumb />
-            </ToggleButton>
-          </ToggleArea>
-        </BottomRow>
-      </main>
-    </div>
-  );
+function mapRows(items: typeof exchangeRequests, page: number): StaffRequestBoardRow[] {
+  return items.map((item, index) => ({
+    id: item.id,
+    no: String((page - 1) * ITEMS_PER_PAGE + index + 1).padStart(2, "0"),
+    className: item.className,
+    title: item.title,
+    author: item.author,
+    date: item.date,
+    status: item.status,
+    detailHref: `/staff/class/exchange/${item.id}`,
+  }));
 }
 
-const Container = styled.main`
-  min-height: 100vh;
-  padding: 40px 56px 48px;
-`;
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const rawPage = resolvedSearchParams?.page;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const parsedPage = rawPage ? Number(rawPage) : 1;
+  const filteredRequests = mineOnly
+    ? exchangeRequests.filter((request) => request.author === CURRENT_AUTHOR)
+    : exchangeRequests;
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
+  const isInvalidPage =
+    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
-const HeaderRow = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: ${spacing.space32};
-`;
-
-const Title = styled.h1`
-  font-size: ${typography.fontSize24};
-  font-weight: 700;
-  margin: 0;
-`;
-
-const WriteButton = styled.button`
-  padding: 14px ${spacing.space24};
-  border: none;
-  background: #e9e9e9;
-  font-size: ${typography.fontSize16};
-  font-weight: 500;
-  cursor: pointer;
-`;
-
-const TableSection = styled.section`
-  width: 100%;
-`;
-
-const Table = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-`;
-
-const Th = styled.th<{ width?: string }>`
-  width: ${({ width }) => width ?? "auto"};
-  padding: 0 ${spacing.space20} 14px;
-  border-bottom: 1px solid #a8a8a8;
-  font-size: ${typography.fontSize16};
-  font-weight: 700;
-  text-align: center;
-`;
-
-const Tr = styled.tr`
-  border-bottom: 1px solid #a8a8a8;
-  cursor: pointer;
-
-  &:hover {
-    background: #f7f7f7;
+  if (isInvalidPage) {
+    redirect(mineOnly ? "/staff/class/exchange?mineOnly=1" : "/staff/class/exchange");
   }
-`;
 
-const Td = styled.td<{ width?: string }>`
-  width: ${({ width }) => width ?? "auto"};
-  padding: 14px ${spacing.space20};
-  font-size: ${typography.fontSize14};
-  text-align: center;
-  white-space: nowrap;
-`;
+  const startIndex = (parsedPage - 1) * ITEMS_PER_PAGE;
+  const rows = mapRows(
+    filteredRequests.slice(startIndex, startIndex + ITEMS_PER_PAGE),
+    parsedPage,
+  );
 
-const TitleTd = styled.td`
-  padding: 14px ${spacing.space20};
-  font-size: ${typography.fontSize14};
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-const BottomRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: ${spacing.space46};
-`;
-
-const ToggleArea = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-`;
-
-const ToggleLabel = styled.span`
-  font-size: ${typography.fontSize14};
-`;
-
-const ToggleButton = styled.button`
-  position: relative;
-  width: 48px;
-  height: 28px;
-  border: none;
-  border-radius: 999px;
-  background: #d9d9d9;
-  cursor: pointer;
-  padding: 0;
-`;
-
-const ToggleThumb = styled.span`
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: #6d6d6d;
-`;
-
-const Pagination = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin: 0 auto;
-`;
-
-const ArrowButton = styled.button`
-  border: none;
-  background: transparent;
-  font-size: 18px;
-  cursor: pointer;
-  color: #666;
-`;
-
-const PageNumber = styled.button<{ $active?: boolean }>`
-  border: none;
-  background: transparent;
-  padding: 0;
-  font-size: ${typography.fontSize16};
-  cursor: pointer;
-  color: ${({ $active }) => ($active ? "#111" : "#9a9a9a")};
-  font-weight: ${({ $active }) => ($active ? 700 : 400)};
-`;
+  return (
+    <StaffRequestBoard
+      title="수업 교환"
+      writeLabel="수업 교환 신청하기"
+      writeHref="/staff/class/exchange/new"
+      listPath="/staff/class/exchange"
+      rows={rows}
+      currentPage={parsedPage}
+      totalPages={totalPages}
+      mineOnly={mineOnly}
+      emptyMessage="교환 신청 내역이 없습니다."
+    />
+  );
+}

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -8,24 +8,20 @@ import {
 type PageProps = {
   searchParams?: Promise<{
     page?: string;
-    mineOnly?: string;
   }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const rawPage = resolvedSearchParams?.page;
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
-  const filteredRequests = mineOnly
-    ? financeRequests.filter((request) => request.author === "김민지")
-    : financeRequests;
+  const filteredRequests = financeRequests;
   const totalPages = Math.max(1, Math.ceil(filteredRequests.length / FINANCE_REQUESTS_PER_PAGE));
   const isInvalidPage =
     !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
   if (isInvalidPage) {
-    redirect(mineOnly ? "/staff/finance?mineOnly=1" : "/staff/finance");
+    redirect("/staff/finance");
   }
 
   const startIndex = (parsedPage - 1) * FINANCE_REQUESTS_PER_PAGE;
@@ -36,7 +32,6 @@ export default async function Page({ searchParams }: PageProps) {
       currentPage={parsedPage}
       requests={requests}
       totalPages={totalPages}
-      mineOnly={mineOnly}
     />
   );
 }

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -1,33 +1,42 @@
 import { redirect } from "next/navigation";
 import FinanceRequestListPage from "@/components/staff/FinanceRequestListPage";
 import {
-  getFinanceRequestsByPage,
-  getFinanceRequestTotalPages,
+  FINANCE_REQUESTS_PER_PAGE,
+  financeRequests,
 } from "@/mocks/staffFinance";
 
 type PageProps = {
   searchParams?: Promise<{
     page?: string;
+    mineOnly?: string;
   }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const rawPage = resolvedSearchParams?.page;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
-  const totalPages = getFinanceRequestTotalPages();
+  const filteredRequests = mineOnly
+    ? financeRequests.filter((request) => request.author === "김민지")
+    : financeRequests;
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / FINANCE_REQUESTS_PER_PAGE));
   const isInvalidPage =
     !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
   if (isInvalidPage) {
-    redirect("/staff/finance");
+    redirect(mineOnly ? "/staff/finance?mineOnly=1" : "/staff/finance");
   }
+
+  const startIndex = (parsedPage - 1) * FINANCE_REQUESTS_PER_PAGE;
+  const requests = filteredRequests.slice(startIndex, startIndex + FINANCE_REQUESTS_PER_PAGE);
 
   return (
     <FinanceRequestListPage
       currentPage={parsedPage}
-      requests={getFinanceRequestsByPage(parsedPage)}
+      requests={requests}
       totalPages={totalPages}
+      mineOnly={mineOnly}
     />
   );
 }

--- a/components/staff/FinanceRequestListPage.tsx
+++ b/components/staff/FinanceRequestListPage.tsx
@@ -8,14 +8,12 @@ type FinanceRequestListPageProps = {
   currentPage: number;
   requests: FinanceRequest[];
   totalPages: number;
-  mineOnly: boolean;
 };
 
 export default function FinanceRequestListPage({
   currentPage,
   requests,
   totalPages,
-  mineOnly,
 }: FinanceRequestListPageProps) {
   const rows = requests.map((request, index) => ({
     id: request.id,
@@ -41,7 +39,7 @@ export default function FinanceRequestListPage({
           rows={rows}
           currentPage={currentPage}
           totalPages={totalPages}
-          mineOnly={mineOnly}
+          showMineOnlyToggle={false}
           emptyMessage="결제 신청 내역이 없습니다."
         />
       </Content>

--- a/components/staff/FinanceRequestListPage.tsx
+++ b/components/staff/FinanceRequestListPage.tsx
@@ -1,92 +1,49 @@
-import Link from "next/link";
 import styled from "styled-components";
+import StaffRequestBoard from "@/components/staff/StaffRequestBoard";
 import StaffSidebar from "@/components/staff/StaffSidebar";
 import type { FinanceRequest } from "@/mocks/staffFinance";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout } from "@/styles/tokens";
 
 type FinanceRequestListPageProps = {
   currentPage: number;
   requests: FinanceRequest[];
   totalPages: number;
+  mineOnly: boolean;
 };
 
 export default function FinanceRequestListPage({
   currentPage,
   requests,
   totalPages,
+  mineOnly,
 }: FinanceRequestListPageProps) {
-  const prevPage = currentPage - 1;
-  const nextPage = currentPage + 1;
+  const rows = requests.map((request, index) => ({
+    id: request.id,
+    no: String((currentPage - 1) * 10 + index + 1).padStart(2, "0"),
+    className: request.className,
+    title: request.title,
+    author: request.author,
+    date: request.paymentDate,
+    status: request.status,
+    detailHref: `/staff/finance/${request.id}`,
+  }));
 
   return (
     <Main>
       <StaffSidebar />
 
       <Content>
-        <ContentHeader>
-          <Title>결제 신청</Title>
-          <RequestButton type="button">결제 신청 하기</RequestButton>
-        </ContentHeader>
-
-        <TableWrapper>
-          <Table aria-label="결제 신청 목록">
-            <thead>
-              <tr>
-                <TableHeaderCell $width="7rem">no.</TableHeaderCell>
-                <TableHeaderCell $width="8rem">반</TableHeaderCell>
-                <TableHeaderCell>제목</TableHeaderCell>
-                <TableHeaderCell $width="12rem">작성자</TableHeaderCell>
-                <TableHeaderCell $width="11rem">작성일</TableHeaderCell>
-                <TableHeaderCell $width="11rem">신청 현황</TableHeaderCell>
-              </tr>
-            </thead>
-            <tbody>
-              {requests.map((request) => (
-                <TableRow key={request.id}>
-                  <TableCell>{String(request.id).padStart(2, "0")}</TableCell>
-                  <TableCell>{request.className}</TableCell>
-                  <TitleCell>
-                    <TitleLink href={`/staff/finance/${request.id}`}>{request.title}</TitleLink>
-                  </TitleCell>
-                  <TableCell>{request.author}</TableCell>
-                  <TableCell>{request.paymentDate}</TableCell>
-                  <TableCell>{request.status}</TableCell>
-                </TableRow>
-              ))}
-            </tbody>
-          </Table>
-        </TableWrapper>
-
-        <Pagination aria-label="페이지 이동">
-          <PageArrow
-            href={prevPage <= 1 ? "/staff/finance" : `/staff/finance?page=${prevPage}`}
-            aria-label="이전 페이지"
-            $isDisabled={currentPage === 1}
-          >
-            ◀
-          </PageArrow>
-          {Array.from({ length: totalPages }, (_, index) => {
-            const pageNumber = index + 1;
-
-            return (
-              <PageNumber
-                key={pageNumber}
-                href={pageNumber === 1 ? "/staff/finance" : `/staff/finance?page=${pageNumber}`}
-                $isActive={pageNumber === currentPage}
-                aria-current={pageNumber === currentPage ? "page" : undefined}
-              >
-                {pageNumber}
-              </PageNumber>
-            );
-          })}
-          <PageArrow
-            href={nextPage === 1 ? "/staff/finance" : `/staff/finance?page=${nextPage}`}
-            aria-label="다음 페이지"
-            $isDisabled={currentPage === totalPages}
-          >
-            ▶
-          </PageArrow>
-        </Pagination>
+        <StaffRequestBoard
+          title="결제 신청"
+          writeLabel="결제 신청 하기"
+          writeHref="/staff/finance/new"
+          listPath="/staff/finance"
+          rows={rows}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          mineOnly={mineOnly}
+          emptyMessage="결제 신청 내역이 없습니다."
+        />
       </Content>
     </Main>
   );
@@ -105,121 +62,5 @@ const Main = styled.main`
 const Content = styled.section`
   flex: 1;
   min-width: 0;
-  padding: 2rem 2.5rem 2.5rem;
-
-  @media (max-width: ${layout.breakpointDesktop}) {
-    padding: 1.75rem 1.5rem 2rem;
-  }
-
-  @media (max-width: ${layout.breakpointMobile}) {
-    padding: 1.5rem 1rem;
-  }
-`;
-
-const ContentHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${spacing.space20};
-  margin-bottom: 1.75rem;
-
-  @media (max-width: ${layout.breakpointMobile}) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-`;
-
-const Title = styled.h2`
-  color: ${colors.text};
-  font-size: 1.9rem;
-  font-weight: 700;
-  line-height: ${typography.lineHeight130};
-`;
-
-const RequestButton = styled.button`
-  border: 0;
-  background-color: #ececec;
-  padding: 0.75rem 1rem;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: ${typography.lineHeight130};
-  cursor: pointer;
-`;
-
-const TableWrapper = styled.div`
   overflow-x: auto;
-`;
-
-const Table = styled.table`
-  width: 100%;
-  min-width: 40rem;
-`;
-
-const TableHeaderCell = styled.th<{ $width?: string }>`
-  width: ${({ $width }) => $width ?? "auto"};
-  padding: 0 0.875rem 0.625rem;
-  border-bottom: 1px solid #8b8b8b;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: ${typography.lineHeight130};
-  text-align: center;
-  white-space: nowrap;
-`;
-
-const TableRow = styled.tr`
-  border-bottom: 1px solid #8b8b8b;
-`;
-
-const TableCell = styled.td`
-  padding: 0.75rem 0.875rem;
-  color: ${colors.text};
-  font-size: 0.9rem;
-  font-weight: 400;
-  line-height: ${typography.lineHeight150};
-  text-align: center;
-  white-space: nowrap;
-`;
-
-const TitleCell = styled(TableCell)`
-  text-align: left;
-`;
-
-const TitleLink = styled(Link)`
-  color: ${colors.text};
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
-const Pagination = styled.nav`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 2.5rem;
-`;
-
-const PageArrow = styled(Link)<{ $isDisabled?: boolean }>`
-  background: transparent;
-  padding: 0;
-  color: #767676;
-  font-size: 1rem;
-  line-height: 1;
-  text-decoration: none;
-  pointer-events: ${({ $isDisabled }) => ($isDisabled ? "none" : "auto")};
-  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.3 : 1)};
-`;
-
-const PageNumber = styled(Link)<{ $isActive?: boolean }>`
-  background: transparent;
-  padding: 0;
-  color: ${({ $isActive }) => ($isActive ? colors.text : "#9c9c9c")};
-  font-size: 1rem;
-  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
-  line-height: 1;
-  text-decoration: none;
 `;

--- a/components/staff/StaffRequestBoard.tsx
+++ b/components/staff/StaffRequestBoard.tsx
@@ -21,7 +21,8 @@ type StaffRequestBoardProps = {
   rows: StaffRequestBoardRow[];
   currentPage: number;
   totalPages: number;
-  mineOnly: boolean;
+  mineOnly?: boolean;
+  showMineOnlyToggle?: boolean;
   emptyMessage?: string;
 };
 
@@ -51,13 +52,14 @@ export default function StaffRequestBoard({
   rows,
   currentPage,
   totalPages,
-  mineOnly,
+  mineOnly = false,
+  showMineOnlyToggle = true,
   emptyMessage = "목록이 없습니다.",
 }: StaffRequestBoardProps) {
   const prevPage = Math.max(1, currentPage - 1);
   const nextPage = Math.min(totalPages, currentPage + 1);
   const toggleHref = buildHref(listPath, { mineOnly: mineOnly ? undefined : 1 });
-  const baseQuery = mineOnly ? { mineOnly: 1 } : {};
+  const baseQuery = showMineOnlyToggle && mineOnly ? { mineOnly: 1 } : {};
 
   return (
     <Container>
@@ -102,18 +104,20 @@ export default function StaffRequestBoard({
         </Table>
       </TableSection>
 
-      <BottomRow>
-        <ToggleArea>
-          <ToggleLabel>내가 작성한 신청서만 보기</ToggleLabel>
-          <ToggleButtonLink
-            href={toggleHref}
-            aria-label="내 신청서만 보기"
-            aria-pressed={mineOnly}
-            $active={mineOnly}
-          >
-            <ToggleThumb $active={mineOnly} />
-          </ToggleButtonLink>
-        </ToggleArea>
+      <BottomRow $hasToggle={showMineOnlyToggle}>
+        {showMineOnlyToggle ? (
+          <ToggleArea>
+            <ToggleLabel>내가 작성한 신청서만 보기</ToggleLabel>
+            <ToggleButtonLink
+              href={toggleHref}
+              aria-label="내 신청서만 보기"
+              aria-pressed={mineOnly}
+              $active={mineOnly}
+            >
+              <ToggleThumb $active={mineOnly} />
+            </ToggleButtonLink>
+          </ToggleArea>
+        ) : null}
 
         <Pagination aria-label="페이지 이동">
           <PageArrow
@@ -238,10 +242,10 @@ const TitleLink = styled(Link)`
   }
 `;
 
-const BottomRow = styled.div`
+const BottomRow = styled.div<{ $hasToggle: boolean }>`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: ${({ $hasToggle }) => ($hasToggle ? "space-between" : "center")};
   margin-top: ${spacing.space46};
 `;
 

--- a/components/staff/StaffRequestBoard.tsx
+++ b/components/staff/StaffRequestBoard.tsx
@@ -1,0 +1,303 @@
+import Link from "next/link";
+import styled from "styled-components";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+export type StaffRequestBoardRow = {
+  id: number;
+  no: string;
+  className: string;
+  title: string;
+  author: string;
+  date: string;
+  status: string;
+  detailHref: string;
+};
+
+type StaffRequestBoardProps = {
+  title: string;
+  writeLabel: string;
+  writeHref: string;
+  listPath: string;
+  rows: StaffRequestBoardRow[];
+  currentPage: number;
+  totalPages: number;
+  mineOnly: boolean;
+  emptyMessage?: string;
+};
+
+type QueryValue = string | number | boolean;
+
+function buildHref(path: string, query: Record<string, QueryValue | undefined>) {
+  const params = new URLSearchParams();
+
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (typeof value === "boolean") {
+      if (value) params.set(key, "1");
+      return;
+    }
+    params.set(key, String(value));
+  });
+
+  const queryString = params.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+export default function StaffRequestBoard({
+  title,
+  writeLabel,
+  writeHref,
+  listPath,
+  rows,
+  currentPage,
+  totalPages,
+  mineOnly,
+  emptyMessage = "목록이 없습니다.",
+}: StaffRequestBoardProps) {
+  const prevPage = Math.max(1, currentPage - 1);
+  const nextPage = Math.min(totalPages, currentPage + 1);
+  const toggleHref = buildHref(listPath, { mineOnly: mineOnly ? undefined : 1 });
+  const baseQuery = mineOnly ? { mineOnly: 1 } : {};
+
+  return (
+    <Container>
+      <HeaderRow>
+        <Title>{title}</Title>
+        <WriteButton href={writeHref}>{writeLabel}</WriteButton>
+      </HeaderRow>
+
+      <TableSection>
+        <Table>
+          <thead>
+            <tr>
+              <Th $width="72px">no.</Th>
+              <Th $width="120px">반</Th>
+              <Th>제목</Th>
+              <Th $width="140px">작성자</Th>
+              <Th $width="140px">작성일</Th>
+              <Th $width="140px">신청 현황</Th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {rows.length > 0 ? (
+              rows.map((row) => (
+                <Tr key={row.id}>
+                  <Td $width="72px">{row.no}</Td>
+                  <Td $width="120px">{row.className}</Td>
+                  <TitleTd>
+                    <TitleLink href={row.detailHref}>{row.title}</TitleLink>
+                  </TitleTd>
+                  <Td $width="140px">{row.author}</Td>
+                  <Td $width="140px">{row.date}</Td>
+                  <Td $width="140px">{row.status}</Td>
+                </Tr>
+              ))
+            ) : (
+              <Tr>
+                <EmptyTd colSpan={6}>{emptyMessage}</EmptyTd>
+              </Tr>
+            )}
+          </tbody>
+        </Table>
+      </TableSection>
+
+      <BottomRow>
+        <ToggleArea>
+          <ToggleLabel>내가 작성한 신청서만 보기</ToggleLabel>
+          <ToggleButtonLink
+            href={toggleHref}
+            aria-label="내 신청서만 보기"
+            aria-pressed={mineOnly}
+            $active={mineOnly}
+          >
+            <ToggleThumb $active={mineOnly} />
+          </ToggleButtonLink>
+        </ToggleArea>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrow
+            href={buildHref(listPath, { ...baseQuery, page: prevPage === 1 ? undefined : prevPage })}
+            aria-label="이전 페이지"
+            $isDisabled={currentPage === 1}
+          >
+            ◀
+          </PageArrow>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumber
+                key={pageNumber}
+                href={buildHref(listPath, {
+                  ...baseQuery,
+                  page: pageNumber === 1 ? undefined : pageNumber,
+                })}
+                $isActive={pageNumber === currentPage}
+                aria-current={pageNumber === currentPage ? "page" : undefined}
+              >
+                {pageNumber}
+              </PageNumber>
+            );
+          })}
+          <PageArrow
+            href={buildHref(listPath, { ...baseQuery, page: nextPage === 1 ? undefined : nextPage })}
+            aria-label="다음 페이지"
+            $isDisabled={currentPage === totalPages}
+          >
+            ▶
+          </PageArrow>
+        </Pagination>
+      </BottomRow>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  min-height: 100vh;
+  padding: 40px 56px 48px;
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: ${spacing.space32};
+`;
+
+const Title = styled.h1`
+  font-size: ${typography.fontSize24};
+  font-weight: 700;
+  margin: 0;
+`;
+
+const WriteButton = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px ${spacing.space24};
+  border: none;
+  background: #e9e9e9;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+`;
+
+const TableSection = styled.section`
+  width: 100%;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const Th = styled.th<{ $width?: string }>`
+  width: ${({ $width }) => $width ?? "auto"};
+  padding: 0 ${spacing.space20} 14px;
+  border-bottom: 1px solid #a8a8a8;
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  text-align: center;
+`;
+
+const Tr = styled.tr`
+  border-bottom: 1px solid #a8a8a8;
+`;
+
+const Td = styled.td<{ $width?: string }>`
+  width: ${({ $width }) => $width ?? "auto"};
+  padding: 14px ${spacing.space20};
+  font-size: ${typography.fontSize14};
+  text-align: center;
+  white-space: nowrap;
+`;
+
+const TitleTd = styled(Td)`
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const EmptyTd = styled.td`
+  padding: 32px 20px;
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  text-align: center;
+`;
+
+const TitleLink = styled(Link)`
+  color: ${colors.text};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const BottomRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: ${spacing.space46};
+`;
+
+const ToggleArea = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+`;
+
+const ToggleLabel = styled.span`
+  font-size: ${typography.fontSize14};
+`;
+
+const ToggleButtonLink = styled(Link)<{ $active: boolean }>`
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: ${({ $active }) => ($active ? "#bbc4ff" : "#d9d9d9")};
+`;
+
+const ToggleThumb = styled.span<{ $active: boolean }>`
+  position: absolute;
+  top: 2px;
+  left: ${({ $active }) => ($active ? "22px" : "2px")};
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #6d6d6d;
+  transition: left 0.2s ease;
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 auto;
+`;
+
+const PageArrow = styled(Link)<{ $isDisabled?: boolean }>`
+  border: none;
+  background: transparent;
+  color: #666;
+  text-decoration: none;
+  pointer-events: ${({ $isDisabled }) => ($isDisabled ? "none" : "auto")};
+  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.3 : 1)};
+`;
+
+const PageNumber = styled(Link)<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-decoration: none;
+  font-size: ${typography.fontSize16};
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+`;


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- `StaffRequestBoard` 공통 컴포넌트를 추가해 목록 테이블, 페이지네이션, 내가 작성한 신청서만 보기 토글 UI를 통합했습니다.
- 수업 결강, 수업 교환, 결제 신청 목록 페이지를 공통 컴포넌트 기반으로 리팩터링해 중복 UI/로직을 제거했습니다.
- 각 페이지에서 page, mineOnly 쿼리 파라미터를 동일 방식으로 파싱하고, 잘못된 페이지 값은 기본 경로로 리다이렉트하도록 정리했습니다.
- 결제 신청 페이지에서는 내가 작성한 신청서만 보기 토글을 삭제했습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #23 

## 💬 기타 사항

-  Refactor Impact (LOC)
   \- 기존 수정 파일 기준: +163 / -591 → 순감소 428줄
   \- 신규 공통 컴포넌트: +303
   \- 최종 순변화: 125줄 감소

## 📂 참고 자료

> N/A
