### PR TITLE
[FEAT] 수업 관리 섹션 api 연동 및 UI 개선

### DIFF
--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -7,7 +7,7 @@ export interface SignupRequestDto {
 }
 
 export interface LoginRequestDto {
-  username: string;
+  email: string;
   password: string;
 }
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -20,6 +20,9 @@ export * as departmentDto from "./department/department.dto";
 export * as lessonApi from "./lesson/lesson.api";
 export * as lessonDto from "./lesson/lesson.dto";
 
+export * as lessonExchangeApi from "./lessonExchange/lessonExchange.api";
+export * as lessonExchangeDto from "./lessonExchange/lessonExchange.dto";
+
 export * as postApi from "./post/post.api";
 export * as postDto from "./post/post.dto";
 

--- a/api/lessonExchange/lessonExchange.api.ts
+++ b/api/lessonExchange/lessonExchange.api.ts
@@ -1,0 +1,136 @@
+import authClient from "../client/authClient";
+import type {
+  ApproveLessonExchangeRequestDto,
+  CreateLessonExchangeRequestDto,
+  LessonExchangeListQueryParamsDto,
+  LessonExchangePathParamsDto,
+  LessonExchangeProposalDto,
+  LessonExchangeProposalListResponseDto,
+  LessonExchangeProposalPathParamsDto,
+  LessonExchangeProposalRequestDto,
+  LessonExchangeRequestDetailDto,
+  LessonExchangeRequestListResponseDto,
+  RejectLessonExchangeRequestDto,
+  UpdateLessonExchangeProposalRequestDto,
+  UpdateLessonExchangeRequestDto,
+} from "./lessonExchange.dto";
+
+// 수업 교환 요청 목록을 조회하는 요청
+export async function getLessonExchangeRequests(query?: LessonExchangeListQueryParamsDto) {
+  const response = await authClient.get<LessonExchangeRequestListResponseDto>(
+    "/api/v1/lesson-exchange-requests",
+    {
+      params: query,
+    },
+  );
+  return response.data;
+}
+
+// 수업 교환 요청을 생성하는 요청
+export async function createLessonExchangeRequest(body: CreateLessonExchangeRequestDto) {
+  const response = await authClient.post<LessonExchangeRequestDetailDto>(
+    "/api/v1/lesson-exchange-requests",
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청 상세를 조회하는 요청
+export async function getLessonExchangeRequestDetail(pathParams: LessonExchangePathParamsDto) {
+  const response = await authClient.get<LessonExchangeRequestDetailDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}`,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청을 수정하는 요청
+export async function updateLessonExchangeRequest(
+  pathParams: LessonExchangePathParamsDto,
+  body: UpdateLessonExchangeRequestDto,
+) {
+  const response = await authClient.patch<LessonExchangeRequestDetailDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청을 반려하는 요청
+export async function rejectLessonExchangeRequest(
+  pathParams: LessonExchangePathParamsDto,
+  body: RejectLessonExchangeRequestDto,
+) {
+  const response = await authClient.patch<LessonExchangeRequestDetailDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/reject`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청을 취소하는 요청
+export async function cancelLessonExchangeRequest(pathParams: LessonExchangePathParamsDto) {
+  const response = await authClient.patch<LessonExchangeRequestDetailDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/cancel`,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청을 승인하는 요청
+export async function approveLessonExchangeRequest(
+  pathParams: LessonExchangePathParamsDto,
+  body?: ApproveLessonExchangeRequestDto,
+) {
+  const response = await authClient.patch<LessonExchangeRequestDetailDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/approve`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청의 제안 목록을 조회하는 요청
+export async function getLessonExchangeProposals(pathParams: LessonExchangePathParamsDto) {
+  const response = await authClient.get<LessonExchangeProposalListResponseDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/proposals`,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청에 제안을 생성하는 요청
+export async function createLessonExchangeProposal(
+  pathParams: LessonExchangePathParamsDto,
+  body: LessonExchangeProposalRequestDto,
+) {
+  const response = await authClient.post<LessonExchangeProposalDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/proposals`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청의 특정 제안을 수정하는 요청
+export async function updateLessonExchangeProposal(
+  pathParams: LessonExchangeProposalPathParamsDto,
+  body: UpdateLessonExchangeProposalRequestDto,
+) {
+  const response = await authClient.patch<LessonExchangeProposalDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/proposals/${pathParams.proposalId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청의 특정 제안을 철회하는 요청
+export async function withdrawLessonExchangeProposal(pathParams: LessonExchangeProposalPathParamsDto) {
+  const response = await authClient.patch<LessonExchangeProposalDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/proposals/${pathParams.proposalId}/withdraw`,
+  );
+  return response.data;
+}
+
+// 특정 수업 교환 요청의 특정 제안을 수락하는 요청
+export async function acceptLessonExchangeProposal(pathParams: LessonExchangeProposalPathParamsDto) {
+  const response = await authClient.patch<LessonExchangeProposalDto>(
+    `/api/v1/lesson-exchange-requests/${pathParams.requestId}/proposals/${pathParams.proposalId}/accept`,
+  );
+  return response.data;
+}

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -1,0 +1,107 @@
+export type LessonExchangeRequestStatus =
+  | "PENDING"
+  | "APPROVED"
+  | "REJECTED"
+  | "CANCELLED"
+  | string;
+
+export type LessonExchangeProposalStatus = "PENDING" | "ACCEPTED" | "WITHDRAWN" | string;
+
+export interface LessonExchangePathParamsDto {
+  requestId: number;
+}
+
+export interface LessonExchangeProposalPathParamsDto extends LessonExchangePathParamsDto {
+  proposalId: number;
+}
+
+export interface LessonExchangeListQueryParamsDto {
+  status?: LessonExchangeRequestStatus;
+}
+
+export interface CreateLessonExchangeRequestDto {
+  lessonDate: string;
+  title: string;
+  content: string;
+  startPeriod?: number;
+  endPeriod?: number;
+  expiresAt: string;
+}
+
+export interface UpdateLessonExchangeRequestDto {
+  lessonDate?: string;
+  title?: string;
+  content?: string;
+  startPeriod?: number;
+  endPeriod?: number;
+  expiresAt?: string;
+}
+
+export interface RejectLessonExchangeRequestDto {
+  note: string;
+}
+
+export interface ApproveLessonExchangeRequestDto {
+  proposalId?: number;
+  exchangeWithUserId?: number;
+}
+
+export interface LessonExchangeRequestDetailDto {
+  id?: number;
+  classroomName?: string;
+  lessonDate?: string;
+  requestedById?: number;
+  requestedByName?: string;
+  title?: string;
+  content?: string;
+  status?: LessonExchangeRequestStatus;
+  scope?: string;
+  startPeriod?: number;
+  endPeriod?: number;
+  expiresAt?: string;
+  processedAt?: string;
+  processedByName?: string;
+  rejectionNote?: string;
+  completedAt?: string;
+  cancelledAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type LessonExchangeRequestListResponseDto = LessonExchangeRequestDetailDto[];
+
+export interface LessonExchangeProposalRequestDto {
+  lessonDate: string;
+  startPeriod: number;
+  endPeriod: number;
+  content: string;
+}
+
+export interface UpdateLessonExchangeProposalRequestDto {
+  lessonDate?: string;
+  startPeriod?: number;
+  endPeriod?: number;
+  content?: string;
+}
+
+export interface LessonExchangeProposalDto {
+  id?: number;
+  requestId?: number;
+  classroomName?: string;
+  proposedById?: number;
+  proposedByName?: string;
+  proposalType?: string;
+  proposalScope?: string;
+  lessonDate?: string;
+  startPeriod?: number;
+  endPeriod?: number;
+  content?: string;
+  status?: LessonExchangeProposalStatus;
+  acceptedAt?: string;
+  withdrawnAt?: string;
+  closedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type LessonExchangeProposalListResponseDto = LessonExchangeProposalDto[];

--- a/app/staff/class/[postId]/page.tsx
+++ b/app/staff/class/[postId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import styled from "styled-components";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, spacing, typography, radii } from "@/styles/tokens";
 
 type PageProps = {
   params: Promise<{
@@ -136,12 +136,13 @@ const ActionButton = styled.button`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  background-color: #e4e4e4;
-  color: #000000;
+  background-color: #88cd5a;
+  color: #ffffff;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
   cursor: pointer;
+  border-radius: ${radii.radius12};
 
   &:hover {
     background-color: #d9d9d9;
@@ -162,12 +163,13 @@ const LinkButton = styled(Link)`
   min-width: 3.9375rem;
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
-  background-color: #e4e4e4;
-  color: #000000;
+  background-color: #88cd5a;
+  color: #ffffff;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
+  border-radius: ${radii.radius12};
 
   &:hover {
     background-color: #d9d9d9;

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
@@ -52,11 +52,11 @@ export default function AbsencePostPage() {
   return (
     <PageWrapper>
       <TopButtonRow>
-        <ActionButton type="button" onClick={handleDelete} disabled={deleteAbsenceMutation.isPending}>
+        <ToolbarDangerButton type="button" onClick={handleDelete} disabled={deleteAbsenceMutation.isPending}>
           {deleteAbsenceMutation.isPending ? "삭제 중..." : "삭제"}
-        </ActionButton>
-        <ActionButton type="button">수정</ActionButton>
-        <LinkButton href="/staff/class/absence">목록</LinkButton>
+        </ToolbarDangerButton>
+        <ToolbarPrimaryButton type="button">수정</ToolbarPrimaryButton>
+        <ToolbarListLink href="/staff/class/absence">목록</ToolbarListLink>
       </TopButtonRow>
 
       <ContentColumn>
@@ -118,7 +118,7 @@ const TopButtonRow = styled.div`
   }
 `;
 
-const ActionButton = styled.button`
+const toolbarButtonBase = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -126,16 +126,12 @@ const ActionButton = styled.button`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  background: #e4e4e4;
-  color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
+  white-space: nowrap;
   cursor: pointer;
-
-  &:hover {
-    background: #d9d9d9;
-  }
+  border-radius: ${radii.radius12};
 
   @media (min-width: 120rem) {
     min-width: 5.9375rem;
@@ -145,29 +141,39 @@ const ActionButton = styled.button`
   }
 `;
 
-const LinkButton = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 3.9375rem;
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space20};
-  background: #e4e4e4;
-  color: #000000;
-  font-size: ${typography.fontSize14};
-  font-weight: 500;
-  line-height: ${typography.lineHeight130};
+const ToolbarDangerButton = styled.button`
+  ${toolbarButtonBase}
+  background: #fde4e2;
+  color: #da3a30;
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.97);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const ToolbarPrimaryButton = styled.button`
+  ${toolbarButtonBase}
+  background: ${colors.point};
+  color: ${colors.white};
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+`;
+
+const ToolbarListLink = styled(Link)`
+  ${toolbarButtonBase}
+  background: ${colors.point};
+  color: ${colors.white};
   text-decoration: none;
 
   &:hover {
-    background: #d9d9d9;
-  }
-
-  @media (min-width: 120rem) {
-    min-width: 5.9375rem;
-    min-height: 4rem;
-    padding: ${spacing.space20} 1.875rem;
-    font-size: ${typography.fontSize20};
+    filter: brightness(0.95);
   }
 `;
 

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -1,26 +1,29 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
-function formatStatus(status?: string) {
-  if (status === "APPROVED") return "승인 완료";
-  if (status === "REJECTED") return "반려";
-  return "대기 중";
-}
-
 export default function AbsencePostPage() {
-  const [isDeleting, setIsDeleting] = useState(false);
   const params = useParams<{ postId: string }>();
   const router = useRouter();
   const postId = Number(params.postId);
   const isValidPostId = Number.isInteger(postId) && postId > 0;
+  const deleteAbsenceMutation = useMutation({
+    mutationFn: deleteAbsenceRequest,
+    onSuccess: () => {
+      router.push("/staff/class/absence");
+      router.refresh();
+    },
+    onError: () => {
+      window.alert("결강 신청서 삭제에 실패했습니다.");
+    },
+  });
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["absence-request", postId],
@@ -33,29 +36,20 @@ export default function AbsencePostPage() {
   const detailLessonDate = formatUtcToKstShortDate(data?.lessonDate);
   const detailWriter = data?.requestedByName ?? "-";
   const detailReason = isError ? "결강 신청 사유를 불러오지 못했습니다." : data?.reason ?? "결강 신청 사유";
-  const detailStatus = isError ? "확인 불가" : formatStatus(data?.status);
+  const detailStatus = isError ? "확인 불가" : formatRequestStatus(data?.status);
   const detailTitle = isLoading ? "불러오는 중..." : "-";
 
   const handleDelete = async () => {
-    if (!isValidPostId || isDeleting) return;
+    if (!isValidPostId || deleteAbsenceMutation.isPending) return;
     if (!window.confirm("결강 신청서를 삭제하시겠습니까?")) return;
-
-    try {
-      setIsDeleting(true);
-      await deleteAbsenceRequest({ requestId: postId });
-      router.push("/staff/class/absence");
-      router.refresh();
-    } catch {
-      window.alert("결강 신청서 삭제에 실패했습니다.");
-      setIsDeleting(false);
-    }
+    deleteAbsenceMutation.mutate({ requestId: postId });
   };
 
   return (
     <PageWrapper>
       <TopButtonRow>
-        <ActionButton type="button" onClick={handleDelete} disabled={isDeleting}>
-          {isDeleting ? "삭제 중..." : "삭제"}
+        <ActionButton type="button" onClick={handleDelete} disabled={deleteAbsenceMutation.isPending}>
+          {deleteAbsenceMutation.isPending ? "삭제 중..." : "삭제"}
         </ActionButton>
         <ActionButton type="button">수정</ActionButton>
         <LinkButton href="/staff/class/absence">목록</LinkButton>

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -29,7 +30,7 @@ export default function AbsencePostPage() {
   });
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["absence-request", postId],
+    queryKey: queryKeys.requests.absenceDetail(postId),
     queryFn: () => getAbsenceRequestDetail({ requestId: postId }),
     enabled: isAuthenticated && isValidPostId,
     retry: false,

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -6,12 +6,15 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 export default function AbsencePostPage() {
   const params = useParams<{ postId: string }>();
   const router = useRouter();
+  const { status: authStatus } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
   const postId = Number(params.postId);
   const isValidPostId = Number.isInteger(postId) && postId > 0;
   const deleteAbsenceMutation = useMutation({
@@ -28,7 +31,7 @@ export default function AbsencePostPage() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["absence-request", postId],
     queryFn: () => getAbsenceRequestDetail({ requestId: postId }),
-    enabled: isValidPostId,
+    enabled: isAuthenticated && isValidPostId,
     retry: false,
   });
 

--- a/app/staff/class/absence/[postId]/page.tsx
+++ b/app/staff/class/absence/[postId]/page.tsx
@@ -1,40 +1,88 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
+import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+function formatStatus(status?: string) {
+  if (status === "APPROVED") return "승인 완료";
+  if (status === "REJECTED") return "반려";
+  return "대기 중";
+}
 
 export default function AbsencePostPage() {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const params = useParams<{ postId: string }>();
+  const router = useRouter();
+  const postId = Number(params.postId);
+  const isValidPostId = Number.isInteger(postId) && postId > 0;
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["absence-request", postId],
+    queryFn: () => getAbsenceRequestDetail({ requestId: postId }),
+    enabled: isValidPostId,
+    retry: false,
+  });
+
+  const detailCreatedDate = formatUtcToKstShortDate(data?.createdAt);
+  const detailLessonDate = formatUtcToKstShortDate(data?.lessonDate);
+  const detailWriter = data?.requestedByName ?? "-";
+  const detailReason = isError ? "결강 신청 사유를 불러오지 못했습니다." : data?.reason ?? "결강 신청 사유";
+  const detailStatus = isError ? "확인 불가" : formatStatus(data?.status);
+  const detailTitle = isLoading ? "불러오는 중..." : "-";
+
+  const handleDelete = async () => {
+    if (!isValidPostId || isDeleting) return;
+    if (!window.confirm("결강 신청서를 삭제하시겠습니까?")) return;
+
+    try {
+      setIsDeleting(true);
+      await deleteAbsenceRequest({ requestId: postId });
+      router.push("/staff/class/absence");
+      router.refresh();
+    } catch {
+      window.alert("결강 신청서 삭제에 실패했습니다.");
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <PageWrapper>
       <TopButtonRow>
-        <ActionButton type="button">삭제</ActionButton>
+        <ActionButton type="button" onClick={handleDelete} disabled={isDeleting}>
+          {isDeleting ? "삭제 중..." : "삭제"}
+        </ActionButton>
         <ActionButton type="button">수정</ActionButton>
         <LinkButton href="/staff/class/absence">목록</LinkButton>
       </TopButtonRow>
 
       <ContentColumn>
-        <DateBar>00.00.00</DateBar>
+        <DateBar>{detailCreatedDate}</DateBar>
 
         <PostSection>
           <Label>제목</Label>
-          <ValueBox>제목</ValueBox>
+          <ValueBox>{detailTitle}</ValueBox>
 
           <Label>신청자 정보</Label>
           <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
-            <FieldValue>개나리반</FieldValue>
+            <FieldValue>-</FieldValue>
             <FieldLabel>수업 일자</FieldLabel>
-            <FieldValue>00.00.00</FieldValue>
+            <FieldValue>{detailLessonDate}</FieldValue>
             <FieldLabel>작성자</FieldLabel>
-            <FieldValue>홍길동</FieldValue>
+            <FieldValue>{detailWriter}</FieldValue>
           </InfoRow>
 
           <Label>결강 신청 사유</Label>
-          <TextBox>결강 신청 사유</TextBox>
+          <TextBox>{detailReason}</TextBox>
 
           <Label>신청 현황</Label>
-          <StatusBox>대기 중</StatusBox>
+          <StatusBox>{detailStatus}</StatusBox>
         </PostSection>
       </ContentColumn>
     </PageWrapper>

--- a/app/staff/class/absence/new/page.tsx
+++ b/app/staff/class/absence/new/page.tsx
@@ -1,19 +1,51 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import styled from "styled-components";
+import { createAbsenceRequest } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const formData = new FormData(event.currentTarget);
+    const reason = String(formData.get("reason") ?? "").trim();
+    const lessonId = Number(searchParams.get("lessonId") ?? "1");
+
+    if (!reason || !Number.isInteger(lessonId) || lessonId < 1) {
+      window.alert("필수 입력값을 확인해주세요.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await createAbsenceRequest({ lessonId, reason });
+      router.push("/staff/class/absence");
+      router.refresh();
+    } catch {
+      window.alert("결강 신청서 생성에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <PageWrapper>
       <HeaderRow>
         <Title>결강 신청서 작성하기</Title>
-        <SubmitButton type="submit" form="absence-form">
-          작성 완료
+        <SubmitButton type="submit" form="absence-form" disabled={isSubmitting}>
+          {isSubmitting ? "작성 중..." : "작성 완료"}
         </SubmitButton>
       </HeaderRow>
 
-      <Form id="absence-form">
+      <Form id="absence-form" onSubmit={handleSubmit}>
         <Section>
           <Label htmlFor="title">제목</Label>
           <Input id="title" name="title" placeholder="제목" />

--- a/app/staff/class/absence/new/page.tsx
+++ b/app/staff/class/absence/new/page.tsx
@@ -1,19 +1,28 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createAbsenceRequest } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const createAbsenceMutation = useMutation({
+    mutationFn: createAbsenceRequest,
+    onSuccess: () => {
+      router.push("/staff/class/absence");
+      router.refresh();
+    },
+    onError: () => {
+      window.alert("결강 신청서 생성에 실패했습니다.");
+    },
+  });
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isSubmitting) return;
+    if (createAbsenceMutation.isPending) return;
 
     const formData = new FormData(event.currentTarget);
     const reason = String(formData.get("reason") ?? "").trim();
@@ -24,24 +33,15 @@ export default function Page() {
       return;
     }
 
-    try {
-      setIsSubmitting(true);
-      await createAbsenceRequest({ lessonId, reason });
-      router.push("/staff/class/absence");
-      router.refresh();
-    } catch {
-      window.alert("결강 신청서 생성에 실패했습니다.");
-    } finally {
-      setIsSubmitting(false);
-    }
+    createAbsenceMutation.mutate({ lessonId, reason });
   };
 
   return (
     <PageWrapper>
       <HeaderRow>
         <Title>결강 신청서 작성하기</Title>
-        <SubmitButton type="submit" form="absence-form" disabled={isSubmitting}>
-          {isSubmitting ? "작성 중..." : "작성 완료"}
+        <SubmitButton type="submit" form="absence-form" disabled={createAbsenceMutation.isPending}>
+          {createAbsenceMutation.isPending ? "작성 중..." : "작성 완료"}
         </SubmitButton>
       </HeaderRow>
 

--- a/app/staff/class/absence/new/page.tsx
+++ b/app/staff/class/absence/new/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createAbsenceRequest } from "@/api/request/request.api";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
   const router = useRouter();
@@ -48,7 +48,7 @@ export default function Page() {
       <Form id="absence-form" onSubmit={handleSubmit}>
         <Section>
           <Label htmlFor="title">제목</Label>
-          <Input id="title" name="title" placeholder="제목" />
+          <TitleInput id="title" name="title" placeholder="제목" />
         </Section>
 
         <Section>
@@ -119,12 +119,12 @@ const SubmitButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 4.75rem;
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  background: #e4e4e4;
-  color: #000000;
+  border-radius: ${radii.radius12};
+  background-color: ${colors.point};
+  color: ${colors.white};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -132,11 +132,15 @@ const SubmitButton = styled.button`
   cursor: pointer;
 
   &:hover {
-    background: #d9d9d9;
+    filter: brightness(0.95);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   @media (min-width: 120rem) {
-    min-width: 6.75rem;
     min-height: 4rem;
     padding: ${spacing.space20} 1.875rem;
     font-size: ${typography.fontSize20};
@@ -175,15 +179,15 @@ const Label = styled.label`
   }
 `;
 
-const Input = styled.input`
-  width: 100%;
+const InlineInput = styled.input`
+  min-width: 0;
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background: ${colors.point};
-  color: #b1b1b1;
+  background: ${colors.background};
+  color: #000000;
   font-size: ${typography.fontSize14};
-  font-weight: 500;
+  font-weight: 400;
   line-height: ${typography.lineHeight130};
   outline: none;
 
@@ -196,6 +200,10 @@ const Input = styled.input`
     padding: ${spacing.space20};
     font-size: ${typography.fontSize20};
   }
+`;
+
+const TitleInput = styled(InlineInput)`
+  width: 100%;
 `;
 
 const InfoRow = styled.div`
@@ -225,36 +233,13 @@ const FieldLabel = styled.label`
   }
 `;
 
-const InlineInput = styled.input`
-  min-width: 0;
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space12};
-  border: 0;
-  background: ${colors.point};
-  color: #b1b1b1;
-  font-size: ${typography.fontSize14};
-  font-weight: 400;
-  line-height: ${typography.lineHeight130};
-  outline: none;
-
-  &::placeholder {
-    color: #b1b1b1;
-  }
-
-  @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20};
-    font-size: ${typography.fontSize20};
-  }
-`;
-
 const TextArea = styled.textarea`
   width: 100%;
   min-height: 6.875rem;
   padding: 0.75rem ${spacing.space12};
   border: 0;
-  background: ${colors.point};
-  color: #b1b1b1;
+  background: ${colors.background};
+  color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};

--- a/app/staff/class/absence/new/page.tsx
+++ b/app/staff/class/absence/new/page.tsx
@@ -180,8 +180,8 @@ const Input = styled.input`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background: #d9d9d9;
-  color: #000000;
+  background: ${colors.point};
+  color: #b1b1b1;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -230,8 +230,8 @@ const InlineInput = styled.input`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background: #d9d9d9;
-  color: #000000;
+  background: ${colors.point};
+  color: #b1b1b1;
   font-size: ${typography.fontSize14};
   font-weight: 400;
   line-height: ${typography.lineHeight130};
@@ -253,8 +253,8 @@ const TextArea = styled.textarea`
   min-height: 6.875rem;
   padding: 0.75rem ${spacing.space12};
   border: 0;
-  background: #d9d9d9;
-  color: #000000;
+  background: ${colors.point};
+  color: #b1b1b1;
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};

--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -8,6 +8,7 @@ import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -22,7 +23,7 @@ export default function Page() {
   const parsedPage = rawPage ? Number(rawPage) : 1;
 
   const { data: absenceRequests = [], isLoading, isError } = useQuery({
-    queryKey: ["absence-requests"],
+    queryKey: queryKeys.requests.absenceList(),
     queryFn: () => getAbsenceRequests(),
     enabled: isAuthenticated,
     retry: false,

--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -4,10 +4,10 @@ import { useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { getAbsenceRequests } from "@/api/request/request.api";
-import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -15,6 +15,8 @@ const ITEMS_PER_PAGE = 9;
 
 export default function Page() {
   const searchParams = useSearchParams();
+  const { status: authStatus, user } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
   const rawPage = searchParams.get("page");
   const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
@@ -22,16 +24,10 @@ export default function Page() {
   const { data: absenceRequests = [], isLoading, isError } = useQuery({
     queryKey: ["absence-requests"],
     queryFn: () => getAbsenceRequests(),
+    enabled: isAuthenticated,
     retry: false,
   });
-
-  const { data: currentUser } = useQuery({
-    queryKey: ["users", "me"],
-    queryFn: getCurrentUser,
-    retry: false,
-  });
-
-  const currentUserName = currentUser?.name?.trim();
+  const currentUserName = user?.name?.trim();
   const filteredRequests = useMemo(
     () =>
       mineOnly
@@ -61,7 +57,11 @@ export default function Page() {
       detailHref: `/staff/class/absence/${item.id ?? ""}`,
     }));
 
-  const emptyMessage = isLoading
+  const emptyMessage = authStatus === "loading"
+    ? "사용자 정보를 확인하는 중입니다."
+    : !isAuthenticated
+      ? "로그인이 필요합니다."
+      : isLoading
     ? "결강 신청 내역을 불러오는 중입니다."
     : isError
       ? "결강 신청 내역을 불러오지 못했습니다."

--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -1,61 +1,75 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getAbsenceRequests } from "@/api/request/request.api";
+import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
-const CURRENT_AUTHOR = "김민지";
-
-const absenceRequests = Array.from({ length: 23 }, (_, index) => ({
-  id: index + 1,
-  className: `${["개나리", "해바라기", "민들레"][index % 3]}반`,
-  title: `${index + 1}회차 수업 결강 신청합니다`,
-  author: index % 2 === 0 ? CURRENT_AUTHOR : "박서준",
-  date: `26.04.${String((index % 28) + 1).padStart(2, "0")}`,
-  status: index % 3 === 0 ? "승인 완료" : "대기 중",
-}));
-
-type PageProps = {
-  searchParams?: Promise<{
-    page?: string;
-    mineOnly?: string;
-  }>;
-};
-
-function mapRows(items: typeof absenceRequests, page: number): ListPanelRow[] {
-  return items.map((item, index) => ({
-    id: item.id,
-    no: String((page - 1) * ITEMS_PER_PAGE + index + 1).padStart(2, "0"),
-    className: item.className,
-    title: item.title,
-    author: item.author,
-    date: item.date,
-    status: item.status,
-    detailHref: `/staff/class/absence/${item.id}`,
-  }));
+function formatStatus(status?: string) {
+  if (status === "APPROVED") return "승인 완료";
+  if (status === "REJECTED") return "반려";
+  return "대기 중";
 }
 
-export default async function Page({ searchParams }: PageProps) {
-  const resolvedSearchParams = await searchParams;
-  const rawPage = resolvedSearchParams?.page;
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+export default function Page() {
+  const searchParams = useSearchParams();
+  const rawPage = searchParams.get("page");
+  const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
-  const filteredRequests = mineOnly
-    ? absenceRequests.filter((request) => request.author === CURRENT_AUTHOR)
-    : absenceRequests;
-  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
-  const isInvalidPage =
-    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
-  if (isInvalidPage) {
-    redirect(mineOnly ? "/staff/class/absence?mineOnly=1" : "/staff/class/absence");
-  }
+  const { data: absenceRequests = [], isLoading, isError } = useQuery({
+    queryKey: ["absence-requests"],
+    queryFn: () => getAbsenceRequests(),
+    retry: false,
+  });
 
-  const startIndex = (parsedPage - 1) * ITEMS_PER_PAGE;
-  const rows = mapRows(
-    filteredRequests.slice(startIndex, startIndex + ITEMS_PER_PAGE),
-    parsedPage,
+  const { data: currentUser } = useQuery({
+    queryKey: ["users", "me"],
+    queryFn: getCurrentUser,
+    retry: false,
+  });
+
+  const currentUserName = currentUser?.name?.trim();
+  const filteredRequests = useMemo(
+    () =>
+      mineOnly
+        ? absenceRequests.filter((request) => {
+            const requestedByName = request.requestedByName?.trim();
+            return Boolean(currentUserName) && requestedByName === currentUserName;
+          })
+        : absenceRequests,
+    [absenceRequests, currentUserName, mineOnly],
   );
+
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
+  const currentPage =
+    Number.isInteger(parsedPage) && parsedPage >= 1 && parsedPage <= totalPages ? parsedPage : 1;
+
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const rows: ListPanelRow[] = filteredRequests
+    .slice(startIndex, startIndex + ITEMS_PER_PAGE)
+    .map((item, index) => ({
+      id: item.id ?? startIndex + index + 1,
+      no: String(startIndex + index + 1).padStart(2, "0"),
+      className: "-",
+      title: "-",
+      author: item.requestedByName ?? "-",
+      date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
+      status: formatStatus(item.status),
+      detailHref: `/staff/class/absence/${item.id ?? ""}`,
+    }));
+
+  const emptyMessage = isLoading
+    ? "결강 신청 내역을 불러오는 중입니다."
+    : isError
+      ? "결강 신청 내역을 불러오지 못했습니다."
+      : "결강 신청 내역이 없습니다.";
 
   return (
     <ListPanel
@@ -64,10 +78,10 @@ export default async function Page({ searchParams }: PageProps) {
       writeHref="/staff/class/absence/new"
       listPath="/staff/class/absence"
       rows={rows}
-      currentPage={parsedPage}
+      currentPage={currentPage}
       totalPages={totalPages}
       mineOnly={mineOnly}
-      emptyMessage="결강 신청 내역이 없습니다."
+      emptyMessage={emptyMessage}
       headerTone="journal"
     />
   );

--- a/app/staff/class/absence/page.tsx
+++ b/app/staff/class/absence/page.tsx
@@ -8,14 +8,10 @@ import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
-function formatStatus(status?: string) {
-  if (status === "APPROVED") return "승인 완료";
-  if (status === "REJECTED") return "반려";
-  return "대기 중";
-}
 
 export default function Page() {
   const searchParams = useSearchParams();
@@ -61,7 +57,7 @@ export default function Page() {
       title: "-",
       author: item.requestedByName ?? "-",
       date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
-      status: formatStatus(item.status),
+      status: formatRequestStatus(item.status),
       detailHref: `/staff/class/absence/${item.id ?? ""}`,
     }));
 

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { getLessonExchangeRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -30,13 +31,15 @@ const proposals = [
 
 export default function ExchangePostPage() {
   const params = useParams<{ postId: string }>();
+  const { status: authStatus } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
   const postId = Number(params.postId);
   const isValidPostId = Number.isInteger(postId) && postId > 0;
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["lesson-exchange-request", postId],
     queryFn: () => getLessonExchangeRequestDetail({ requestId: postId }),
-    enabled: isValidPostId,
+    enabled: isAuthenticated && isValidPostId,
     retry: false,
   });
 

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -1,12 +1,12 @@
-import Link from "next/link";
-import styled from "styled-components";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+"use client";
 
-type PageProps = {
-  params: Promise<{
-    postId: string;
-  }>;
-};
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getLessonExchangeRequestDetail } from "@/api/request/request.api";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const proposals = [
   {
@@ -27,8 +27,35 @@ const proposals = [
   },
 ];
 
-export default async function ExchangePostPage({ params }: PageProps) {
-  const { postId } = await params;
+function formatStatus(status?: string) {
+  if (status === "APPROVED") return "승인 완료";
+  if (status === "REJECTED") return "반려";
+  return "대기 중";
+}
+
+export default function ExchangePostPage() {
+  const params = useParams<{ postId: string }>();
+  const postId = Number(params.postId);
+  const isValidPostId = Number.isInteger(postId) && postId > 0;
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["lesson-exchange-request", postId],
+    queryFn: () => getLessonExchangeRequestDetail({ requestId: postId }),
+    enabled: isValidPostId,
+    retry: false,
+  });
+
+  const detailTitle = isLoading
+    ? "불러오는 중..."
+    : isError
+      ? "수업 교환 신청을 불러오지 못했습니다."
+      : data?.title ?? "제목";
+  const detailWriter = data?.requestedByName ?? "홍길동";
+  const detailLessonDate = formatUtcToKstShortDate(data?.lessonDate);
+  const detailContent = isError ? "교환 신청 사유를 불러오지 못했습니다." : data?.content ?? "교환 신청 사유";
+  const detailStatus = isError ? "확인 불가" : formatStatus(data?.status);
+  const detailCreatedDate = formatUtcToKstShortDate(data?.createdAt);
+
   const acceptedHref = `/staff/class/exchange/${postId}/accepted`;
 
   return (
@@ -40,30 +67,30 @@ export default async function ExchangePostPage({ params }: PageProps) {
       </TopButtonRow>
 
       <ContentColumn>
-        <DateBar>00.00.00</DateBar>
+        <DateBar>{detailCreatedDate}</DateBar>
 
         <PostSection>
           <Label>제목</Label>
-          <ValueBox $weight="semibold">제목</ValueBox>
+          <ValueBox $weight="semibold">{detailTitle}</ValueBox>
 
           <Label>신청자 정보</Label>
           <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
             <FieldValue>개나리반</FieldValue>
             <FieldLabel>수업 일자</FieldLabel>
-            <FieldValue>00.00.00</FieldValue>
+            <FieldValue>{detailLessonDate}</FieldValue>
             <FieldLabel>작성자</FieldLabel>
-            <FieldValue>홍길동</FieldValue>
+            <FieldValue>{detailWriter}</FieldValue>
           </InfoRow>
 
           <Label>교환 신청 사유</Label>
-          <TextBox>교환 신청 사유</TextBox>
+          <TextBox>{detailContent}</TextBox>
 
           <Label>만료일</Label>
           <DateBox>00.00.00</DateBox>
 
           <Label>신청 현황</Label>
-          <StatusBox>대기 중</StatusBox>
+          <StatusBox>{detailStatus}</StatusBox>
         </PostSection>
 
         <Divider />

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { getLessonExchangeRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const proposals = [
@@ -27,12 +28,6 @@ const proposals = [
   },
 ];
 
-function formatStatus(status?: string) {
-  if (status === "APPROVED") return "승인 완료";
-  if (status === "REJECTED") return "반려";
-  return "대기 중";
-}
-
 export default function ExchangePostPage() {
   const params = useParams<{ postId: string }>();
   const postId = Number(params.postId);
@@ -53,7 +48,7 @@ export default function ExchangePostPage() {
   const detailWriter = data?.requestedByName ?? "홍길동";
   const detailLessonDate = formatUtcToKstShortDate(data?.lessonDate);
   const detailContent = isError ? "교환 신청 사유를 불러오지 못했습니다." : data?.content ?? "교환 신청 사유";
-  const detailStatus = isError ? "확인 불가" : formatStatus(data?.status);
+  const detailStatus = isError ? "확인 불가" : formatRequestStatus(data?.status);
   const detailCreatedDate = formatUtcToKstShortDate(data?.createdAt);
 
   const acceptedHref = `/staff/class/exchange/${postId}/accepted`;

--- a/app/staff/class/exchange/[postId]/page.tsx
+++ b/app/staff/class/exchange/[postId]/page.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { getLessonExchangeRequestDetail } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -37,7 +38,7 @@ export default function ExchangePostPage() {
   const isValidPostId = Number.isInteger(postId) && postId > 0;
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["lesson-exchange-request", postId],
+    queryKey: queryKeys.requests.lessonExchangeDetail(postId),
     queryFn: () => getLessonExchangeRequestDetail({ requestId: postId }),
     enabled: isAuthenticated && isValidPostId,
     retry: false,

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
 import styled from "styled-components";
+import { createLessonExchangeRequest } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
   const [expireDateText, setExpireDateText] = useState("00.00.00");
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const dateInputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   const handleOpenDatePicker = () => {
     const dateInput = dateInputRef.current;
@@ -29,16 +34,46 @@ export default function Page() {
     setExpireDateText(`00.${month}.${day}`);
   };
 
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const formData = new FormData(event.currentTarget);
+    const title = String(formData.get("title") ?? "").trim();
+    const content = String(formData.get("reason") ?? "").trim();
+    const lessonId = Number(searchParams.get("lessonId") ?? "1");
+
+    if (!title || !content || !Number.isInteger(lessonId) || lessonId < 1) {
+      window.alert("필수 입력값을 확인해주세요.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await createLessonExchangeRequest({
+        lessonId,
+        title,
+        content,
+      });
+      router.push("/staff/class/exchange");
+      router.refresh();
+    } catch {
+      window.alert("수업 교환 신청서 생성에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <PageWrapper>
       <HeaderRow>
         <Title>교환 신청서 작성하기</Title>
-        <SubmitButton type="submit" form="exchange-form">
-          작성 완료
+        <SubmitButton type="submit" form="exchange-form" disabled={isSubmitting}>
+          {isSubmitting ? "작성 중..." : "작성 완료"}
         </SubmitButton>
       </HeaderRow>
 
-      <Form id="exchange-form">
+      <Form id="exchange-form" onSubmit={handleSubmit}>
         <Section>
           <Label htmlFor="title">제목</Label>
           <Input id="title" name="title" defaultValue="제목" />

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
+import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
@@ -24,10 +25,19 @@ function getKstTodayShortDate() {
 export default function Page() {
   const kstToday = getKstTodayShortDate();
   const [expireDateText, setExpireDateText] = useState(kstToday);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const dateInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const createLessonExchangeMutation = useMutation({
+    mutationFn: createLessonExchangeRequest,
+    onSuccess: () => {
+      router.push("/staff/class/exchange");
+      router.refresh();
+    },
+    onError: () => {
+      window.alert("수업 교환 신청서 생성에 실패했습니다.");
+    },
+  });
 
   const handleOpenDatePicker = () => {
     const dateInput = dateInputRef.current;
@@ -51,7 +61,7 @@ export default function Page() {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isSubmitting) return;
+    if (createLessonExchangeMutation.isPending) return;
 
     const formData = new FormData(event.currentTarget);
     const title = String(formData.get("title") ?? "").trim();
@@ -63,28 +73,19 @@ export default function Page() {
       return;
     }
 
-    try {
-      setIsSubmitting(true);
-      await createLessonExchangeRequest({
-        lessonId,
-        title,
-        content,
-      });
-      router.push("/staff/class/exchange");
-      router.refresh();
-    } catch {
-      window.alert("수업 교환 신청서 생성에 실패했습니다.");
-    } finally {
-      setIsSubmitting(false);
-    }
+    createLessonExchangeMutation.mutate({
+      lessonId,
+      title,
+      content,
+    });
   };
 
   return (
     <PageWrapper>
       <HeaderRow>
         <Title>교환 신청서 작성하기</Title>
-        <SubmitButton type="submit" form="exchange-form" disabled={isSubmitting}>
-          {isSubmitting ? "작성 중..." : "작성 완료"}
+        <SubmitButton type="submit" form="exchange-form" disabled={createLessonExchangeMutation.isPending}>
+          {createLessonExchangeMutation.isPending ? "작성 중..." : "작성 완료"}
         </SubmitButton>
       </HeaderRow>
 

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
-import { createLessonExchangeRequest } from "@/api/request/request.api";
+import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 function getKstTodayShortDate() {
@@ -22,12 +22,26 @@ function getKstTodayShortDate() {
   return `${year}.${month}.${day}`;
 }
 
+function shortDateToIsoDate(text: string): string | null {
+  const m = /^(\d{2})\.(\d{2})\.(\d{2})$/.exec(text.trim());
+  if (!m) return null;
+  const yy = Number(m[1]);
+  const [, , mm, dd] = m;
+  const fullYear = 2000 + yy;
+  return `${fullYear}-${mm}-${dd}`;
+}
+
+function shortDateToExpiresAt(text: string): string | null {
+  const datePart = shortDateToIsoDate(text);
+  if (!datePart) return null;
+  return `${datePart}T22:00:00`;
+}
+
 export default function Page() {
   const kstToday = getKstTodayShortDate();
   const [expireDateText, setExpireDateText] = useState(kstToday);
   const dateInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
-  const searchParams = useSearchParams();
   const createLessonExchangeMutation = useMutation({
     mutationFn: createLessonExchangeRequest,
     onSuccess: () => {
@@ -66,17 +80,39 @@ export default function Page() {
     const formData = new FormData(event.currentTarget);
     const title = String(formData.get("title") ?? "").trim();
     const content = String(formData.get("reason") ?? "").trim();
-    const lessonId = Number(searchParams.get("lessonId") ?? "1");
+    const lessonDateRaw = String(formData.get("lessonDate") ?? "").trim();
+    const periodFromRaw = String(formData.get("lessonPeriodFrom") ?? "").trim();
+    const periodToRaw = String(formData.get("lessonPeriodTo") ?? "").trim();
 
-    if (!title || !content || !Number.isInteger(lessonId) || lessonId < 1) {
+    const lessonDate = shortDateToIsoDate(lessonDateRaw);
+    const expiresAt = shortDateToExpiresAt(expireDateText.trim());
+    const startPeriod = Number.parseInt(periodFromRaw, 10);
+    const endPeriod = Number.parseInt(periodToRaw, 10);
+
+    if (!title || !content) {
       window.alert("필수 입력값을 확인해주세요.");
+      return;
+    }
+    if (!lessonDate) {
+      window.alert("수업 일자를 YY.MM.DD 형식으로 입력해 주세요.");
+      return;
+    }
+    if (!expiresAt) {
+      window.alert("만료일을 달력에서 선택해 주세요.");
+      return;
+    }
+    if (!Number.isFinite(startPeriod) || !Number.isFinite(endPeriod) || startPeriod < 1 || endPeriod < 1) {
+      window.alert("수업 교시를 올바른 숫자로 입력해 주세요.");
       return;
     }
 
     createLessonExchangeMutation.mutate({
-      lessonId,
+      lessonDate,
       title,
       content,
+      startPeriod,
+      endPeriod,
+      expiresAt,
     });
   };
 

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -7,8 +7,23 @@ import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/request/request.api";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
+function getKstTodayShortDate() {
+  const formatter = new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(new Date());
+  const year = parts.find((part) => part.type === "year")?.value ?? "00";
+  const month = parts.find((part) => part.type === "month")?.value ?? "00";
+  const day = parts.find((part) => part.type === "day")?.value ?? "00";
+  return `${year}.${month}.${day}`;
+}
+
 export default function Page() {
-  const [expireDateText, setExpireDateText] = useState("00.00.00");
+  const kstToday = getKstTodayShortDate();
+  const [expireDateText, setExpireDateText] = useState(kstToday);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const dateInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
@@ -30,8 +45,8 @@ export default function Page() {
     const value = event.target.value;
     if (!value) return;
 
-    const [, month, day] = value.split("-");
-    setExpireDateText(`00.${month}.${day}`);
+    const [year, month, day] = value.split("-");
+    setExpireDateText(`${year.slice(-2)}.${month}.${day}`);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -85,9 +100,9 @@ export default function Page() {
             <FieldLabel htmlFor="className">반 이름</FieldLabel>
             <InlineInput id="className" name="className" defaultValue="개나리반" />
             <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-            <InlineInput id="lessonDate" name="lessonDate" defaultValue="00.00.00" />
+            <InlineInput id="lessonDate" name="lessonDate" defaultValue={kstToday} disabled />
             <FieldLabel htmlFor="writer">작성자</FieldLabel>
-            <InlineInput id="writer" name="writer" defaultValue="홍길동" />
+            <InlineInput id="writer" name="writer" defaultValue="홍길동" disabled />
           </InfoRow>
         </Section>
 
@@ -283,6 +298,12 @@ const InlineInput = styled.input`
   font-weight: 400;
   line-height: ${typography.lineHeight130};
   outline: none;
+
+  &:disabled {
+    background: #b5b5b5;
+    color: #4f4f4f;
+    cursor: not-allowed;
+  }
 
   @media (min-width: 120rem) {
     min-height: 4rem;

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -6,7 +6,7 @@ import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/request/request.api";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 function getKstTodayShortDate() {
   const formatter = new Intl.DateTimeFormat("ko-KR", {
@@ -97,14 +97,28 @@ export default function Page() {
 
         <Section>
           <Label as="h2">신청자 정보</Label>
-          <InfoRow>
-            <FieldLabel htmlFor="className">반 이름</FieldLabel>
-            <InlineInput id="className" name="className" defaultValue="개나리반" />
-            <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-            <InlineInput id="lessonDate" name="lessonDate" defaultValue={kstToday} disabled />
-            <FieldLabel htmlFor="writer">작성자</FieldLabel>
-            <InlineInput id="writer" name="writer" defaultValue="홍길동" disabled />
-          </InfoRow>
+          <InfoStack>
+            <InfoPairRow $wideFirst>
+              <FieldLabel htmlFor="className">반 이름</FieldLabel>
+              <InlineInput id="className" name="className" defaultValue="개나리반" />
+              <FieldLabel htmlFor="writer">작성자</FieldLabel>
+              <InlineInput id="writer" name="writer" defaultValue="홍길동" disabled />
+            </InfoPairRow>
+            <InfoPairRow>
+              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
+              <InlineInput id="lessonDate" name="lessonDate" defaultValue={kstToday} />
+              <FieldLabel id="lessonPeriod-label">수업 교시</FieldLabel>
+              <LessonPeriodInputs role="group" aria-labelledby="lessonPeriod-label">
+                <LessonPeriodInput
+                  name="lessonPeriodFrom"
+                  defaultValue="1"
+                  aria-label="수업 교시 시작"
+                />
+                <PeriodTilde aria-hidden>~</PeriodTilde>
+                <LessonPeriodInput name="lessonPeriodTo" defaultValue="2" aria-label="수업 교시 끝" />
+              </LessonPeriodInputs>
+            </InfoPairRow>
+          </InfoStack>
         </Section>
 
         <Section>
@@ -130,7 +144,7 @@ export default function Page() {
               tabIndex={-1}
             />
             <CalendarButton type="button" aria-label="달력 열기" onClick={handleOpenDatePicker}>
-              <IconCalendarMonth size={16} stroke={2} />
+              <IconCalendarMonth size={16} stroke={2} color={colors.white} />
             </CalendarButton>
           </DateRow>
         </Section>
@@ -190,8 +204,9 @@ const SubmitButton = styled.button`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  background: #e4e4e4;
-  color: #000000;
+  border-radius: ${radii.radius12};
+  background-color: ${colors.point};
+  color: ${colors.white};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -199,7 +214,12 @@ const SubmitButton = styled.button`
   cursor: pointer;
 
   &:hover {
-    background: #d9d9d9;
+    filter: brightness(0.95);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   @media (min-width: 120rem) {
@@ -247,7 +267,7 @@ const Input = styled.input`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background: #e2e2e2;
+  background: ${colors.background};
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 600;
@@ -261,9 +281,20 @@ const Input = styled.input`
   }
 `;
 
-const InfoRow = styled.div`
+const InfoStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const InfoPairRow = styled.div<{ $wideFirst?: boolean }>`
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: ${({ $wideFirst }) =>
+    $wideFirst ? `auto minmax(0, 2.25fr) auto minmax(0, 1fr)` : `auto minmax(0, 1fr) auto minmax(0, 1fr)`};
   align-items: center;
   gap: ${spacing.space12};
 
@@ -273,6 +304,29 @@ const InfoRow = styled.div`
 
   @media (max-width: ${layout.breakpointMobile}) {
     grid-template-columns: 1fr;
+  }
+`;
+
+const LessonPeriodInputs = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  min-width: 0;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12};
+  }
+`;
+
+const PeriodTilde = styled.span`
+  flex-shrink: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
   }
 `;
 
@@ -293,7 +347,7 @@ const InlineInput = styled.input`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background: #e2e2e2;
+  background: ${colors.background};
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 400;
@@ -313,12 +367,18 @@ const InlineInput = styled.input`
   }
 `;
 
+const LessonPeriodInput = styled(InlineInput)`
+  flex: 1 1 0;
+  min-width: 2.5rem;
+  text-align: center;
+`;
+
 const TextArea = styled.textarea`
   width: 100%;
   min-height: 6.875rem;
   padding: 0.75rem ${spacing.space12};
   border: 0;
-  background: #e2e2e2;
+  background: ${colors.background};
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
@@ -340,7 +400,7 @@ const DateRow = styled.div`
   width: 7.75rem;
   min-height: 2.6875rem;
   padding: 0.4375rem ${spacing.space12};
-  background: #e2e2e2;
+  background: ${colors.background};
 
   @media (min-width: 120rem) {
     width: 11.625rem;
@@ -381,8 +441,8 @@ const CalendarButton = styled.button`
   height: 1.5rem;
   border: 0;
   border-radius: 50%;
-  background: #a8a8a8;
-  color: #000000;
+  background: ${colors.point};
+  color: ${colors.white};
   cursor: pointer;
 
   @media (min-width: 120rem) {

--- a/app/staff/class/exchange/new/page.tsx
+++ b/app/staff/class/exchange/new/page.tsx
@@ -6,36 +6,12 @@ import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
+import {
+  getKstTodayShortDate,
+  koreanShortDateToLocalDateTime,
+  parseKoreanShortDateToIsoDate,
+} from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
-
-function getKstTodayShortDate() {
-  const formatter = new Intl.DateTimeFormat("ko-KR", {
-    timeZone: "Asia/Seoul",
-    year: "2-digit",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  const parts = formatter.formatToParts(new Date());
-  const year = parts.find((part) => part.type === "year")?.value ?? "00";
-  const month = parts.find((part) => part.type === "month")?.value ?? "00";
-  const day = parts.find((part) => part.type === "day")?.value ?? "00";
-  return `${year}.${month}.${day}`;
-}
-
-function shortDateToIsoDate(text: string): string | null {
-  const m = /^(\d{2})\.(\d{2})\.(\d{2})$/.exec(text.trim());
-  if (!m) return null;
-  const yy = Number(m[1]);
-  const [, , mm, dd] = m;
-  const fullYear = 2000 + yy;
-  return `${fullYear}-${mm}-${dd}`;
-}
-
-function shortDateToExpiresAt(text: string): string | null {
-  const datePart = shortDateToIsoDate(text);
-  if (!datePart) return null;
-  return `${datePart}T22:00:00`;
-}
 
 export default function Page() {
   const kstToday = getKstTodayShortDate();
@@ -84,8 +60,8 @@ export default function Page() {
     const periodFromRaw = String(formData.get("lessonPeriodFrom") ?? "").trim();
     const periodToRaw = String(formData.get("lessonPeriodTo") ?? "").trim();
 
-    const lessonDate = shortDateToIsoDate(lessonDateRaw);
-    const expiresAt = shortDateToExpiresAt(expireDateText.trim());
+    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateRaw);
+    const expiresAt = koreanShortDateToLocalDateTime(expireDateText.trim());
     const startPeriod = Number.parseInt(periodFromRaw, 10);
     const endPeriod = Number.parseInt(periodToRaw, 10);
 

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -1,61 +1,66 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getLessonExchangeRequests } from "@/api/request/request.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
 const CURRENT_AUTHOR = "김민지";
 
-const exchangeRequests = Array.from({ length: 27 }, (_, index) => ({
-  id: index + 1,
-  className: `${["개나리", "해바라기", "민들레"][index % 3]}반`,
-  title: `${index + 1}회차 수업 교환 신청합니다`,
-  author: index % 2 === 0 ? CURRENT_AUTHOR : "최유진",
-  date: `26.04.${String((index % 28) + 1).padStart(2, "0")}`,
-  status: index % 4 === 0 ? "승인 완료" : "대기 중",
-}));
-
-type PageProps = {
-  searchParams?: Promise<{
-    page?: string;
-    mineOnly?: string;
-  }>;
-};
-
-function mapRows(items: typeof exchangeRequests, page: number): ListPanelRow[] {
-  return items.map((item, index) => ({
-    id: item.id,
-    no: String((page - 1) * ITEMS_PER_PAGE + index + 1).padStart(2, "0"),
-    className: item.className,
-    title: item.title,
-    author: item.author,
-    date: item.date,
-    status: item.status,
-    detailHref: `/staff/class/exchange/${item.id}`,
-  }));
+function formatStatus(status?: string) {
+  if (status === "APPROVED") return "승인 완료";
+  if (status === "REJECTED") return "반려";
+  return "대기 중";
 }
 
-export default async function Page({ searchParams }: PageProps) {
-  const resolvedSearchParams = await searchParams;
-  const rawPage = resolvedSearchParams?.page;
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+export default function Page() {
+  const searchParams = useSearchParams();
+  const rawPage = searchParams.get("page");
+  const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
-  const filteredRequests = mineOnly
-    ? exchangeRequests.filter((request) => request.author === CURRENT_AUTHOR)
-    : exchangeRequests;
-  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
-  const isInvalidPage =
-    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
-  if (isInvalidPage) {
-    redirect(mineOnly ? "/staff/class/exchange?mineOnly=1" : "/staff/class/exchange");
-  }
+  const { data: exchangeRequests = [], isLoading, isError } = useQuery({
+    queryKey: ["lesson-exchange-requests"],
+    queryFn: () => getLessonExchangeRequests(),
+    retry: false,
+  });
 
-  const startIndex = (parsedPage - 1) * ITEMS_PER_PAGE;
-  const rows = mapRows(
-    filteredRequests.slice(startIndex, startIndex + ITEMS_PER_PAGE),
-    parsedPage,
+  const filteredRequests = useMemo(
+    () =>
+      mineOnly
+        ? exchangeRequests.filter((request) => request.requestedByName === CURRENT_AUTHOR)
+        : exchangeRequests,
+    [exchangeRequests, mineOnly],
   );
+
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
+  const currentPage =
+    Number.isInteger(parsedPage) && parsedPage >= 1 && parsedPage <= totalPages ? parsedPage : 1;
+
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const rows: ListPanelRow[] = filteredRequests
+    .slice(startIndex, startIndex + ITEMS_PER_PAGE)
+    .map((item, index) => ({
+      id: item.id ?? startIndex + index + 1,
+      no: String(startIndex + index + 1).padStart(2, "0"),
+      className: "-",
+      title: item.title ?? "제목 없음",
+      author: item.requestedByName ?? "-",
+      date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
+      status: formatStatus(item.status),
+      detailHref: `/staff/class/exchange/${item.id ?? ""}`,
+    }));
+
+  const emptyMessage = isLoading
+    ? "교환 신청 내역을 불러오는 중입니다."
+    : isError
+      ? "교환 신청 내역을 불러오지 못했습니다."
+      : "교환 신청 내역이 없습니다.";
 
   return (
     <ListPanel
@@ -64,10 +69,10 @@ export default async function Page({ searchParams }: PageProps) {
       writeHref="/staff/class/exchange/new"
       listPath="/staff/class/exchange"
       rows={rows}
-      currentPage={parsedPage}
+      currentPage={currentPage}
       totalPages={totalPages}
       mineOnly={mineOnly}
-      emptyMessage="교환 신청 내역이 없습니다."
+      emptyMessage={emptyMessage}
       headerTone="journal"
     />
   );

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -4,10 +4,10 @@ import { useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { getLessonExchangeRequests } from "@/api/request/request.api";
-import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -15,6 +15,8 @@ const ITEMS_PER_PAGE = 9;
 
 export default function Page() {
   const searchParams = useSearchParams();
+  const { status: authStatus, user } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
   const rawPage = searchParams.get("page");
   const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
@@ -22,16 +24,10 @@ export default function Page() {
   const { data: exchangeRequests = [], isLoading, isError } = useQuery({
     queryKey: ["lesson-exchange-requests"],
     queryFn: () => getLessonExchangeRequests(),
+    enabled: isAuthenticated,
     retry: false,
   });
-
-  const { data: currentUser } = useQuery({
-    queryKey: ["users", "me"],
-    queryFn: getCurrentUser,
-    retry: false,
-  });
-
-  const currentUserName = currentUser?.name?.trim();
+  const currentUserName = user?.name?.trim();
 
   const filteredRequests = useMemo(
     () =>
@@ -62,7 +58,11 @@ export default function Page() {
       detailHref: `/staff/class/exchange/${item.id ?? ""}`,
     }));
 
-  const emptyMessage = isLoading
+  const emptyMessage = authStatus === "loading"
+    ? "사용자 정보를 확인하는 중입니다."
+    : !isAuthenticated
+      ? "로그인이 필요합니다."
+      : isLoading
     ? "교환 신청 내역을 불러오는 중입니다."
     : isError
       ? "교환 신청 내역을 불러오지 못했습니다."

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -4,13 +4,13 @@ import { useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { getLessonExchangeRequests } from "@/api/request/request.api";
+import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
-const CURRENT_AUTHOR = "김민지";
 
 function formatStatus(status?: string) {
   if (status === "APPROVED") return "승인 완료";
@@ -30,12 +30,23 @@ export default function Page() {
     retry: false,
   });
 
+  const { data: currentUser } = useQuery({
+    queryKey: ["users", "me"],
+    queryFn: getCurrentUser,
+    retry: false,
+  });
+
+  const currentUserName = currentUser?.name?.trim();
+
   const filteredRequests = useMemo(
     () =>
       mineOnly
-        ? exchangeRequests.filter((request) => request.requestedByName === CURRENT_AUTHOR)
+        ? exchangeRequests.filter((request) => {
+            const requestedByName = request.requestedByName?.trim();
+            return Boolean(currentUserName) && requestedByName === currentUserName;
+          })
         : exchangeRequests,
-    [exchangeRequests, mineOnly],
+    [currentUserName, exchangeRequests, mineOnly],
   );
 
   const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -8,15 +8,10 @@ import { getCurrentUser } from "@/api/user/user.api";
 import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
+import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
-
-function formatStatus(status?: string) {
-  if (status === "APPROVED") return "승인 완료";
-  if (status === "REJECTED") return "반려";
-  return "대기 중";
-}
 
 export default function Page() {
   const searchParams = useSearchParams();
@@ -63,7 +58,7 @@ export default function Page() {
       title: item.title ?? "제목 없음",
       author: item.requestedByName ?? "-",
       date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
-      status: formatStatus(item.status),
+      status: formatRequestStatus(item.status),
       detailHref: `/staff/class/exchange/${item.id ?? ""}`,
     }));
 

--- a/app/staff/class/exchange/page.tsx
+++ b/app/staff/class/exchange/page.tsx
@@ -8,6 +8,7 @@ import ListPanel, {
   type ListPanelRow,
 } from "@/components/staff/ListPanel";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -22,7 +23,7 @@ export default function Page() {
   const parsedPage = rawPage ? Number(rawPage) : 1;
 
   const { data: exchangeRequests = [], isLoading, isError } = useQuery({
-    queryKey: ["lesson-exchange-requests"],
+    queryKey: queryKeys.requests.lessonExchangeList(),
     queryFn: () => getLessonExchangeRequests(),
     enabled: isAuthenticated,
     retry: false,

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -423,11 +423,12 @@ const SwitchInput = styled.input`
   opacity: 0;
 
   &:checked + span {
-    background-color: #bbc4ff;
+    background-color: #eef9e6;
   }
 
   &:checked + span span {
     transform: translateX(1.3125rem);
+    background-color: #88cd5a;
 
     @media (min-width: 120rem) {
       transform: translateX(2.125rem);
@@ -462,7 +463,7 @@ const SwitchThumb = styled.span`
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  background-color: #6d6d6d;
+  background-color: #616161;
   transition: transform 0.2s ease;
 
   @media (min-width: 120rem) {

--- a/app/staff/class/page.tsx
+++ b/app/staff/class/page.tsx
@@ -194,7 +194,7 @@ const ActionButton = styled.button`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  border-radius: ${radii.radius15};
+  border-radius: ${radii.radius12};
   background-color: ${colors.point};
   color: ${colors.white};
   font-size: ${typography.fontSize14};
@@ -265,9 +265,11 @@ const JournalCard = styled(Link)`
   flex-direction: column;
   justify-content: space-between;
   height: 12.6875rem;
-  background-color: #d9d9d9;
   color: #000000;
   text-decoration: none;
+  border: 1px solid #88cd5a;
+  overflow: hidden;
+  border-radius: ${radii.radius20};
 
   @media (min-width: 120rem) {
     height: 19.0625rem;
@@ -328,7 +330,7 @@ const CardFooter = styled.footer`
   gap: ${spacing.space8};
   min-height: 2.625rem;
   padding: 0 ${spacing.space16};
-  background-color: #f3f3f3;
+  background-color: #88cd5a;
 
   @media (min-width: 120rem) {
     min-height: 3.9375rem;
@@ -339,7 +341,7 @@ const CardFooter = styled.footer`
 const ClassName = styled.strong`
   min-width: 0;
   overflow: hidden;
-  color: #000000;
+  color: #ffffff;
   font-size: ${typography.fontSize14};
   font-weight: 600;
   line-height: ${typography.lineHeight130};
@@ -363,7 +365,7 @@ const MetaGroup = styled.div`
 `;
 
 const Teacher = styled.span`
-  color: #000000;
+  color: #ffffff;
   font-size: 0.6875rem;
   font-weight: 500;
   line-height: ${typography.lineHeight130};

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -15,12 +15,12 @@ import {
 import AuthShell from "@/components/auth/AuthShell";
 
 type LoginFormState = {
-  username: string;
+  email: string;
   password: string;
 };
 
 const initialState: LoginFormState = {
-  username: "",
+  email: "",
   password: "",
 };
 
@@ -30,7 +30,7 @@ export default function LoginForm() {
   const [statusMessage, setStatusMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const canSubmit = form.username.trim().length > 0 && form.password.length > 0;
+  const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -44,7 +44,7 @@ export default function LoginForm() {
 
     try {
       await login({
-        username: form.username.trim(),
+        email: form.email.trim(),
         password: form.password,
       });
       setStatusMessage("로그인되었습니다. 잠시 후 메인으로 이동합니다.");
@@ -61,16 +61,16 @@ export default function LoginForm() {
       <Form onSubmit={handleSubmit} aria-label="로그인 폼">
         <FieldGroup>
           <Field>
-            <Label htmlFor="login-username">아이디</Label>
+            <Label htmlFor="login-email">이메일</Label>
             <Input
-              id="login-username"
-              name="username"
-              type="text"
-              autoComplete="username"
-              placeholder="아이디를 입력하세요"
-              value={form.username}
+              id="login-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="이메일을 입력하세요"
+              value={form.email}
               onChange={(event) =>
-                setForm((current) => ({ ...current, username: event.target.value }))
+                setForm((current) => ({ ...current, email: event.target.value }))
               }
               required
             />

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -3,8 +3,8 @@ import EventPhotoCard from "@/components/home/EventPhotoCard";
 import LoginCard from "@/components/home/LoginCard";
 import MeetingMinutesCard from "@/components/home/MeetingMinutesCard";
 import NoticeCard from "@/components/home/NoticeCard";
-import WeeklyScheduleCard from "@/components/home/WeeklyScheduleCard";
-import { eventPhotos, meetingMinutes, weeklySchedule } from "@/mocks/home";
+import WeeklySchedulePanel from "@/components/home/WeeklySchedulePanel";
+import { eventPhotos, meetingMinutes } from "@/mocks/home";
 import { colors, layout, spacing } from "@/styles/tokens";
 
 export default function HomePage() {
@@ -17,7 +17,7 @@ export default function HomePage() {
           </LoginArea>
 
           <ScheduleArea>
-            <WeeklyScheduleCard schedule={weeklySchedule} />
+            <WeeklySchedulePanel />
           </ScheduleArea>
         </TopRow>
 

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -4,7 +4,7 @@ import LoginCard from "@/components/home/LoginCard";
 import MeetingMinutesCard from "@/components/home/MeetingMinutesCard";
 import NoticeCard from "@/components/home/NoticeCard";
 import WeeklyScheduleCard from "@/components/home/WeeklyScheduleCard";
-import { eventPhotos, meetingMinutes, notices, weeklySchedule } from "@/mocks/home";
+import { eventPhotos, meetingMinutes, weeklySchedule } from "@/mocks/home";
 import { colors, layout, spacing } from "@/styles/tokens";
 
 export default function HomePage() {
@@ -23,7 +23,7 @@ export default function HomePage() {
 
         <BottomGrid>
           <NoticeArea>
-            <NoticeCard notices={notices} />
+            <NoticeCard />
           </NoticeArea>
 
           <MeetingArea>

--- a/components/home/LoginCard.tsx
+++ b/components/home/LoginCard.tsx
@@ -12,12 +12,12 @@ import { useAuthSession } from "@/hooks/useAuthSession";
 import { colors, radii, spacing, typography } from "@/styles/tokens";
 
 type LoginFormState = {
-  username: string;
+  email: string;
   password: string;
 };
 
 const initialLoginForm: LoginFormState = {
-  username: "",
+  email: "",
   password: "",
 };
 
@@ -28,7 +28,7 @@ export default function LoginCard() {
   const [errorMessage, setErrorMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const displayName = user?.name ?? "회원";
-  const canSubmit = form.username.trim().length > 0 && form.password.length > 0;
+  const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
 
   async function handleLogout() {
     await signOut();
@@ -47,7 +47,7 @@ export default function LoginCard() {
 
     try {
       await login({
-        username: form.username.trim(),
+        email: form.email.trim(),
         password: form.password,
       });
       setForm(initialLoginForm);
@@ -92,12 +92,12 @@ export default function LoginCard() {
       <Form aria-label="로그인 폼" onSubmit={handleLogin}>
         <InputGroup>
           <Input
-            type="text"
-            placeholder="아이디"
-            autoComplete="username"
-            value={form.username}
+            type="email"
+            placeholder="이메일"
+            autoComplete="email"
+            value={form.email}
             onChange={(event) =>
-              setForm((current) => ({ ...current, username: event.target.value }))
+              setForm((current) => ({ ...current, email: event.target.value }))
             }
           />
           <Input

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -4,11 +4,12 @@ import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { getPosts } from "@/api/post/post.api";
 import HomeCard from "@/components/home/HomeCard";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, spacing, typography } from "@/styles/tokens";
 
 export default function NoticeCard() {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["posts", "notice", "top12"],
+    queryKey: queryKeys.posts.noticeTop12(),
     queryFn: () =>
       getPosts({
         postType: "NOTICE",

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -1,23 +1,41 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
+import { getPosts } from "@/api/post/post.api";
 import HomeCard from "@/components/home/HomeCard";
 import { colors, spacing, typography } from "@/styles/tokens";
-import type { Notice } from "@/types/home";
 
-type NoticeCardProps = {
-  notices: Notice[];
-};
+export default function NoticeCard() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["posts", "notice", "top12"],
+    queryFn: () =>
+      getPosts({
+        postType: "NOTICE",
+        page: 0,
+        size: 12,
+      }),
+    retry: false,
+  });
 
-export default function NoticeCard({ notices }: NoticeCardProps) {
+  const notices = data?.content ?? [];
+
   return (
     <Card title="공지사항" actionLabel="더보기">
       <List>
-        {notices.length === 0 && <Fallback>공지사항이 없습니다.</Fallback>}
-        {notices.map((notice) => (
-          <ListItem key={notice.id}>
-            <Title>{notice.title}</Title>
-            <Date dateTime={notice.date}>{notice.date}</Date>
-          </ListItem>
-        ))}
+        {isLoading && <Fallback>공지사항 불러오는 중...</Fallback>}
+        {isError && <Fallback>공지사항을 불러오지 못했습니다.</Fallback>}
+        {!isLoading && !isError && notices.length === 0 && (
+          <Fallback>공지사항이 없습니다.</Fallback>
+        )}
+        {!isLoading &&
+          !isError &&
+          notices.map((notice, index) => (
+            <ListItem key={`${notice.id ?? "notice"}-${index}`}>
+              <Title>{notice.title ?? "제목 없음"}</Title>
+              {/* <Date>{notice.date}</Date> */} {/*TODO*/}
+            </ListItem>
+          ))}
       </List>
     </Card>
   );
@@ -54,18 +72,6 @@ const Title = styled.h3`
   line-height: ${typography.lineHeight150};
   white-space: nowrap;
   text-overflow: ellipsis;
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize24};
-  }
-`;
-
-const Date = styled.time`
-  color: ${colors.muted};
-  font-size: ${typography.fontSize16};
-  line-height: ${typography.lineHeight130};
-  font-weight: 300;
-  white-space: nowrap;
 
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize24};

--- a/components/home/WeeklyScheduleCard.tsx
+++ b/components/home/WeeklyScheduleCard.tsx
@@ -29,7 +29,11 @@ export default function WeeklyScheduleCard({ schedule }: WeeklyScheduleCardProps
               <ItemList>
                 {daySchedule.items.length === 0 ? (
                   <EmptyText>
-                    예정된 수업이 <br /> 없습니다
+                    예정된
+                    <br />
+                    수업이
+                    <br />
+                    없습니다
                   </EmptyText>
                 ) : (
                   <>
@@ -134,6 +138,9 @@ const ItemTitle = styled.span`
   color: ${colors.text};
   display: -webkit-box;
   overflow: hidden;
+  white-space: normal;
+  word-break: keep-all;
+  overflow-wrap: normal;
   font-size: ${typography.fontSize13};
   font-weight: 500;
   line-height: ${typography.lineHeight130};

--- a/components/home/WeeklySchedulePanel.tsx
+++ b/components/home/WeeklySchedulePanel.tsx
@@ -5,6 +5,7 @@ import isoWeek from "dayjs/plugin/isoWeek";
 import { useQuery } from "@tanstack/react-query";
 import { getLessons } from "@/api/lesson/lesson.api";
 import WeeklyScheduleCard from "@/components/home/WeeklyScheduleCard";
+import { queryKeys } from "@/lib/queryKeys";
 import { mapLessonsToWeeklySchedule } from "@/utils/mapLessonsToWeeklySchedule";
 
 dayjs.extend(isoWeek);
@@ -14,7 +15,7 @@ export default function WeeklySchedulePanel() {
   const to = dayjs().endOf("isoWeek").format("YYYY-MM-DD");
 
   const { data: lessons = [] } = useQuery({
-    queryKey: ["lessons", "weekly", { from, to }],
+    queryKey: queryKeys.lessons.weekly(from, to),
     queryFn: () => getLessons({ from, to }),
     retry: false,
   });

--- a/components/home/WeeklySchedulePanel.tsx
+++ b/components/home/WeeklySchedulePanel.tsx
@@ -5,7 +5,6 @@ import isoWeek from "dayjs/plugin/isoWeek";
 import { useQuery } from "@tanstack/react-query";
 import { getLessons } from "@/api/lesson/lesson.api";
 import WeeklyScheduleCard from "@/components/home/WeeklyScheduleCard";
-import { weeklySchedule as fallbackWeeklySchedule } from "@/mocks/home";
 import { mapLessonsToWeeklySchedule } from "@/utils/mapLessonsToWeeklySchedule";
 
 dayjs.extend(isoWeek);
@@ -20,8 +19,7 @@ export default function WeeklySchedulePanel() {
     retry: false,
   });
 
-  const weeklySchedule =
-    lessons.length > 0 ? mapLessonsToWeeklySchedule(lessons) : fallbackWeeklySchedule;
+  const weeklySchedule = mapLessonsToWeeklySchedule(lessons);
 
   return <WeeklyScheduleCard schedule={weeklySchedule} />;
 }

--- a/components/staff/ClassJournalCreatePage.tsx
+++ b/components/staff/ClassJournalCreatePage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import styled from "styled-components";
-import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const teacherFields = [
   { id: "writer", label: "작성자", placeholder: "홍길동" },
@@ -57,24 +57,26 @@ export default function ClassJournalCreatePage() {
 
         <AttendanceSection>
           <SectionTitle>출석</SectionTitle>
-          <AttendanceGrid aria-label="출석부">
-            {attendanceColumns.map((column) => (
-              <AttendanceInput
-                key={`student-${column}`}
-                name={`studentName${column + 1}`}
-                aria-label={`${column + 1}번 학생 이름`}
-                placeholder={column < 4 ? "최양진" : ""}
-              />
-            ))}
-            {attendanceColumns.map((column) => (
-              <AttendanceInput
-                key={`attendance-${column}`}
-                name={`attendanceStatus${column + 1}`}
-                aria-label={`${column + 1}번 출석 상태`}
-              />
-            ))}
-          </AttendanceGrid>
-          <AddAttendanceButton type="button">출석부 추가하기</AddAttendanceButton>
+          <AttendanceTableWrap>
+            <AttendanceGrid aria-label="출석부">
+              {attendanceColumns.map((column) => (
+                <AttendanceInput
+                  key={`student-${column}`}
+                  name={`studentName${column + 1}`}
+                  aria-label={`${column + 1}번 학생 이름`}
+                  placeholder={column < 4 ? "최양진" : ""}
+                />
+              ))}
+              {attendanceColumns.map((column) => (
+                <AttendanceInput
+                  key={`attendance-${column}`}
+                  name={`attendanceStatus${column + 1}`}
+                  aria-label={`${column + 1}번 출석 상태`}
+                />
+              ))}
+            </AttendanceGrid>
+            <AddAttendanceButton type="button">출석부 추가하기</AddAttendanceButton>
+          </AttendanceTableWrap>
         </AttendanceSection>
       </Form>
     </PageSection>
@@ -157,13 +159,37 @@ const ConsentLabel = styled.label`
 `;
 
 const ConsentCheckbox = styled.input`
+  flex-shrink: 0;
   width: 1rem;
   height: 1rem;
-  accent-color: ${colors.point};
+  margin: 0;
+  appearance: none;
+  border: 1px solid #c8deb8;
+  border-radius: 4px;
+  background-color: #eef9e6;
+  cursor: pointer;
+
+  &:checked {
+    background-color: #eef9e6;
+    border-color: ${colors.point};
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill='none' stroke='%2388CD5A' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M2 6l3 3 5-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 0.75rem;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${colors.point};
+    outline-offset: 2px;
+  }
 
   @media (min-width: 120rem) {
     width: 1.5625rem;
     height: 1.5625rem;
+
+    &:checked {
+      background-size: 1rem;
+    }
   }
 `;
 
@@ -174,8 +200,9 @@ const SubmitButton = styled.button`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space20};
   border: 0;
-  background-color: #e4e4e4;
-  color: #000000;
+  border-radius: ${radii.radius12};
+  background-color: #88cd5a;
+  color: ${colors.white};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -183,7 +210,12 @@ const SubmitButton = styled.button`
   cursor: pointer;
 
   &:hover {
-    background-color: #d9d9d9;
+    filter: brightness(0.95);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   @media (min-width: 120rem) {
@@ -254,7 +286,7 @@ const FieldInput = styled.input`
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background-color: #d9d9d9;
+  background-color: #f8f8f8;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
@@ -291,7 +323,7 @@ const LessonTextArea = styled.textarea`
   min-height: 5.375rem;
   padding: 0.8125rem ${spacing.space12};
   border: 0;
-  background-color: #e2e2e2;
+  background-color: #f8f8f8;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
@@ -320,12 +352,25 @@ const AttendanceSection = styled.section`
   }
 `;
 
+const AttendanceTableWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+  max-width: 100%;
+  align-self: flex-start;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
 const AttendanceGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(10, minmax(4.5rem, 1fr));
   overflow-x: auto;
-  border-top: 1px solid #000000;
-  border-left: 1px solid #000000;
+  border-top: 1px solid #c0c0c0;
+  border-left: 1px solid #c0c0c0;
 `;
 
 const AttendanceInput = styled.input`
@@ -333,9 +378,9 @@ const AttendanceInput = styled.input`
   min-height: 2.75rem;
   padding: ${spacing.space8};
   border: 0;
-  border-right: 1px solid #000000;
-  border-bottom: 1px solid #000000;
-  background-color: #e2e2e2;
+  border-right: 1px solid #c0c0c0;
+  border-bottom: 1px solid #c0c0c0;
+  background: transparent;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
@@ -359,8 +404,8 @@ const AddAttendanceButton = styled.button`
   justify-content: center;
   width: 100%;
   min-height: 2.6875rem;
-  border: 1px solid #000000;
-  background-color: #e2e2e2;
+  border: 1px solid #88cd5a;
+  background-color: #eef9e6;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 600;
@@ -368,7 +413,7 @@ const AddAttendanceButton = styled.button`
   cursor: pointer;
 
   &:hover {
-    background-color: #d9d9d9;
+    filter: brightness(0.97);
   }
 
   @media (min-width: 120rem) {

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,0 +1,14 @@
+export const queryKeys = {
+  posts: {
+    noticeTop12: () => ["posts", "notice", "top12"] as const,
+  },
+  lessons: {
+    weekly: (from: string, to: string) => ["lessons", "weekly", { from, to }] as const,
+  },
+  requests: {
+    lessonExchangeList: () => ["lesson-exchange-requests"] as const,
+    lessonExchangeDetail: (requestId: number) => ["lesson-exchange-request", requestId] as const,
+    absenceList: () => ["absence-requests"] as const,
+    absenceDetail: (requestId: number) => ["absence-request", requestId] as const,
+  },
+};

--- a/mocks/handlers/auth.handlers.ts
+++ b/mocks/handlers/auth.handlers.ts
@@ -10,7 +10,8 @@ import type {
 
 export const API_BASE_URL = "http://localhost:8080";
 
-export const VALID_USERNAME = "valid-user";
+/** MSW 로그인 성공에 사용하는 이메일(백엔드 login API는 `email` 필드 기준) */
+export const VALID_LOGIN_EMAIL = "valid-user@example.com";
 export const VALID_PASSWORD = "correct-password";
 export const VALID_ACCESS_TOKEN = "valid-access-token";
 export const EXPIRED_ACCESS_TOKEN = "expired-access-token";
@@ -20,7 +21,7 @@ export const REFRESHED_REFRESH_TOKEN = "refreshed-refresh-token";
 export const INVALID_REFRESH_TOKEN = "invalid-refresh-token";
 
 export const DEFAULT_LOGIN_REQUEST: LoginRequestDto = {
-  username: VALID_USERNAME,
+  email: VALID_LOGIN_EMAIL,
   password: VALID_PASSWORD,
 };
 
@@ -46,7 +47,7 @@ export const authHandlers = [
   http.post(`${API_BASE_URL}/api/v1/auth/login`, async ({ request }) => {
     const body = (await request.json()) as LoginRequestDto;
 
-    if (body.username !== VALID_USERNAME || body.password !== VALID_PASSWORD) {
+    if (body.email !== VALID_LOGIN_EMAIL || body.password !== VALID_PASSWORD) {
       return createUnauthorizedResponse("Invalid credentials");
     }
 

--- a/utils/formatRequestStatus.ts
+++ b/utils/formatRequestStatus.ts
@@ -1,0 +1,7 @@
+import type { RequestStatus } from "@/api/request/request.dto";
+
+export function formatRequestStatus(status?: RequestStatus | string) {
+  if (status === "APPROVED") return "승인 완료";
+  if (status === "REJECTED") return "반려";
+  return "대기 중";
+}

--- a/utils/formatUtcToKstShortDate.ts
+++ b/utils/formatUtcToKstShortDate.ts
@@ -1,0 +1,23 @@
+const EMPTY_DATE = "00.00.00";
+
+export function formatUtcToKstShortDate(value?: string) {
+  if (!value) return EMPTY_DATE;
+
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) return EMPTY_DATE;
+
+  const formatter = new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const parts = formatter.formatToParts(parsedDate);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+
+  if (!year || !month || !day) return EMPTY_DATE;
+  return `${year}.${month}.${day}`;
+}

--- a/utils/kstShortDate.test.ts
+++ b/utils/kstShortDate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  koreanShortDateToLocalDateTime,
+  parseKoreanShortDateToIsoDate,
+} from "./kstShortDate";
+
+describe("kstShortDate", () => {
+  it("parses yy.mm.dd to ISO date", () => {
+    expect(parseKoreanShortDateToIsoDate("26.06.01")).toBe("2026-06-01");
+    expect(parseKoreanShortDateToIsoDate(" 26.06.01 ")).toBe("2026-06-01");
+    expect(parseKoreanShortDateToIsoDate("bad")).toBeNull();
+  });
+
+  it("builds API expiresAt-style datetime", () => {
+    expect(koreanShortDateToLocalDateTime("26.06.01")).toBe("2026-06-01T22:00:00");
+    expect(koreanShortDateToLocalDateTime("26.06.01", "15:30:00")).toBe("2026-06-01T15:30:00");
+  });
+});

--- a/utils/kstShortDate.ts
+++ b/utils/kstShortDate.ts
@@ -1,0 +1,23 @@
+import { formatUtcToKstShortDate } from "./formatUtcToKstShortDate";
+
+export function getKstTodayShortDate(): string {
+  return formatUtcToKstShortDate(new Date().toISOString());
+}
+
+export function parseKoreanShortDateToIsoDate(text: string): string | null {
+  const m = /^(\d{2})\.(\d{2})\.(\d{2})$/.exec(text.trim());
+  if (!m) return null;
+  const yy = Number(m[1]);
+  const [, , mm, dd] = m;
+  const fullYear = 2000 + yy;
+  return `${fullYear}-${mm}-${dd}`;
+}
+
+export function koreanShortDateToLocalDateTime(
+  text: string,
+  time: string = "22:00:00",
+): string | null {
+  const datePart = parseKoreanShortDateToIsoDate(text);
+  if (!datePart) return null;
+  return `${datePart}T${time}`;
+}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. api
- 홈 공지사항 api 연동
- 홈 주간 일정 섹션 api 연동
- 수업 교환 api 연동 (백엔드 과거 dev 브랜치 기준으로 연동)
- 수업 결강 api 연동 (백엔드 최신 dev 브랜치 기준)
- 수업 교환 api 클라이언트 개발 (백엔드 최신 dev 브랜치 기준)

2. 퍼블리싱
- 수업 일지, 교환, 결강 페이지 디자인 반영 (교원 권한 없는 신청서 작성 페이지 제외)

3. 주요 수정
- 로그인 request dto에서 필드를 email로 수정

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #36 

## 💬 기타 사항

추가로 공유할 내용, 논의할 주제, 고민점이 있다면 적어주세요.

## 📂 참고 자료

> N/A
