### PR TITLE
[FEAT] 수업 관리 섹션 UI 개선

### DIFF
--- a/app/staff/class/[postId]/page.tsx
+++ b/app/staff/class/[postId]/page.tsx
@@ -1,13 +1,11 @@
-"use client";
-
 import Link from "next/link";
 import styled from "styled-components";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 type PageProps = {
-  params: {
+  params: Promise<{
     postId: string;
-  };
+  }>;
 };
 
 const journalPosts = [
@@ -49,8 +47,9 @@ const detailFields = [
   { label: "활동 시간", key: "activityTime" },
 ] as const;
 
-export default function StaffClassJournalPostPage({ params }: PageProps) {
-  const journal = journalPosts.find((item) => item.id === params.postId) ?? journalPosts[0];
+export default async function StaffClassJournalPostPage({ params }: PageProps) {
+  const { postId } = await params;
+  const journal = journalPosts.find((item) => item.id === postId) ?? journalPosts[0];
 
   return (
     <PageSection>

--- a/app/staff/class/[postId]/page.tsx
+++ b/app/staff/class/[postId]/page.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import Link from "next/link";
+import styled from "styled-components";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+
+type PageProps = {
+  params: {
+    postId: string;
+  };
+};
+
+const journalPosts = [
+  {
+    id: "1",
+    createdAt: "00.00.00",
+    writer: "홍길동",
+    birthPrefix: "000000",
+    phone: "010-0000-0000",
+    className: "장미반",
+    activityDate: "00.00.00",
+    activityTime: "14:00-15:00",
+    lessons: [
+      "1교시 수업 내용 입니다 1교시 수업 내용 입니다 1교시 수업 내용 입니다",
+      "2교시 수업 내용 입니다 2교시 수업 내용 입니다 2교시 수업 내용 입니다",
+      "3교시 수업 내용 입니다 3교시 수업 내용 입니다 3교시 수업 내용 입니다 3교시 수업 내용 입니다",
+    ],
+    attendance: [
+      { name: "최양진", status: "O" },
+      { name: "최양진", status: "O" },
+      { name: "최양진", status: "O" },
+      { name: "최양진", status: "X" },
+      { name: "", status: "" },
+      { name: "", status: "" },
+      { name: "", status: "" },
+      { name: "", status: "" },
+      { name: "", status: "" },
+      { name: "", status: "" },
+    ],
+  },
+];
+
+const detailFields = [
+  { label: "작성자", key: "writer" },
+  { label: "주민번호 앞자리", key: "birthPrefix" },
+  { label: "연락처", key: "phone" },
+  { label: "담당 수업", key: "className" },
+  { label: "활동 일자", key: "activityDate" },
+  { label: "활동 시간", key: "activityTime" },
+] as const;
+
+export default function StaffClassJournalPostPage({ params }: PageProps) {
+  const journal = journalPosts.find((item) => item.id === params.postId) ?? journalPosts[0];
+
+  return (
+    <PageSection>
+      <ButtonRow>
+        <ActionButton type="button">삭제</ActionButton>
+        <ActionButton type="button">수정</ActionButton>
+        <LinkButton href="/staff/class">목록</LinkButton>
+      </ButtonRow>
+
+      <ContentColumn>
+        <DateBar>{journal.createdAt}</DateBar>
+
+        <InfoGrid>
+          {detailFields.map((field) => (
+            <InfoField key={field.key}>
+              <FieldLabel>{field.label}</FieldLabel>
+              <FieldValue>{journal[field.key]}</FieldValue>
+            </InfoField>
+          ))}
+        </InfoGrid>
+
+        <LessonSection>
+          <SectionTitle>수업 내용</SectionTitle>
+          {journal.lessons.map((lesson, index) => (
+            <LessonBlock key={index + 1}>
+              <FieldLabel>{index + 1}교시</FieldLabel>
+              <LessonContent>{lesson}</LessonContent>
+            </LessonBlock>
+          ))}
+        </LessonSection>
+
+        <AttendanceSection>
+          <SectionTitle>출석</SectionTitle>
+          <AttendanceGrid>
+            {journal.attendance.map((student, index) => (
+              <AttendanceCell key={`name-${index}`}>{student.name}</AttendanceCell>
+            ))}
+            {journal.attendance.map((student, index) => (
+              <AttendanceCell key={`status-${index}`}>{student.status}</AttendanceCell>
+            ))}
+          </AttendanceGrid>
+        </AttendanceSection>
+      </ContentColumn>
+    </PageSection>
+  );
+}
+
+const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 1.8125rem 3.125rem 2rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 2.75rem 4.6875rem 5.1875rem 4.625rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${spacing.space20};
+  margin-bottom: 2.25rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
+`;
+
+const ActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background-color: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover {
+    background-color: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const LinkButton = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  background-color: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+
+  &:hover {
+    background-color: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ContentColumn = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+  width: 100%;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const DateBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid #a8a8a8;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space20} 3.75rem;
+  margin-top: ${spacing.space8};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem 5.625rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const InfoField = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const FieldLabel = styled.p`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const FieldValue = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background-color: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const LessonSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+  margin-top: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const LessonBlock = styled.div`
+  display: contents;
+`;
+
+const LessonContent = styled.p`
+  min-height: 5.375rem;
+  margin: 0;
+  padding: 0.8125rem ${spacing.space12};
+  background-color: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 8.0625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const AttendanceSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const AttendanceGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+  overflow-x: auto;
+  border-top: 1px solid #000000;
+  border-left: 1px solid #000000;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(5, minmax(5rem, 1fr));
+  }
+`;
+
+const AttendanceCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: ${spacing.space8};
+  border-right: 1px solid #000000;
+  border-bottom: 1px solid #000000;
+  background-color: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+
+  @media (min-width: 120rem) {
+    min-height: 3.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -2,17 +2,9 @@
 
 import Link from "next/link";
 import styled from "styled-components";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
-type PageProps = {
-  params: {
-    postId: string;
-  };
-};
-
-export default function ExchangePostAcceptedPage({ params }: PageProps) {
-  const { postId } = params;
-
+export default function AbsencePostPage() {
   return (
     <PageWrapper>
       <TopButtonRow>
@@ -21,143 +13,233 @@ export default function ExchangePostAcceptedPage({ params }: PageProps) {
         <LinkButton href="/staff/class/absence">목록</LinkButton>
       </TopButtonRow>
 
-      <Section>
-        <Label>제목</Label>
-        <ValueBox>제목</ValueBox>
-      </Section>
+      <ContentColumn>
+        <DateBar>00.00.00</DateBar>
 
-      <Section>
-        <Label>신청자 정보</Label>
-        <InfoRow>
-          <InfoItem>
+        <PostSection>
+          <Label>제목</Label>
+          <ValueBox>제목</ValueBox>
+
+          <Label>신청자 정보</Label>
+          <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
             <FieldValue>개나리반</FieldValue>
-          </InfoItem>
-
-          <InfoItem>
             <FieldLabel>수업 일자</FieldLabel>
             <FieldValue>00.00.00</FieldValue>
-          </InfoItem>
-
-          <InfoItem>
             <FieldLabel>작성자</FieldLabel>
             <FieldValue>홍길동</FieldValue>
-          </InfoItem>
-        </InfoRow>
-      </Section>
+          </InfoRow>
 
-      <Section>
-        <Label>결강 신청 사유</Label>
-        <TextBox>결강 신청 사유</TextBox>
-      </Section>
+          <Label>결강 신청 사유</Label>
+          <TextBox>결강 신청 사유</TextBox>
 
-      <Section>
-        <Label>신청 현황</Label>
-        <StatusBox>대기 중</StatusBox>
-      </Section>
+          <Label>신청 현황</Label>
+          <StatusBox>대기 중</StatusBox>
+        </PostSection>
+      </ContentColumn>
     </PageWrapper>
   );
 }
 
-const PageWrapper = styled.main`
-  width: 100%;
-  min-height: 100vh;
-  padding: 36px 72px 80px;
+const PageWrapper = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 1.8125rem 3.125rem 4rem;
   background: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
 `;
 
 const TopButtonRow = styled.div`
   display: flex;
   justify-content: flex-end;
-  gap: ${spacing.space28};
-  margin-bottom: 44px;
+  gap: ${spacing.space20};
+  margin-bottom: 2.25rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
 `;
 
 const ActionButton = styled.button`
-  width: 92px;
-  height: 62px;
-  border: none;
-  background: #e6e6e6;
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   cursor: pointer;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const LinkButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 92px;
-  height: 62px;
-  background: #e6e6e6;
-  color: ${colors.text};
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   text-decoration: none;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const Section = styled.section`
-  margin-bottom: 28px;
+const ContentColumn = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
 `;
 
-const Label = styled.h3`
-  margin: 0 0 22px;
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+const DateBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid #a9a9a9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const PostSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const Label = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const ValueBox = styled.div`
-  width: 100%;
-  height: 62px;
-  padding: 0 20px;
-  background: #f5f5f5;
   display: flex;
   align-items: center;
-  font-size: ${typography.fontSize18};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const InfoRow = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 42px;
-`;
-
-const InfoItem = styled.div`
-  display: grid;
-  grid-template-columns: 74px 1fr;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  gap: 24px;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const FieldLabel = styled.span`
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const FieldValue = styled.div`
-  height: 62px;
-  padding: 0 20px;
-  background: #f5f5f5;
-  display: flex;
-  align-items: center;
-  font-size: ${typography.fontSize18};
+const FieldValue = styled(ValueBox)`
+  min-width: 0;
 `;
 
-const TextBox = styled.div`
-  width: 100%;
-  height: 150px;
-  padding: 20px;
-  background: #f5f5f5;
-  font-size: ${typography.fontSize18};
+const TextBox = styled(ValueBox)`
+  align-items: flex-start;
+  min-height: 6.875rem;
+  padding-top: 0.8125rem;
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding-top: 1.1875rem;
+  }
 `;
 
-const StatusBox = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 114px;
-  height: 62px;
-  background: #f5f5f5;
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+const StatusBox = styled(ValueBox)`
+  width: fit-content;
+  padding-inline: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
+  }
 `;

--- a/app/staff/class/absence/new/page.tsx
+++ b/app/staff/class/absence/new/page.tsx
@@ -1,213 +1,241 @@
 "use client";
 
 import styled from "styled-components";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
   return (
     <PageWrapper>
       <HeaderRow>
         <Title>결강 신청서 작성하기</Title>
-        <SubmitButton type="submit" form="exchange-form">
-          결강 신청서 제출하기
+        <SubmitButton type="submit" form="absence-form">
+          작성 완료
         </SubmitButton>
       </HeaderRow>
 
-      <Form id="exchange-form">
+      <Form id="absence-form">
         <Section>
           <Label htmlFor="title">제목</Label>
-          <Input id="title" name="title" defaultValue="제목" />
+          <Input id="title" name="title" placeholder="제목" />
         </Section>
 
         <Section>
-          <Label as="h3">신청자 정보</Label>
-          <Row>
-            <FieldBox>
-              <FieldLabel htmlFor="className">반 이름</FieldLabel>
-              <InlineInput id="className" name="className" defaultValue="개나리반" />
-            </FieldBox>
-
-            <FieldBox>
-              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-              <InlineInput id="lessonDate" name="lessonDate" defaultValue="00.00.00" />
-            </FieldBox>
-          </Row>
+          <Label as="h2">신청자 정보</Label>
+          <InfoRow>
+            <FieldLabel htmlFor="className">반 이름</FieldLabel>
+            <InlineInput id="className" name="className" placeholder="개나리반" />
+            <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
+            <InlineInput id="lessonDate" name="lessonDate" placeholder="00.00.00" />
+            <FieldLabel htmlFor="writer">작성자</FieldLabel>
+            <InlineInput id="writer" name="writer" placeholder="홍길동" />
+          </InfoRow>
         </Section>
 
         <Section>
           <Label htmlFor="reason">결강 신청 사유</Label>
-          <TextArea id="reason" name="reason" defaultValue="교환 신청 사유" />
-        </Section>
-
-        <Section>
-          <Label htmlFor="status">신청 현황</Label>
-          <StatusSelect id="status" name="status" defaultValue="pending">
-            <option value="pending">대기 중</option>
-            <option value="accepted">수락 완료</option>
-            <option value="closed">마감</option>
-          </StatusSelect>
+          <TextArea id="reason" name="reason" placeholder="결강 신청 사유" />
         </Section>
       </Form>
     </PageWrapper>
   );
 }
 
-const PageWrapper = styled.main`
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: ${spacing.space32} ${spacing.space24} 80px;
+const PageWrapper = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.3125rem 3.125rem 4rem;
   background: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
 `;
 
 const HeaderRow = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: ${spacing.space32};
+  gap: ${spacing.space24};
+  margin-bottom: 2.125rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
 `;
 
 const Title = styled.h1`
   margin: 0;
-  font-size: ${typography.fontSize32};
-  font-weight: 700;
-  color: ${colors.text};
+  color: #000000;
+  font-size: ${typography.fontSize20};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
 `;
 
 const SubmitButton = styled.button`
-  min-width: 150px;
-  height: 48px;
-  padding: 0 ${typography.fontSize18};
-  border: none;
-  background: #e6e6e6;
-  color: ${colors.text};
-  font-size: ${typography.fontSize16};
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.75rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
   cursor: pointer;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 6.75rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Form = styled.form`
   display: flex;
   flex-direction: column;
-`;
+  gap: ${spacing.space20};
 
-const Section = styled.section`
-  margin-bottom: ${spacing.space28};
-`;
-
-const Label = styled.label`
-  display: inline-block;
-  margin-bottom: ${spacing.space12};
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
-  color: ${colors.text};
-`;
-
-const Row = styled.div`
-  display: flex;
-  gap: ${typography.fontSize18};
-
-  @media (max-width: 768px) {
-    flex-direction: column;
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
   }
 `;
 
-const FieldBox = styled.div`
-  flex: 1;
-  min-height: 48px;
-  background: #f3f3f3;
+const Section = styled.section`
   display: flex;
-  align-items: center;
-  gap: ${spacing.space16};
-  padding: 0 ${spacing.space16};
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
 `;
 
-const FieldLabel = styled.label`
-  flex-shrink: 0;
-  font-size: ${typography.fontSize16};
-  font-weight: 700;
-  color: ${colors.text};
+const Label = styled.label`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Input = styled.input`
   width: 100%;
-  height: 48px;
-  padding: 0 ${spacing.space16};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background: #d9d9d9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   outline: none;
 
   &::placeholder {
-    color: #666;
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FieldLabel = styled.label`
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
   }
 `;
 
 const InlineInput = styled.input`
-  flex: 1;
-  height: 48px;
-  border: none;
-  background: transparent;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-width: 0;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background: #d9d9d9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
   outline: none;
 
   &::placeholder {
-    color: #666;
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
   }
 `;
 
 const TextArea = styled.textarea`
   width: 100%;
-  min-height: 120px;
-  padding: ${spacing.space16};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-height: 6.875rem;
+  padding: 0.75rem ${spacing.space12};
+  border: 0;
+  background: #d9d9d9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   resize: none;
   outline: none;
 
   &::placeholder {
-    color: #666;
+    color: #b1b1b1;
   }
-`;
 
-const DateRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${spacing.space8};
-`;
-
-const DateInput = styled.input`
-  width: 120px;
-  height: 48px;
-  padding: 0 ${spacing.space12};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
-  outline: none;
-`;
-
-const CalendarButton = styled.button`
-  width: 32px;
-  height: 32px;
-  border: none;
-  border-radius: 50%;
-  background: #bdbdbd;
-  cursor: pointer;
-  font-size: ${typography.fontSize14};
-`;
-
-const StatusSelect = styled.select`
-  width: 92px;
-  height: 42px;
-  padding: 0 ${spacing.space12};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
-  outline: none;
-  appearance: none;
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding: 1.1875rem ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;

--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -68,6 +68,7 @@ export default async function Page({ searchParams }: PageProps) {
       totalPages={totalPages}
       mineOnly={mineOnly}
       emptyMessage="결강 신청 내역이 없습니다."
+      headerTone="journal"
     />
   );
 }

--- a/app/staff/class/exchange/[postId]/accepted/page.tsx
+++ b/app/staff/class/exchange/[postId]/accepted/page.tsx
@@ -2,17 +2,16 @@
 
 import Link from "next/link";
 import styled from "styled-components";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
-type PageProps = {
-  params: {
-    postId: string;
-  };
+const exchangeTarget = {
+  className: "개나리반",
+  lessonDate: "00.00.00",
+  writer: "최양진",
+  content: "내용내용내용내용내용내용내용내용내용내용내용내용내용내용",
 };
 
-export default function ExchangePostDetailPage({ params }: PageProps) {
-  const { postId } = params;
-
+export default function ExchangeAcceptedPage() {
   return (
     <PageWrapper>
       <TopButtonRow>
@@ -21,166 +20,323 @@ export default function ExchangePostDetailPage({ params }: PageProps) {
         <LinkButton href="/staff/class/exchange">목록</LinkButton>
       </TopButtonRow>
 
-      <Section>
-        <Label>제목</Label>
-        <ValueBox>제목</ValueBox>
-      </Section>
+      <ContentColumn>
+        <PostSection>
+          <Label>제목</Label>
+          <ValueBox $weight="semibold">제목</ValueBox>
 
-      <Section>
-        <Label>신청자 정보</Label>
-        <Row>
-          <FieldBox>
+          <Label>신청자 정보</Label>
+          <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
             <FieldValue>개나리반</FieldValue>
-          </FieldBox>
-          <FieldBox>
             <FieldLabel>수업 일자</FieldLabel>
             <FieldValue>00.00.00</FieldValue>
-          </FieldBox>
-        </Row>
-      </Section>
+            <FieldLabel>작성자</FieldLabel>
+            <FieldValue>홍길동</FieldValue>
+          </InfoRow>
 
-      <Section>
-        <Label>교환 신청 사유</Label>
-        <TextBox>교환 신청 사유</TextBox>
-      </Section>
+          <Label>교환 신청 사유</Label>
+          <TextBox>교환 신청 사유</TextBox>
 
-      <Section>
-        <Label>신청 현황</Label>
-        <StatusBox>대기 중</StatusBox>
-      </Section>
+          <Label>신청 현황</Label>
+          <StatusBox>대기 중</StatusBox>
 
-      <Section>
-        <Label>교환 대상</Label>
+          <Label>교환 대상</Label>
+          <TargetSection>
+            <TargetMetaRow>
+              <TargetMeta>
+                <MetaLabel>반 이름</MetaLabel>
+                <span>{exchangeTarget.className}</span>
+              </TargetMeta>
+              <TargetMeta>
+                <MetaLabel>수업일자</MetaLabel>
+                <span>{exchangeTarget.lessonDate}</span>
+              </TargetMeta>
+              <TargetMeta>
+                <MetaLabel>작성자</MetaLabel>
+                <span>{exchangeTarget.writer}</span>
+              </TargetMeta>
+            </TargetMetaRow>
 
-        <TargetMetaRow>
-          <MetaBox>개나리반</MetaBox>
-          <MetaBox>00.00.00</MetaBox>
-          <MetaBox>최양진</MetaBox>
-        </TargetMetaRow>
-
-        <TargetContent>내용내용내용내용내용내용내용내용내용내용내용내용</TargetContent>
-        <TargetDate>00.00.00</TargetDate>
-      </Section>
+            <TargetContent>{exchangeTarget.content}</TargetContent>
+            <ChangeTargetButton type="button">교환 대상 변경하기</ChangeTargetButton>
+          </TargetSection>
+        </PostSection>
+      </ContentColumn>
     </PageWrapper>
   );
 }
 
-const PageWrapper = styled.main`
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: ${spacing.space32} ${spacing.space24} 80px;
+const PageWrapper = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 0.3125rem 3.125rem 4rem;
   background: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
 `;
 
 const TopButtonRow = styled.div`
   display: flex;
   justify-content: flex-end;
-  gap: ${spacing.space16};
-  margin-bottom: ${spacing.space32};
+  gap: ${spacing.space20};
+  margin-bottom: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
 `;
 
 const ActionButton = styled.button`
-  width: 80px;
-  height: 48px;
-  border: none;
-  background: #e6e6e6;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   cursor: pointer;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const LinkButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 80px;
-  height: 48px;
-  padding: 0 ${spacing.space16};
-  background: #e6e6e6;
-  color: ${colors.text};
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   text-decoration: none;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const Section = styled.section`
-  margin-bottom: ${spacing.space24};
-`;
-
-const Label = styled.h3`
-  margin: 0 0 12px;
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
-`;
-
-const ValueBox = styled.div`
-  min-height: 48px;
-  padding: 14px ${spacing.space16};
-  background: #f3f3f3;
-`;
-
-const Row = styled.div`
+const ContentColumn = styled.article`
   display: flex;
-  gap: ${typography.fontSize18};
+  flex-direction: column;
+  width: 100%;
 `;
 
-const FieldBox = styled.div`
-  flex: 1;
-  min-height: 48px;
-  padding: 14px ${spacing.space16};
-  background: #f3f3f3;
+const PostSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const Label = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ValueBox = styled.div<{ $weight?: "regular" | "semibold" }>`
   display: flex;
   align-items: center;
-  gap: ${spacing.space16};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: ${({ $weight }) => ($weight === "semibold" ? 600 : 400)};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const FieldLabel = styled.span`
-  font-weight: 700;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const FieldValue = styled.span``;
-
-const TextBox = styled.div`
-  min-height: 100px;
-  padding: ${spacing.space16};
-  background: #f3f3f3;
+const FieldValue = styled(ValueBox)`
+  min-width: 0;
 `;
 
-const StatusBox = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 92px;
-  height: 42px;
-  padding: 0 ${spacing.space16};
-  background: #f3f3f3;
+const TextBox = styled(ValueBox)`
+  align-items: flex-start;
+  min-height: 5.1875rem;
+  padding-top: 0.75rem;
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding-top: 1.125rem;
+  }
+`;
+
+const StatusBox = styled(ValueBox)`
+  width: fit-content;
+  padding-inline: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
+  }
+`;
+
+const TargetSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: ${spacing.space8};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
 `;
 
 const TargetMetaRow = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 14px;
-  margin-bottom: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space12};
+  width: 100%;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
-const MetaBox = styled.div`
-  height: 48px;
-  padding: 0 14px;
-  background: #f3f3f3;
+const TargetMeta = styled.div`
   display: flex;
   align-items: center;
+  gap: ${spacing.space8};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    gap: 0.625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const MetaLabel = styled.span`
+  color: #878787;
+  font-weight: 600;
 `;
 
 const TargetContent = styled.div`
-  min-height: 48px;
-  padding: 14px;
-  background: #f3f3f3;
+  width: 100%;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const TargetDate = styled.div`
-  margin-top: 10px;
-  color: ${colors.muted};
-`;
+const ChangeTargetButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #9d9d9d;
+  color: #1c1c1c;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
 
-const BottomRow = styled.div`
-  margin-top: ${spacing.space32};
-  display: flex;
-  justify-content: flex-end;
+  &:hover {
+    background: #8f8f8f;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -1,14 +1,11 @@
-"use client";
-
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 type PageProps = {
-  params: {
+  params: Promise<{
     postId: string;
-  };
+  }>;
 };
 
 const proposals = [
@@ -30,13 +27,9 @@ const proposals = [
   },
 ];
 
-export default function ExchangePostPage({ params }: PageProps) {
-  const { postId } = params;
-  const router = useRouter();
-
-  const handleAcceptProposal = () => {
-    router.push(`/staff/class/exchange/${postId}/accepted`);
-  };
+export default async function ExchangePostPage({ params }: PageProps) {
+  const { postId } = await params;
+  const acceptedHref = `/staff/class/exchange/${postId}/accepted`;
 
   return (
     <PageWrapper>
@@ -107,9 +100,9 @@ export default function ExchangePostPage({ params }: PageProps) {
               <ProposalContent>{proposal.content}</ProposalContent>
               <ProposalFooter>
                 <ProposalDate>{proposal.createdAt}</ProposalDate>
-                <AcceptButton type="button" onClick={handleAcceptProposal}>
+                <AcceptLink href={acceptedHref}>
                   제안 수락하기
-                </AcceptButton>
+                </AcceptLink>
               </ProposalFooter>
             </ProposalCard>
           ))}
@@ -534,6 +527,23 @@ const ProposalDate = styled.span`
   }
 `;
 
-const AcceptButton = styled(SecondaryButton)`
+const AcceptLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
   background: #9d9d9d;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 type PageProps = {
   params: {
@@ -17,7 +17,7 @@ const proposals = [
     className: "개나리반",
     lessonDate: "00.00.00",
     writer: "최양진",
-    content: "내용내용내용내용내용내용내용내용내용내용내용내용",
+    content: "내용내용내용내용내용내용내용내용내용내용내용내용내용내용",
     createdAt: "00.00.00",
   },
   {
@@ -25,12 +25,12 @@ const proposals = [
     className: "개나리반",
     lessonDate: "00.00.00",
     writer: "최양진",
-    content: "내용내용내용내용내용내용내용내용내용내용내용내용",
+    content: "내용내용내용내용내용내용내용내용내용내용내용내용내용내용",
     createdAt: "00.00.00",
   },
 ];
 
-export default function ExchangePostAcceptedPage({ params }: PageProps) {
+export default function ExchangePostPage({ params }: PageProps) {
   const { postId } = params;
   const router = useRouter();
 
@@ -46,257 +46,494 @@ export default function ExchangePostAcceptedPage({ params }: PageProps) {
         <LinkButton href="/staff/class/exchange">목록</LinkButton>
       </TopButtonRow>
 
-      <Section>
-        <Label>제목</Label>
-        <ValueBox>제목</ValueBox>
-      </Section>
+      <ContentColumn>
+        <DateBar>00.00.00</DateBar>
 
-      <Section>
-        <Label>신청자 정보</Label>
-        <Row>
-          <FieldBox>
+        <PostSection>
+          <Label>제목</Label>
+          <ValueBox $weight="semibold">제목</ValueBox>
+
+          <Label>신청자 정보</Label>
+          <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
             <FieldValue>개나리반</FieldValue>
-          </FieldBox>
-          <FieldBox>
             <FieldLabel>수업 일자</FieldLabel>
             <FieldValue>00.00.00</FieldValue>
-          </FieldBox>
-        </Row>
-      </Section>
+            <FieldLabel>작성자</FieldLabel>
+            <FieldValue>홍길동</FieldValue>
+          </InfoRow>
 
-      <Section>
-        <Label>교환 신청 사유</Label>
-        <TextBox>교환 신청 사유</TextBox>
-      </Section>
+          <Label>교환 신청 사유</Label>
+          <TextBox>교환 신청 사유</TextBox>
 
-      <Section>
-        <Label>만료일</Label>
-        <ValueBoxSmall>00.00.00</ValueBoxSmall>
-      </Section>
+          <Label>만료일</Label>
+          <DateBox>00.00.00</DateBox>
 
-      <Section>
-        <Label>신청 현황</Label>
-        <StatusBox>대기 중</StatusBox>
-      </Section>
+          <Label>신청 현황</Label>
+          <StatusBox>대기 중</StatusBox>
+        </PostSection>
 
-      <Divider />
+        <Divider />
 
-      <ProposalHeader>
-        <ProposalTitle>교환 제안서</ProposalTitle>
-        <ActionButton type="button">작성 완료</ActionButton>
-      </ProposalHeader>
+        <ProposalHeader>
+          <ProposalTitle>교환 제안서</ProposalTitle>
+          <SecondaryButton type="button">작성 완료</SecondaryButton>
+        </ProposalHeader>
 
-      <FormRow>
-        <Input placeholder="반 이름" />
-        <Input placeholder="수업 일자" />
-        <Input placeholder="작성자" />
-      </FormRow>
+        <ProposalForm>
+          <ProposalInput placeholder="반 이름" />
+          <ProposalInput placeholder="수업 일자" />
+          <ProposalInput placeholder="작성자" />
+          <ProposalTextarea placeholder="내용" />
+        </ProposalForm>
 
-      <Textarea placeholder="내용" />
-
-      <ProposalList>
-        {proposals.map((proposal) => (
-          <ProposalCard key={proposal.id}>
-            <MetaRow>
-              <MetaBox>{proposal.className}</MetaBox>
-              <MetaBox>{proposal.lessonDate}</MetaBox>
-              <MetaBox>{proposal.writer}</MetaBox>
-            </MetaRow>
-
-            <ContentBox>{proposal.content}</ContentBox>
-
-            <CardBottom>
-              <DateText>{proposal.createdAt}</DateText>
-              <ActionButton type="button" onClick={handleAcceptProposal}>
-                제안 수락하기
-              </ActionButton>
-            </CardBottom>
-          </ProposalCard>
-        ))}
-      </ProposalList>
+        <ProposalList>
+          {proposals.map((proposal) => (
+            <ProposalCard key={proposal.id}>
+              <ProposalMetaRow>
+                <ProposalMeta>
+                  <MetaLabel>반 이름</MetaLabel>
+                  <span>{proposal.className}</span>
+                </ProposalMeta>
+                <ProposalMeta>
+                  <MetaLabel>수업일자</MetaLabel>
+                  <span>{proposal.lessonDate}</span>
+                </ProposalMeta>
+                <ProposalMeta>
+                  <MetaLabel>작성자</MetaLabel>
+                  <span>{proposal.writer}</span>
+                </ProposalMeta>
+              </ProposalMetaRow>
+              <ProposalContent>{proposal.content}</ProposalContent>
+              <ProposalFooter>
+                <ProposalDate>{proposal.createdAt}</ProposalDate>
+                <AcceptButton type="button" onClick={handleAcceptProposal}>
+                  제안 수락하기
+                </AcceptButton>
+              </ProposalFooter>
+            </ProposalCard>
+          ))}
+        </ProposalList>
+      </ContentColumn>
     </PageWrapper>
   );
 }
 
-const PageWrapper = styled.main`
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: ${spacing.space32} ${spacing.space24} 80px;
+const PageWrapper = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 1.8125rem 3.125rem 4rem;
   background: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
 `;
 
 const TopButtonRow = styled.div`
   display: flex;
   justify-content: flex-end;
-  gap: ${spacing.space16};
-  margin-bottom: ${spacing.space32};
+  gap: ${spacing.space20};
+  margin-bottom: 2.25rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
 `;
 
 const ActionButton = styled.button`
-  min-width: 80px;
-  height: 48px;
-  border: none;
-  background: #e6e6e6;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   cursor: pointer;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const LinkButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 80px;
-  height: 48px;
-  padding: 0 ${spacing.space16};
-  background: #e6e6e6;
-  color: ${colors.text};
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   text-decoration: none;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const Section = styled.section`
-  margin-bottom: ${spacing.space24};
+const ContentColumn = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 1.3125rem;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space32};
+  }
 `;
 
-const Label = styled.h3`
-  margin: 0 0 12px;
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
+const DateBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid #a9a9a9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const ValueBox = styled.div`
-  min-height: 48px;
-  padding: 14px ${spacing.space16};
-  background: #f3f3f3;
+const PostSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
 `;
 
-const ValueBoxSmall = styled.div`
-  width: 120px;
-  height: 48px;
-  padding: 0 12px;
-  background: #f3f3f3;
+const Label = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ValueBox = styled.div<{ $weight?: "regular" | "semibold" }>`
   display: flex;
   align-items: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #f7f7f7;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: ${({ $weight }) => ($weight === "semibold" ? 600 : 400)};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const Row = styled.div`
-  display: flex;
-  gap: ${typography.fontSize18};
-`;
-
-const FieldBox = styled.div`
-  flex: 1;
-  min-height: 48px;
-  padding: 14px ${spacing.space16};
-  background: #f3f3f3;
-  display: flex;
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  gap: ${spacing.space16};
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const FieldLabel = styled.span`
-  font-weight: 700;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const FieldValue = styled.span``;
-
-const TextBox = styled.div`
-  min-height: 100px;
-  padding: ${spacing.space16};
-  background: #f3f3f3;
+const FieldValue = styled(ValueBox)`
+  min-width: 0;
 `;
 
-const StatusBox = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 92px;
-  height: 42px;
-  padding: 0 ${spacing.space16};
-  background: #f3f3f3;
+const TextBox = styled(ValueBox)`
+  align-items: flex-start;
+  min-height: 6.875rem;
+  padding-top: 0.75rem;
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding-top: 1.125rem;
+  }
+`;
+
+const DateBox = styled(ValueBox)`
+  width: 7.75rem;
+
+  @media (min-width: 120rem) {
+    width: 11.625rem;
+  }
+`;
+
+const StatusBox = styled(ValueBox)`
+  width: fit-content;
+  padding-inline: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
+  }
 `;
 
 const Divider = styled.hr`
-  border: none;
-  border-top: 1px solid #d7d7d7;
-  margin: 32px 0 28px;
+  width: 100%;
+  border: 0;
+  border-top: 1px solid #a9a9a9;
+  margin: 0;
 `;
 
 const ProposalHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
+  gap: ${spacing.space24};
 `;
 
 const ProposalTitle = styled.h2`
   margin: 0;
-  font-size: ${typography.fontSize32};
-  font-weight: 700;
+  color: #000000;
+  font-size: ${typography.fontSize20};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
 `;
 
-const FormRow = styled.div`
+const SecondaryButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #a0a0a0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ProposalForm = styled.form`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-  margin-bottom: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
-const Input = styled.input`
-  height: 48px;
-  padding: 0 14px;
-  border: 1px solid #999;
+const ProposalInput = styled.input`
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid #000000;
+  background: #e9e9e9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
   outline: none;
+
+  &::placeholder {
+    color: #9c9c9c;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const Textarea = styled.textarea`
-  width: 100%;
-  min-height: 120px;
-  padding: 14px;
-  border: 1px solid #999;
+const ProposalTextarea = styled.textarea`
+  grid-column: 1 / -1;
+  min-height: 6.75rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid #000000;
+  background: #e9e9e9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
   resize: none;
   outline: none;
-  margin-bottom: 24px;
+
+  &::placeholder {
+    color: #9c9c9c;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 10.0625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const ProposalList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: ${spacing.space20};
 `;
 
 const ProposalCard = styled.article`
-  border-top: 1px solid #d7d7d7;
-  padding-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8125rem;
+  padding-top: ${spacing.space20};
+  border-top: 1px solid #a9a9a9;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding-top: 1.875rem;
+  }
 `;
 
-const MetaRow = styled.div`
+const ProposalMetaRow = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-  margin-bottom: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
-const MetaBox = styled.div`
-  height: 48px;
-  padding: 0 14px;
-  background: #f3f3f3;
+const ProposalMeta = styled.div`
   display: flex;
   align-items: center;
+  gap: ${spacing.space8};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #e8e8e8;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    gap: 0.625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const ContentBox = styled.div`
-  min-height: 48px;
-  padding: 14px;
-  background: #f3f3f3;
+const MetaLabel = styled.span`
+  color: #878787;
+  font-weight: 600;
 `;
 
-const CardBottom = styled.div`
+const ProposalContent = styled.div`
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  background: #e8e8e8;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ProposalFooter = styled.div`
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-end;
-  margin-top: 12px;
+  gap: ${spacing.space20};
+  padding-left: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding-left: ${spacing.space20};
+  }
 `;
 
-const DateText = styled.span`
+const ProposalDate = styled.span`
   color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const AcceptButton = styled(SecondaryButton)`
+  background: #9d9d9d;
 `;

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import { IconCalendarMonth } from "@tabler/icons-react";
 import styled from "styled-components";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
   const [expireDateText, setExpireDateText] = useState("00.00.00");
@@ -25,8 +25,8 @@ export default function Page() {
     const value = event.target.value;
     if (!value) return;
 
-    const [year, month, day] = value.split("-");
-    setExpireDateText(`${year}.${month}.${day}`);
+    const [, month, day] = value.split("-");
+    setExpireDateText(`00.${month}.${day}`);
   };
 
   return (
@@ -34,7 +34,7 @@ export default function Page() {
       <HeaderRow>
         <Title>교환 신청서 작성하기</Title>
         <SubmitButton type="submit" form="exchange-form">
-          교환 신청서 제출하기
+          작성 완료
         </SubmitButton>
       </HeaderRow>
 
@@ -45,18 +45,15 @@ export default function Page() {
         </Section>
 
         <Section>
-          <Label as="h3">신청자 정보</Label>
-          <Row>
-            <FieldBox>
-              <FieldLabel htmlFor="className">반 이름</FieldLabel>
-              <InlineInput id="className" name="className" defaultValue="개나리반" />
-            </FieldBox>
-
-            <FieldBox>
-              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-              <InlineInput id="lessonDate" name="lessonDate" defaultValue="00.00.00" />
-            </FieldBox>
-          </Row>
+          <Label as="h2">신청자 정보</Label>
+          <InfoRow>
+            <FieldLabel htmlFor="className">반 이름</FieldLabel>
+            <InlineInput id="className" name="className" defaultValue="개나리반" />
+            <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
+            <InlineInput id="lessonDate" name="lessonDate" defaultValue="00.00.00" />
+            <FieldLabel htmlFor="writer">작성자</FieldLabel>
+            <InlineInput id="writer" name="writer" defaultValue="홍길동" />
+          </InfoRow>
         </Section>
 
         <Section>
@@ -82,160 +79,233 @@ export default function Page() {
               tabIndex={-1}
             />
             <CalendarButton type="button" aria-label="달력 열기" onClick={handleOpenDatePicker}>
-              <IconCalendarMonth size={18} stroke={2} />
+              <IconCalendarMonth size={16} stroke={2} />
             </CalendarButton>
           </DateRow>
-        </Section>
-
-        <Section>
-          <Label htmlFor="status">신청 현황</Label>
-          <StatusSelect id="status" name="status" defaultValue="pending">
-            <option value="pending">대기 중</option>
-            <option value="accepted">수락 완료</option>
-            <option value="closed">마감</option>
-          </StatusSelect>
         </Section>
       </Form>
     </PageWrapper>
   );
 }
 
-const PageWrapper = styled.main`
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: ${spacing.space32} ${spacing.space24} 80px;
+const PageWrapper = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.3125rem 3.125rem 4rem;
   background: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
 `;
 
 const HeaderRow = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: ${spacing.space32};
+  gap: ${spacing.space24};
+  margin-bottom: 2.625rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.9375rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
 `;
 
 const Title = styled.h1`
   margin: 0;
-  font-size: ${typography.fontSize32};
-  font-weight: 700;
-  color: ${colors.text};
+  color: #000000;
+  font-size: ${typography.fontSize20};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
 `;
 
 const SubmitButton = styled.button`
-  min-width: 150px;
-  height: 48px;
-  padding: 0 ${typography.fontSize18};
-  border: none;
-  background: #e6e6e6;
-  color: ${colors.text};
-  font-size: ${typography.fontSize16};
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.75rem;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
   cursor: pointer;
+
+  &:hover {
+    background: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 6.75rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Form = styled.form`
   display: flex;
   flex-direction: column;
-`;
+  gap: ${spacing.space20};
 
-const Section = styled.section`
-  margin-bottom: ${spacing.space28};
-`;
-
-const Label = styled.label`
-  display: inline-block;
-  margin-bottom: ${spacing.space12};
-  font-size: ${typography.fontSize18};
-  font-weight: 700;
-  color: ${colors.text};
-`;
-
-const Row = styled.div`
-  display: flex;
-  gap: ${typography.fontSize18};
-
-  @media (max-width: 768px) {
-    flex-direction: column;
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
   }
 `;
 
-const FieldBox = styled.div`
-  flex: 1;
-  min-height: 48px;
-  background: #f3f3f3;
+const Section = styled.section`
   display: flex;
-  align-items: center;
-  gap: ${spacing.space16};
-  padding: 0 ${spacing.space16};
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
 `;
 
-const FieldLabel = styled.label`
-  flex-shrink: 0;
-  font-size: ${typography.fontSize16};
-  font-weight: 700;
-  color: ${colors.text};
+const Label = styled.label`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Input = styled.input`
   width: 100%;
-  height: 48px;
-  padding: 0 ${spacing.space16};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
   outline: none;
 
-  &::placeholder {
-    color: #666;
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FieldLabel = styled.label`
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
   }
 `;
 
 const InlineInput = styled.input`
-  flex: 1;
-  height: 48px;
-  border: none;
-  background: transparent;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-width: 0;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
   outline: none;
 
-  &::placeholder {
-    color: #666;
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
   }
 `;
 
 const TextArea = styled.textarea`
   width: 100%;
-  min-height: 120px;
-  padding: ${spacing.space16};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  min-height: 6.875rem;
+  padding: 0.75rem ${spacing.space12};
+  border: 0;
+  background: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   resize: none;
   outline: none;
 
-  &::placeholder {
-    color: #666;
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding: 1.125rem ${spacing.space20};
+    font-size: ${typography.fontSize20};
   }
 `;
 
 const DateRow = styled.div`
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: ${spacing.space8};
+  justify-content: space-between;
+  width: 7.75rem;
+  min-height: 2.6875rem;
+  padding: 0.4375rem ${spacing.space12};
+  background: #e2e2e2;
+
+  @media (min-width: 120rem) {
+    width: 11.625rem;
+    min-height: 4rem;
+    padding: 0.625rem ${spacing.space20};
+  }
 `;
 
 const DateInput = styled.input`
-  width: 120px;
-  height: 48px;
-  padding: 0 ${spacing.space12};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
+  width: 4.375rem;
+  border: 0;
+  background: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
   outline: none;
+
+  @media (min-width: 120rem) {
+    width: 6.25rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const HiddenNativeDateInput = styled.input`
@@ -247,26 +317,19 @@ const HiddenNativeDateInput = styled.input`
 `;
 
 const CalendarButton = styled.button`
-  width: 32px;
-  height: 32px;
-  border: none;
-  border-radius: 50%;
-  background: #bdbdbd;
-  cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: ${colors.white};
-`;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 50%;
+  background: #a8a8a8;
+  color: #000000;
+  cursor: pointer;
 
-const StatusSelect = styled.select`
-  width: 92px;
-  height: 42px;
-  padding: 0 ${spacing.space12};
-  border: none;
-  background: #f3f3f3;
-  font-size: ${typography.fontSize16};
-  color: ${colors.text};
-  outline: none;
-  appearance: none;
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
 `;

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -68,6 +68,7 @@ export default async function Page({ searchParams }: PageProps) {
       totalPages={totalPages}
       mineOnly={mineOnly}
       emptyMessage="교환 신청 내역이 없습니다."
+      headerTone="journal"
     />
   );
 }

--- a/app/staff/class/layout.tsx
+++ b/app/staff/class/layout.tsx
@@ -39,5 +39,4 @@ const ClassStage = styled.div`
 const ClassContent = styled.main`
   flex: 1;
   min-width: 0;
-  overflow-x: auto;
 `;

--- a/app/staff/class/new/page.tsx
+++ b/app/staff/class/new/page.tsx
@@ -1,0 +1,5 @@
+import ClassJournalCreatePage from "@/components/staff/ClassJournalCreatePage";
+
+export default function Page() {
+  return <ClassJournalCreatePage />;
+}

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -43,7 +43,7 @@ export default function StaffClassPage() {
 
       <JournalGrid aria-label="수업 일지 목록">
         {classJournals.map((journal) => (
-          <JournalCard key={journal.id}>
+          <JournalCard key={journal.id} href={`/staff/class/${journal.id}`}>
             <LessonList>
               {journalLessons.map((lesson) => (
                 <LessonItem key={lesson.period}>
@@ -211,12 +211,14 @@ const JournalGrid = styled.div`
   }
 `;
 
-const JournalCard = styled.article`
+const JournalCard = styled(Link)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   height: 12.6875rem;
   background-color: #d9d9d9;
+  color: #000000;
+  text-decoration: none;
 
   @media (min-width: 120rem) {
     height: 19.0625rem;

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -37,7 +37,7 @@ export default function StaffClassPage() {
         <Title>수업 일지</Title>
         <ActionGroup>
           <ActionButton type="button">수업 일지 출력</ActionButton>
-          <ActionButton type="button">새 수업 일지 작성하기</ActionButton>
+          <ActionLink href="/staff/class/new">새 수업 일지 작성하기</ActionLink>
         </ActionGroup>
       </HeaderRow>
 
@@ -179,6 +179,34 @@ const ActionButton = styled.button`
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #76bd49;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ActionLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  border-radius: ${radii.radius15};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
   white-space: nowrap;
   cursor: pointer;
 

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -1,37 +1,454 @@
 "use client";
 
+import Link from "next/link";
 import styled from "styled-components";
-import { useRouter } from "next/navigation";
-import PageTemplate from "@/components/common/PageTemplate";
-export default function Page() {
-  const router = useRouter();
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-  const handleCreateClassNote = () => {
-    router.push("/staff/class"); //TODO 추후 경로 수정
-  };
+const classJournals = [
+  { id: 1, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 2, className: "장미반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 3, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 4, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 5, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 6, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 7, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+  { id: 8, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
+];
+
+const journalLessons = [
+  { period: "1교시", content: "수업일지 내용 수업일지 내용" },
+  { period: "2교시", content: "수업일지 내용 수업일지 내용 수업일지 내용" },
+  { period: "3교시", content: "수업일지 내용 수업일지 내용 수업일지 내용" },
+];
+
+function buildPageHref(page: number) {
+  return page === 1 ? "/staff/class" : `/staff/class?page=${page}`;
+}
+
+export default function StaffClassPage() {
+  const currentPage: number = 1;
+  const totalPages: number = 5;
+  const prevPage = Math.max(1, currentPage - 1);
+  const nextPage = Math.min(totalPages, currentPage + 1);
 
   return (
-    <main className="flex-1">
-      <ButtonWrapper onClick={handleCreateClassNote}>새 수업 일지 작성하기</ButtonWrapper>
-      <PageTemplate title="수업 대시보드" description="대시보드 페이지" />
-    </main>
+    <PageSection>
+      <HeaderRow>
+        <Title>수업 일지</Title>
+        <ActionGroup>
+          <ActionButton type="button">수업 일지 출력</ActionButton>
+          <ActionButton type="button">새 수업 일지 작성하기</ActionButton>
+        </ActionGroup>
+      </HeaderRow>
+
+      <JournalGrid aria-label="수업 일지 목록">
+        {classJournals.map((journal) => (
+          <JournalCard key={journal.id}>
+            <LessonList>
+              {journalLessons.map((lesson) => (
+                <LessonItem key={lesson.period}>
+                  <Period>{lesson.period}</Period>
+                  <LessonContent>{lesson.content}</LessonContent>
+                </LessonItem>
+              ))}
+            </LessonList>
+
+            <CardFooter>
+              <ClassName>{journal.className}</ClassName>
+              <MetaGroup>
+                <Teacher>{journal.teacher}</Teacher>
+                <DateText>{journal.date}</DateText>
+              </MetaGroup>
+            </CardFooter>
+          </JournalCard>
+        ))}
+      </JournalGrid>
+
+      <FooterRow>
+        <MineOnlyLabel>
+          <span>내가 작성한 일지만 보기</span>
+          <SwitchInput type="checkbox" aria-label="내가 작성한 일지만 보기" />
+          <SwitchTrack aria-hidden="true">
+            <SwitchThumb />
+          </SwitchTrack>
+        </MineOnlyLabel>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrow
+            href={buildPageHref(prevPage)}
+            aria-label="이전 페이지"
+            $isDisabled={currentPage === 1}
+          >
+            ◀
+          </PageArrow>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumber
+                key={pageNumber}
+                href={buildPageHref(pageNumber)}
+                $isActive={pageNumber === currentPage}
+                aria-current={pageNumber === currentPage ? "page" : undefined}
+              >
+                {pageNumber}
+              </PageNumber>
+            );
+          })}
+          <PageArrow
+            href={buildPageHref(nextPage)}
+            aria-label="다음 페이지"
+            $isDisabled={currentPage === totalPages}
+          >
+            ▶
+          </PageArrow>
+        </Pagination>
+      </FooterRow>
+    </PageSection>
   );
 }
 
-const ButtonWrapper = styled.button`
-  position: fixed;
-  right: 40px;
-  top: 100px;
+const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 3.125rem 0;
+  background-color: ${colors.white};
 
-  padding: 12px 20px;
-  font-size: 14px;
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 3.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: 2.1875rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: 2.5rem;
+  }
+`;
+
+const ActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.125rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+`;
+
+const ActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  border-radius: ${radii.radius15};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
   font-weight: 500;
-
-  background-color: #e5e7eb;
-  border: none;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
   cursor: pointer;
 
   &:hover {
-    background-color: #d1d5db;
+    background-color: #76bd49;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const JournalGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.25rem 1.375rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem 2.0625rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const JournalCard = styled.article`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 12.6875rem;
+  background-color: #d9d9d9;
+
+  @media (min-width: 120rem) {
+    height: 19.0625rem;
+  }
+`;
+
+const LessonList = styled.div`
+  display: grid;
+  gap: 0.625rem;
+  padding: 1.1875rem ${spacing.space16} 1rem;
+
+  @media (min-width: 120rem) {
+    gap: 0.6875rem;
+    padding: 1.8125rem ${spacing.space24} 1.5rem;
+  }
+`;
+
+const LessonItem = styled.div`
+  display: grid;
+  gap: 0.375rem;
+
+  @media (min-width: 120rem) {
+    gap: 0.875rem;
+  }
+`;
+
+const Period = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const LessonContent = styled.p`
+  margin: 0;
+  overflow: hidden;
+  color: #000000;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const CardFooter = styled.footer`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${spacing.space8};
+  min-height: 2.625rem;
+  padding: 0 ${spacing.space16};
+  background-color: #f3f3f3;
+
+  @media (min-width: 120rem) {
+    min-height: 3.9375rem;
+    padding: 0 ${spacing.space24};
+  }
+`;
+
+const ClassName = styled.strong`
+  min-width: 0;
+  overflow: hidden;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const MetaGroup = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  @media (min-width: 120rem) {
+    gap: 0.8125rem;
+  }
+`;
+
+const Teacher = styled.span`
+  color: #000000;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const DateText = styled(Teacher)``;
+
+const FooterRow = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2.5rem;
+
+  @media (min-width: 120rem) {
+    margin-top: 3.25rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: ${spacing.space24};
+  }
+`;
+
+const MineOnlyLabel = styled.label`
+  position: absolute;
+  left: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    gap: 1.1875rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    position: static;
+  }
+`;
+
+const SwitchInput = styled.input`
+  position: absolute;
+  opacity: 0;
+
+  &:checked + span {
+    background-color: #bbc4ff;
+  }
+
+  &:checked + span span {
+    transform: translateX(1.3125rem);
+
+    @media (min-width: 120rem) {
+      transform: translateX(2.125rem);
+    }
+  }
+
+  &:focus-visible + span {
+    outline: 2px solid ${colors.point};
+    outline-offset: 3px;
+  }
+`;
+
+const SwitchTrack = styled.span`
+  position: relative;
+  display: inline-flex;
+  width: 3rem;
+  height: 1.75rem;
+  border-radius: ${radii.radius999};
+  background-color: #d9d9d9;
+  transition: background-color 0.2s ease;
+
+  @media (min-width: 120rem) {
+    width: 4.5rem;
+    height: 2.375rem;
+  }
+`;
+
+const SwitchThumb = styled.span`
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background-color: #6d6d6d;
+  transition: transform 0.2s ease;
+
+  @media (min-width: 120rem) {
+    width: 2.125rem;
+    height: 2.125rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 auto;
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const PageArrow = styled(Link)<{ $isDisabled?: boolean }>`
+  border: 0;
+  background: transparent;
+  color: #666666;
+  text-decoration: none;
+  pointer-events: ${({ $isDisabled }) => ($isDisabled ? "none" : "auto")};
+  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.3 : 1)};
+`;
+
+const PageNumber = styled(Link)<{ $isActive?: boolean }>`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-decoration: none;
+  font-size: ${typography.fontSize16};
+  color: ${({ $isActive }) => ($isActive ? "#111111" : "#9a9a9a")};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
   }
 `;

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -1,10 +1,14 @@
-"use client";
-
 import Link from "next/link";
 import styled from "styled-components";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-const classJournals = [
+type PageProps = {
+  searchParams?: Promise<{
+    page?: string;
+  }>;
+};
+
+const classJournalTemplates = [
   { id: 1, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
   { id: 2, className: "장미반 수학", teacher: "최양진", date: "26.00.00" },
   { id: 3, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
@@ -14,6 +18,17 @@ const classJournals = [
   { id: 7, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
   { id: 8, className: "주말 스마트폰반 수학", teacher: "최양진", date: "26.00.00" },
 ];
+
+const JOURNALS_PER_PAGE = 8;
+const classJournals = Array.from({ length: 40 }, (_, index) => {
+  const template = classJournalTemplates[index % classJournalTemplates.length];
+  const id = index + 1;
+
+  return {
+    ...template,
+    id,
+  };
+});
 
 const journalLessons = [
   { period: "1교시", content: "수업일지 내용 수업일지 내용" },
@@ -25,11 +40,17 @@ function buildPageHref(page: number) {
   return page === 1 ? "/staff/class" : `/staff/class?page=${page}`;
 }
 
-export default function StaffClassPage() {
-  const currentPage: number = 1;
-  const totalPages: number = 5;
+export default async function StaffClassPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const pageParam = Number(resolvedSearchParams?.page);
+  const totalPages = Math.ceil(classJournals.length / JOURNALS_PER_PAGE);
+  const currentPage = Number.isInteger(pageParam)
+    ? Math.min(Math.max(pageParam, 1), totalPages)
+    : 1;
   const prevPage = Math.max(1, currentPage - 1);
   const nextPage = Math.min(totalPages, currentPage + 1);
+  const startIndex = (currentPage - 1) * JOURNALS_PER_PAGE;
+  const visibleJournals = classJournals.slice(startIndex, startIndex + JOURNALS_PER_PAGE);
 
   return (
     <PageSection>
@@ -42,7 +63,7 @@ export default function StaffClassPage() {
       </HeaderRow>
 
       <JournalGrid aria-label="수업 일지 목록">
-        {classJournals.map((journal) => (
+        {visibleJournals.map((journal) => (
           <JournalCard key={journal.id} href={`/staff/class/${journal.id}`}>
             <LessonList>
               {journalLessons.map((lesson) => (

--- a/components/staff/ClassJournalCreatePage.tsx
+++ b/components/staff/ClassJournalCreatePage.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import styled from "styled-components";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+
+const teacherFields = [
+  { id: "writer", label: "작성자", placeholder: "홍길동" },
+  { id: "birthPrefix", label: "주민번호 앞자리", placeholder: "000000" },
+  { id: "phone", label: "연락처", placeholder: "010-0000-0000" },
+  { id: "className", label: "담당 수업", placeholder: "반 이름" },
+  { id: "activityDate", label: "활동 일자", placeholder: "00.00.00" },
+  { id: "activityTime", label: "활동 시간", placeholder: "14:00-15:00" },
+] as const;
+
+const lessonPeriods = [1, 2, 3] as const;
+const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
+
+export default function ClassJournalCreatePage() {
+  return (
+    <PageSection>
+      <HeaderRow>
+        <Title>수업 일지 작성하기</Title>
+        <HeaderActions>
+          <ConsentLabel>
+            <ConsentCheckbox type="checkbox" name="privacyConsent" form="class-journal-form" />
+            <span>정보 제공 동의</span>
+          </ConsentLabel>
+          <SubmitButton type="submit" form="class-journal-form">
+            수업 일지 제출하기
+          </SubmitButton>
+        </HeaderActions>
+      </HeaderRow>
+
+      <Form id="class-journal-form">
+        <InfoGrid>
+          {teacherFields.map((field) => (
+            <InfoField key={field.id}>
+              <FieldLabel htmlFor={field.id}>{field.label}</FieldLabel>
+              <FieldInput id={field.id} name={field.id} placeholder={field.placeholder} />
+            </InfoField>
+          ))}
+        </InfoGrid>
+
+        <LessonSection>
+          <SectionTitle>수업 내용</SectionTitle>
+          {lessonPeriods.map((period) => (
+            <LessonField key={period}>
+              <FieldLabel htmlFor={`lesson-${period}`}>{period}교시</FieldLabel>
+              <LessonTextArea
+                id={`lesson-${period}`}
+                name={`lesson${period}`}
+                placeholder={`${period}교시 수업 내용을 작성해주세요`}
+              />
+            </LessonField>
+          ))}
+        </LessonSection>
+
+        <AttendanceSection>
+          <SectionTitle>출석</SectionTitle>
+          <AttendanceGrid aria-label="출석부">
+            {attendanceColumns.map((column) => (
+              <AttendanceInput
+                key={`student-${column}`}
+                name={`studentName${column + 1}`}
+                aria-label={`${column + 1}번 학생 이름`}
+                placeholder={column < 4 ? "최양진" : ""}
+              />
+            ))}
+            {attendanceColumns.map((column) => (
+              <AttendanceInput
+                key={`attendance-${column}`}
+                name={`attendanceStatus${column + 1}`}
+                aria-label={`${column + 1}번 출석 상태`}
+              />
+            ))}
+          </AttendanceGrid>
+          <AddAttendanceButton type="button">출석부 추가하기</AddAttendanceButton>
+        </AttendanceSection>
+      </Form>
+    </PageSection>
+  );
+}
+
+const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 3.125rem 4rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: 2.1875rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: 2.5rem;
+  }
+`;
+
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+`;
+
+const ConsentLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ConsentCheckbox = styled.input`
+  width: 1rem;
+  height: 1rem;
+  accent-color: ${colors.point};
+
+  @media (min-width: 120rem) {
+    width: 1.5625rem;
+    height: 1.5625rem;
+  }
+`;
+
+const SubmitButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  background-color: #e4e4e4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space24};
+
+  @media (min-width: 120rem) {
+    gap: 2rem;
+  }
+`;
+
+const InfoGrid = styled.section`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space20} 3.75rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem 5.625rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const InfoField = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const FieldLabel = styled.label`
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const FieldInput = styled.input`
+  width: 100%;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background-color: #d9d9d9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  &::placeholder {
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const LessonSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const LessonField = styled.div`
+  display: contents;
+`;
+
+const LessonTextArea = styled.textarea`
+  width: 100%;
+  min-height: 5.375rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 0;
+  background-color: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  resize: vertical;
+  outline: none;
+
+  &::placeholder {
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 8.0625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const AttendanceSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const AttendanceGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(10, minmax(4.5rem, 1fr));
+  overflow-x: auto;
+  border-top: 1px solid #000000;
+  border-left: 1px solid #000000;
+`;
+
+const AttendanceInput = styled.input`
+  min-width: 0;
+  min-height: 2.75rem;
+  padding: ${spacing.space8};
+  border: 0;
+  border-right: 1px solid #000000;
+  border-bottom: 1px solid #000000;
+  background-color: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+  outline: none;
+
+  &::placeholder {
+    color: #000000;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const AddAttendanceButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 2.6875rem;
+  border: 1px solid #000000;
+  background-color: #e2e2e2;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover {
+    background-color: #d9d9d9;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.4375rem;
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/staff/FinanceRequestListPage.tsx
+++ b/components/staff/FinanceRequestListPage.tsx
@@ -78,5 +78,4 @@ const Stage = styled.div`
 const Content = styled.section`
   flex: 1;
   min-width: 0;
-  overflow-x: auto;
 `;

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -178,14 +178,17 @@ export default function ListPanel({
 }
 
 const Container = styled.section`
-  min-height: calc(100vh - ${layout.headerHeight});
-  padding: 2.5rem 3.3125rem 3rem 3.125rem;
+  min-height: 0;
+  overflow: visible;
+  padding: 2.1875rem 3.3125rem 0 3.125rem;
 
   @media (min-width: 120rem) {
-    padding: 3.5rem 5rem 4rem 4.6875rem;
+    padding: 3.5rem 4.6875rem 3.875rem;
   }
 
   @media (max-width: ${layout.breakpointTablet}) {
+    height: auto;
+    overflow: visible;
     padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
   }
 `;
@@ -195,7 +198,7 @@ const HeaderRow = styled.div`
   align-items: flex-start;
   justify-content: space-between;
   gap: ${spacing.space24};
-  margin-bottom: 0.875rem;
+  margin-bottom: 1.4375rem;
 
   @media (min-width: 120rem) {
     margin-bottom: 1.75rem;
@@ -246,7 +249,7 @@ const Table = styled.table`
 
 const Th = styled.th<{ $width720?: string; $width1080?: string }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
-  padding: 0.8125rem ${spacing.space12};
+  padding: 0.625rem ${spacing.space12};
   border-bottom: 1px solid #6d6d6d;
   font-size: ${typography.fontSize16};
   font-weight: 700;
@@ -255,7 +258,7 @@ const Th = styled.th<{ $width720?: string; $width1080?: string }>`
 
   @media (min-width: 120rem) {
     width: ${({ $width1080, $width720 }) => $width1080 ?? $width720 ?? "auto"};
-    padding: ${spacing.space20} ${spacing.space12};
+    padding: 1rem ${spacing.space12};
     font-size: ${typography.fontSize24};
   }
 `;
@@ -266,14 +269,14 @@ const Tr = styled.tr`
 
 const Td = styled.td<{ $width720?: string; $width1080?: string }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
-  padding: 0.875rem ${spacing.space12};
+  padding: 0.65625rem ${spacing.space12};
   font-size: ${typography.fontSize14};
   text-align: center;
   white-space: nowrap;
 
   @media (min-width: 120rem) {
     width: ${({ $width1080, $width720 }) => $width1080 ?? $width720 ?? "auto"};
-    padding: ${spacing.space20} ${spacing.space12};
+    padding: 1.1875rem ${spacing.space12};
     font-size: ${typography.fontSize20};
   }
 `;
@@ -301,29 +304,45 @@ const TitleLink = styled(Link)`
 `;
 
 const BottomRow = styled.div<{ $hasToggle: boolean }>`
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: ${({ $hasToggle }) => ($hasToggle ? "space-between" : "center")};
+  justify-content: center;
   gap: ${spacing.space24};
-  margin-top: ${spacing.space32};
+  margin-top: 1.75rem;
 
   @media (min-width: 120rem) {
-    margin-top: 4rem;
+    margin-top: 3.25rem;
   }
 
   @media (max-width: ${layout.breakpointMobile}) {
     flex-direction: column;
+    align-items: flex-start;
   }
 `;
 
 const ToggleArea = styled.div`
+  position: absolute;
+  left: 0;
   display: flex;
   align-items: center;
   gap: 14px;
+
+  @media (min-width: 120rem) {
+    gap: 1.1875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    position: static;
+  }
 `;
 
 const ToggleLabel = styled.span`
   font-size: ${typography.fontSize14};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const ToggleButtonLink = styled(Link)<{ $active: boolean }>`
@@ -334,6 +353,11 @@ const ToggleButtonLink = styled(Link)<{ $active: boolean }>`
   border: none;
   border-radius: 999px;
   background: ${({ $active }) => ($active ? "#bbc4ff" : "#d9d9d9")};
+
+  @media (min-width: 120rem) {
+    width: 4.5rem;
+    height: 2.375rem;
+  }
 `;
 
 const ToggleThumb = styled.span<{ $active: boolean }>`
@@ -345,6 +369,12 @@ const ToggleThumb = styled.span<{ $active: boolean }>`
   border-radius: 50%;
   background: #6d6d6d;
   transition: left 0.2s ease;
+
+  @media (min-width: 120rem) {
+    left: ${({ $active }) => ($active ? "2.25rem" : "0.125rem")};
+    width: 2.125rem;
+    height: 2.125rem;
+  }
 `;
 
 const Pagination = styled.nav`
@@ -355,6 +385,7 @@ const Pagination = styled.nav`
   font-size: ${typography.fontSize16};
 
   @media (min-width: 120rem) {
+    gap: ${spacing.space16};
     font-size: ${typography.fontSize24};
   }
 `;
@@ -376,4 +407,8 @@ const PageNumber = styled(Link)<{ $isActive?: boolean }>`
   font-size: ${typography.fontSize16};
   color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
   font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+  }
 `;

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import styled from "styled-components";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export type ListPanelRow = {
   id: number;
@@ -24,6 +24,7 @@ type ListPanelProps = {
   mineOnly?: boolean;
   showMineOnlyToggle?: boolean;
   emptyMessage?: string;
+  headerTone?: "default" | "journal";
 };
 
 type QueryValue = string | number | boolean;
@@ -55,6 +56,7 @@ export default function ListPanel({
   mineOnly = false,
   showMineOnlyToggle = true,
   emptyMessage = "목록이 없습니다.",
+  headerTone = "default",
 }: ListPanelProps) {
   const prevPage = Math.max(1, currentPage - 1);
   const nextPage = Math.min(totalPages, currentPage + 1);
@@ -64,8 +66,10 @@ export default function ListPanel({
   return (
     <Container>
       <HeaderRow>
-        <Title>{title}</Title>
-        <WriteButton href={writeHref}>{writeLabel}</WriteButton>
+        <Title $tone={headerTone}>{title}</Title>
+        <WriteButton href={writeHref} $tone={headerTone}>
+          {writeLabel}
+        </WriteButton>
       </HeaderRow>
 
       <TableSection>
@@ -205,34 +209,44 @@ const HeaderRow = styled.div`
   }
 `;
 
-const Title = styled.h1`
-  font-size: ${typography.fontSize24};
-  font-weight: 700;
+const Title = styled.h1<{ $tone: "default" | "journal" }>`
   margin: 0;
+  color: #000000;
+  font-size: ${({ $tone }) => ($tone === "journal" ? "1.625rem" : typography.fontSize24)};
+  font-weight: ${({ $tone }) => ($tone === "journal" ? 600 : 700)};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${({ $tone }) => ($tone === "journal" ? "2.5rem" : typography.fontSize24)};
+  }
 `;
 
-const WriteButton = styled(Link)`
+const WriteButton = styled(Link)<{ $tone: "default" | "journal" }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 7.75rem;
-  min-height: 2.75rem;
-  padding: 0.75rem ${spacing.space20};
-  border: none;
-  background: #e4e4e4;
-  color: ${colors.text};
+  min-width: ${({ $tone }) => ($tone === "journal" ? "auto" : "7.75rem")};
+  min-height: ${({ $tone }) => ($tone === "journal" ? "2.6875rem" : "2.75rem")};
+  padding: ${({ $tone }) => ($tone === "journal" ? `0.8125rem ${spacing.space20}` : `0.75rem ${spacing.space20}`)};
+  border: 0;
+  border-radius: ${({ $tone }) => ($tone === "journal" ? radii.radius15 : "0")};
+  background: ${({ $tone }) => ($tone === "journal" ? colors.point : "#e4e4e4")};
+  color: ${({ $tone }) => ($tone === "journal" ? colors.white : colors.text)};
   font-size: ${typography.fontSize14};
   font-weight: 500;
+  line-height: ${typography.lineHeight130};
   text-decoration: none;
+  white-space: nowrap;
   cursor: pointer;
 
   &:hover {
-    background: #d9d9d9;
+    background: ${({ $tone }) => ($tone === "journal" ? "#76bd49" : "#d9d9d9")};
   }
 
   @media (min-width: 120rem) {
-    min-width: 9.375rem;
-    min-height: 4.25rem;
+    min-width: ${({ $tone }) => ($tone === "journal" ? "auto" : "9.375rem")};
+    min-height: ${({ $tone }) => ($tone === "journal" ? "4rem" : "4.25rem")};
+    padding: ${({ $tone }) => ($tone === "journal" ? `${spacing.space20} 1.875rem` : `0.75rem ${spacing.space20}`)};
     font-size: ${typography.fontSize20};
   }
 `;

--- a/components/staff/StaffSidebar.tsx
+++ b/components/staff/StaffSidebar.tsx
@@ -65,21 +65,42 @@ function getStoredOpenSections() {
   }
 }
 
+function isCurrentStaffPath(pathname: string, href: string) {
+  if (href === "/staff/class") {
+    return (
+      pathname === href ||
+      pathname === "/staff/class/new" ||
+      /^\/staff\/class\/(?!(exchange|absence)$)[^/]+$/.test(pathname)
+    );
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function getCurrentSectionTitle(pathname: string) {
+  return staffSections.find((section) =>
+    section.items.some((item) => isCurrentStaffPath(pathname, item.href)),
+  )?.title;
+}
+
 export default function StaffSidebar() {
   const pathname = usePathname();
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(getClosedSections);
 
   useEffect(() => {
     const timerId = window.setTimeout(() => {
-      setOpenSections(getStoredOpenSections());
+      const currentSectionTitle = getCurrentSectionTitle(pathname);
+      setOpenSections({
+        ...getStoredOpenSections(),
+        ...(currentSectionTitle ? { [currentSectionTitle]: true } : {}),
+      });
     }, 0);
 
     return () => window.clearTimeout(timerId);
-  }, []);
+  }, [pathname]);
 
   const isCurrent = (href: string) => {
-    if (href === "/staff/class") return pathname === href;
-    return pathname === href || pathname.startsWith(`${href}/`);
+    return isCurrentStaffPath(pathname, href);
   };
 
   const toggleSection = (title: string) => {

--- a/components/staff/StaffSidebar.tsx
+++ b/components/staff/StaffSidebar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import styled from "styled-components";
 import { colors, layout, typography } from "@/styles/tokens";
+
+const SIDEBAR_STORAGE_KEY = "staff-sidebar-open-sections";
 
 const staffSections = [
   {
@@ -40,11 +42,40 @@ const staffSections = [
   },
 ];
 
+function getClosedSections() {
+  return Object.fromEntries(staffSections.map((section) => [section.title, false]));
+}
+
+function getStoredOpenSections() {
+  const storedValue = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+  if (!storedValue) return getClosedSections();
+
+  try {
+    const parsedValue = JSON.parse(storedValue) as Record<string, boolean>;
+
+    return {
+      ...getClosedSections(),
+      ...Object.fromEntries(
+        staffSections.map((section) => [section.title, Boolean(parsedValue[section.title])]),
+      ),
+    };
+  } catch {
+    window.localStorage.removeItem(SIDEBAR_STORAGE_KEY);
+    return getClosedSections();
+  }
+}
+
 export default function StaffSidebar() {
   const pathname = usePathname();
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(staffSections.map((section) => [section.title, true])),
-  );
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(getClosedSections);
+
+  useEffect(() => {
+    const timerId = window.setTimeout(() => {
+      setOpenSections(getStoredOpenSections());
+    }, 0);
+
+    return () => window.clearTimeout(timerId);
+  }, []);
 
   const isCurrent = (href: string) => {
     if (href === "/staff/class") return pathname === href;
@@ -52,10 +83,24 @@ export default function StaffSidebar() {
   };
 
   const toggleSection = (title: string) => {
-    setOpenSections((current) => ({
-      ...current,
-      [title]: !current[title],
-    }));
+    setOpenSections((current) => {
+      const nextOpenSections = {
+        ...current,
+        [title]: !current[title],
+      };
+
+      window.localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(nextOpenSections));
+
+      return nextOpenSections;
+    });
+  };
+
+  const keepOnlySectionOpen = (title: string) => {
+    const nextOpenSections = Object.fromEntries(
+      staffSections.map((section) => [section.title, section.title === title]),
+    );
+
+    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(nextOpenSections));
   };
 
   return (
@@ -63,8 +108,7 @@ export default function StaffSidebar() {
       <SidebarHeader>교원</SidebarHeader>
       <SidebarContent>
         {staffSections.map((section, sectionIndex) => {
-          const hasCurrentItem = section.items.some((item) => isCurrent(item.href));
-          const isOpen = openSections[section.title] ?? hasCurrentItem;
+          const isOpen = openSections[section.title] ?? false;
           const sectionId = `staff-sidebar-section-${sectionIndex}`;
 
           return (
@@ -74,7 +118,6 @@ export default function StaffSidebar() {
                 onClick={() => toggleSection(section.title)}
                 aria-expanded={isOpen}
                 aria-controls={sectionId}
-                $hasCurrentItem={hasCurrentItem}
               >
                 <span>{section.title}</span>
                 <Chevron aria-hidden="true" $isOpen={isOpen}>
@@ -90,6 +133,7 @@ export default function StaffSidebar() {
                         href={item.href}
                         $isCurrent={current}
                         aria-current={current ? "page" : undefined}
+                        onClick={() => keepOnlySectionOpen(section.title)}
                       >
                         {item.label}
                       </SectionLink>
@@ -108,7 +152,8 @@ export default function StaffSidebar() {
 const Sidebar = styled.aside`
   width: 11.625rem;
   flex-shrink: 0;
-  background-color: #e8e8e8;
+  background-color: ${colors.background};
+  border-right: 1px solid ${colors.border};
 
   @media (min-width: 120rem) {
     width: 17.4375rem;
@@ -125,8 +170,8 @@ const SidebarHeader = styled.h1`
   min-height: 3.625rem;
   margin: 0;
   padding: 0 1.625rem;
-  background-color: #939393;
-  color: ${colors.text};
+  background-color: ${colors.point};
+  color: ${colors.white};
   font-size: ${typography.fontSize16};
   font-weight: 700;
   line-height: ${typography.lineHeight130};
@@ -151,12 +196,12 @@ const SectionBlock = styled.section`
     margin-top: 1.375rem;
 
     @media (min-width: 120rem) {
-      margin-top: 2.5rem;
+      margin-top: 1.5rem;
     }
   }
 `;
 
-const SectionButton = styled.button<{ $hasCurrentItem: boolean }>`
+const SectionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -164,7 +209,7 @@ const SectionButton = styled.button<{ $hasCurrentItem: boolean }>`
   border: 0;
   padding: 0 1.625rem;
   background: transparent;
-  color: ${({ $hasCurrentItem }) => ($hasCurrentItem ? colors.text : "#9f9f9f")};
+  color: ${colors.point};
   font-family: inherit;
   font-size: ${typography.fontSize14};
   font-weight: 700;
@@ -190,14 +235,20 @@ const Chevron = styled.span<{ $isOpen: boolean }>`
 
 const SectionList = styled.ul<{ $isOpen: boolean }>`
   max-height: ${({ $isOpen }) => ($isOpen ? "24rem" : "0")};
-  margin: 0.375rem 0 0;
+  margin: ${({ $isOpen }) => ($isOpen ? "0.625rem 0 0" : "0")};
   padding: 0;
   overflow: hidden;
   list-style: none;
-  transition: max-height 0.2s ease;
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+  transform: translateY(${({ $isOpen }) => ($isOpen ? "0" : "-0.375rem")});
+  transition:
+    max-height 0.28s ease,
+    margin 0.28s ease,
+    opacity 0.18s ease,
+    transform 0.28s ease;
 
   @media (min-width: 120rem) {
-    margin-top: 0.9375rem;
+    margin-top: ${({ $isOpen }) => ($isOpen ? "0.9375rem" : "0")};
   }
 `;
 
@@ -209,15 +260,18 @@ const SectionItem = styled.li`
 const SectionLink = styled(Link)<{ $isCurrent: boolean }>`
   display: block;
   padding: 0.25rem 1.625rem;
-  background-color: ${({ $isCurrent }) => ($isCurrent ? "#d9d9d9" : "transparent")};
-  color: ${colors.text};
+  background-color: ${({ $isCurrent }) => ($isCurrent ? colors.point : "transparent")};
+  color: ${({ $isCurrent }) => ($isCurrent ? colors.white : "#000000")};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
+  transition:
+    background-color 0.28s ease,
+    color 0.28s ease;
 
   &:hover {
-    background-color: ${({ $isCurrent }) => ($isCurrent ? "#d9d9d9" : "#dedede")};
+    background-color: ${({ $isCurrent }) => ($isCurrent ? colors.point : "#eeeeee")};
   }
 
   @media (min-width: 120rem) {


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 수업 일지 목록, 수업 일지 상세, 수업 일지 작성 페이지 구현
   \- 카드형 목록 UI를 추가하였습니다.
   \- 카드 클릭 시, 상세 페이지 `/staff/class/[postId]` 로 이동하도록 연결하였습니다.
   \- 1920x1080 및 1280x720 레이아웃을 별도로 구성하여, 다양한 크기의 CSS viewport 및 여러 OS 배율에서도 디자인 시안의 의도대로 화면이 구성되도록 반응형 UI로 구현하였습니다.

   <img width="1919" height="866" alt="스크린샷 2026-05-01 183443" src="https://github.com/user-attachments/assets/62bf0c32-a328-4b48-88a6-62792377515c" />

   <img width="1898" height="869" alt="스크린샷 2026-05-01 183500" src="https://github.com/user-attachments/assets/bd82fb87-acab-4947-a6f6-18c670a0c450" />

   <img width="1900" height="866" alt="스크린샷 2026-05-01 183512" src="https://github.com/user-attachments/assets/7c0c2564-67e2-465a-b27e-5fb91c55067f" />

2. 수업 교환 및 결강 신청 관련 페이지(본문 및 신청서 작성 페이지)를 반응형 UI로 개선하였습니다.

3. 공용 목록 패널 UI 보정
   \- `ListPanel`의 불필요한 스크롤과 하단 페이지네이션 위치 문제를 보정하였습니다.
   \- 수업 교환/결강 목록 페이지의 상단 제목과 작성 버튼 톤을 수업 일지 목록 화면과 맞추었습니다.

   <img width="1566" height="261" alt="스크린샷 2026-05-01 145819" src="https://github.com/user-attachments/assets/6fe6c0bf-9861-49dc-acfe-1a15ee98c3ac" />

   <img width="1561" height="263" alt="스크린샷 2026-05-01 145838" src="https://github.com/user-attachments/assets/20cb5069-6144-47b7-9d65-05a24aea94a0" />

4. 사이드바 동작 개선
   \- 사이드바 하위 메뉴를 초기에 숨김 상태로 두고, 섹션 이동 시 열림 상태 유지/정리 동작을 추가하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #29 

## 💬 기타 사항

현재 뒤로 가기 버튼에 여러 페이지가 중복 배치되어 있습니다.
추후 뒤로 가기 버튼의 역할을 정리하여 화면 이동 흐름을 개선해야 합니다.

## 📂 참고 자료

> N/A
