### PR TITLE
[FEAT] 재무 관리 섹션 UI 개선

### DIFF
--- a/app/staff/finance/new/page.tsx
+++ b/app/staff/finance/new/page.tsx
@@ -1,0 +1,5 @@
+import FinanceRequestCreatePage from "@/components/staff/FinanceRequestCreatePage";
+
+export default function Page() {
+  return <FinanceRequestCreatePage />;
+}

--- a/components/staff/FinanceRequestCreatePage.tsx
+++ b/components/staff/FinanceRequestCreatePage.tsx
@@ -1,0 +1,379 @@
+import { IconFilePlus } from "@tabler/icons-react";
+import styled from "styled-components";
+import StaffSidebar from "@/components/staff/StaffSidebar";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export default function FinanceRequestCreatePage() {
+  return (
+    <Main>
+      <Stage>
+        <StaffSidebar />
+
+        <Content>
+          <HeaderRow>
+            <Title>결제 신청서 작성하기</Title>
+            <SubmitButton type="submit" form="finance-request-form">
+              결제 신청서 제출하기
+            </SubmitButton>
+          </HeaderRow>
+
+          <Form id="finance-request-form">
+            <Section>
+              <Label htmlFor="title">제목</Label>
+              <Input id="title" name="title" placeholder="제목" />
+            </Section>
+
+            <Section>
+              <SectionTitle>신청자 정보</SectionTitle>
+              <InfoRow>
+                <FieldLabel htmlFor="className">반 이름</FieldLabel>
+                <InlineInput id="className" name="className" placeholder="개나리반" />
+                <FieldLabel htmlFor="paymentDate">결제 일자</FieldLabel>
+                <InlineInput id="paymentDate" name="paymentDate" placeholder="00.00.00" />
+                <FieldLabel htmlFor="applicant">신청자</FieldLabel>
+                <InlineInput id="applicant" name="applicant" placeholder="홍길동" />
+              </InfoRow>
+            </Section>
+
+            <Section>
+              <SectionTitle>상세 품목</SectionTitle>
+              <ItemBlock>
+                <ItemFieldRow>
+                  <ItemLabel htmlFor="itemName">품목</ItemLabel>
+                  <ItemInput id="itemName" name="itemName" placeholder="품목" />
+                </ItemFieldRow>
+                <ItemFieldRow>
+                  <ItemLabel htmlFor="paymentReason">결제 사유</ItemLabel>
+                  <ItemInput id="paymentReason" name="paymentReason" placeholder="품목" />
+                </ItemFieldRow>
+                <ItemLabel as="span">영수증</ItemLabel>
+                <UploadControl>
+                  <UploadInput id="receiptFile" name="receiptFile" type="file" />
+                  <UploadBox htmlFor="receiptFile">
+                    <IconFilePlus size={24} stroke={1.8} aria-hidden="true" />
+                    <span>파일 추가하기</span>
+                  </UploadBox>
+                </UploadControl>
+              </ItemBlock>
+
+              <AddItemButton type="button">품목 추가하기</AddItemButton>
+            </Section>
+          </Form>
+        </Content>
+      </Stage>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.white};
+`;
+
+const Stage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const Content = styled.section`
+  flex: 1;
+  min-width: 0;
+  padding: 2.3125rem 3.125rem 4rem;
+
+  @media (min-width: 120rem) {
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    padding-inline: ${spacing.space16};
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: 2.125rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize20};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+const SubmitButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space20};
+  border: 0;
+  border-radius: ${radii.radius15};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const Label = styled.label`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const inputBase = `
+  min-width: 0;
+  min-height: 2.6875rem;
+  border: 0;
+  background-color: ${colors.background};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  &::placeholder {
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const Input = styled.input`
+  ${inputBase}
+  width: 100%;
+  padding: 0.8125rem ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+  }
+`;
+
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FieldLabel = styled.label`
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InlineInput = styled.input`
+  ${inputBase}
+  padding: 0.8125rem ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+  }
+`;
+
+const ItemBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+  padding-bottom: ${spacing.space20};
+  border-bottom: 1px solid #bcbcbc;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding-bottom: 1.875rem;
+  }
+`;
+
+const ItemFieldRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ItemLabel = styled(Label)`
+  min-width: 4rem;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    min-width: 6.125rem;
+  }
+`;
+
+const ItemInput = styled(Input)`
+  padding-inline: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
+  }
+`;
+
+const UploadControl = styled.div`
+  display: flex;
+  align-items: flex-start;
+`;
+
+const UploadInput = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+`;
+
+const UploadBox = styled.label`
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space8};
+  min-width: 5.5rem;
+  min-height: 4.125rem;
+  padding: ${spacing.space20};
+  background-color: ${colors.background};
+  color: #969696;
+  font-size: 0.5rem;
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-width: 8.375rem;
+    min-height: 6.25rem;
+    gap: 0.9375rem;
+    padding: 1.875rem;
+    font-size: 0.75rem;
+
+    svg {
+      width: 2rem;
+      height: 2rem;
+    }
+  }
+`;
+
+const AddItemButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.125rem;
+  border: 1px solid ${colors.point};
+  background-color: #eef9e6;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 3.125rem;
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/staff/FinanceRequestDetailPage.tsx
+++ b/components/staff/FinanceRequestDetailPage.tsx
@@ -1,62 +1,117 @@
 import Link from "next/link";
+import { IconDownload } from "@tabler/icons-react";
 import styled from "styled-components";
 import StaffSidebar from "@/components/staff/StaffSidebar";
 import type { FinanceRequest } from "@/mocks/staffFinance";
-import { colors, layout, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 type FinanceRequestDetailPageProps = {
   request: FinanceRequest;
 };
 
+const receiptFiles = ["자료.pdf", "자료.pdf", "자료.pdf", "자료.pdf"];
+
 export default function FinanceRequestDetailPage({ request }: FinanceRequestDetailPageProps) {
+  const detailItems = [
+    {
+      id: request.id,
+      name: request.title,
+      reason: request.detail,
+      receipts: receiptFiles,
+    },
+  ];
+
   return (
     <Main>
-      <StaffSidebar />
+      <Stage>
+        <StaffSidebar />
 
-      <Content>
-        <Actions>
-          <ActionButton type="button">삭제</ActionButton>
-          <ActionButton type="button">수정</ActionButton>
-          <ListButton href="/staff/finance">목록</ListButton>
-        </Actions>
+        <Content>
+          <Actions>
+            <ActionButton type="button" $variant="danger">
+              삭제
+            </ActionButton>
+            <ActionButton type="button">수정</ActionButton>
+            <ListButton href="/staff/finance">목록</ListButton>
+          </Actions>
 
-        <Section>
-          <Label>제목</Label>
-          <Field>{request.title}</Field>
-        </Section>
+          <ContentColumn>
+            <DateBar>{request.paymentDate}</DateBar>
 
-        <Section>
-          <SectionTitle>신청자 정보</SectionTitle>
-          <InlineGrid>
-            <InlineGroup>
-              <InlineLabel>반 이름</InlineLabel>
-              <InlineField>{request.className}</InlineField>
-            </InlineGroup>
-            <InlineGroup>
-              <InlineLabel>결제 일자</InlineLabel>
-              <InlineField>{request.paymentDate}</InlineField>
-            </InlineGroup>
-          </InlineGrid>
-        </Section>
+            <Section>
+              <Label>제목</Label>
+              <Field>{request.title}</Field>
+            </Section>
 
-        <Section>
-          <SectionTitle>상세 품목</SectionTitle>
-          <LargeField>{request.detail}</LargeField>
-        </Section>
+            <Section>
+              <SectionTitle>신청자 정보</SectionTitle>
+              <InfoRow>
+                <InlineLabel>반 이름</InlineLabel>
+                <InlineField>{request.className}</InlineField>
+                <InlineLabel>결제 일자</InlineLabel>
+                <InlineField>{request.paymentDate}</InlineField>
+                <InlineLabel>신청자</InlineLabel>
+                <InlineField>{request.author}</InlineField>
+              </InfoRow>
+            </Section>
 
-        <Section>
-          <SectionTitle>신청 현황</SectionTitle>
-          <StatusField>{request.status}</StatusField>
-        </Section>
-      </Content>
+            <Section>
+              <SectionTitle>상세 품목</SectionTitle>
+              <DetailItemList>
+                {detailItems.map((item, index) => (
+                  <DetailItemRow key={item.id}>
+                    <DetailLabel>품목 {index + 1}</DetailLabel>
+                    <DetailField>{item.name}</DetailField>
+                    <DetailLabel>결제 사유</DetailLabel>
+                    <ReasonField>{item.reason}</ReasonField>
+                    <DetailLabel>영수증</DetailLabel>
+                    <ReceiptList>
+                      {item.receipts.map((receipt, receiptIndex) => (
+                        <ReceiptLink
+                          key={`${item.id}-${receiptIndex}`}
+                          href="#"
+                          aria-label={`${receipt} 다운로드`}
+                        >
+                          <span>{receipt}</span>
+                          <ReceiptIcon aria-hidden="true">
+                            <IconDownload size={16} stroke={2.25} />
+                          </ReceiptIcon>
+                        </ReceiptLink>
+                      ))}
+                    </ReceiptList>
+                  </DetailItemRow>
+                ))}
+              </DetailItemList>
+            </Section>
+
+            <Section>
+              <SectionTitle>신청 현황</SectionTitle>
+              <StatusField>{request.status}</StatusField>
+            </Section>
+          </ContentColumn>
+        </Content>
+      </Stage>
     </Main>
   );
 }
 
 const Main = styled.main`
-  display: flex;
   min-height: calc(100vh - ${layout.headerHeight});
   background-color: ${colors.white};
+`;
+
+const Stage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
 
   @media (max-width: ${layout.breakpointTablet}) {
     flex-direction: column;
@@ -66,34 +121,88 @@ const Main = styled.main`
 const Content = styled.section`
   flex: 1;
   min-width: 0;
-  padding: 2rem 2.5rem 2.5rem;
+  padding: 1.8125rem 3.125rem 4rem;
 
-  @media (max-width: ${layout.breakpointDesktop}) {
-    padding: 1.75rem 1.5rem 2rem;
+  @media (min-width: 120rem) {
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
   }
 
   @media (max-width: ${layout.breakpointMobile}) {
-    padding: 1.5rem 1rem;
+    padding-inline: ${spacing.space16};
   }
 `;
 
 const Actions = styled.div`
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
-  margin-bottom: 2.75rem;
+  gap: ${spacing.space20};
+  margin-bottom: 2.25rem;
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
 `;
 
-const BaseAction = styled.button`
+const ContentColumn = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+const DateBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid #a9a9a9;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const BaseAction = styled.button<{ $variant?: "default" | "danger" }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
   border: 0;
-  background-color: #ececec;
-  padding: 0.95rem 1.5rem;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 600;
+  border-radius: ${radii.radius15};
+  background-color: ${({ $variant }) => ($variant === "danger" ? "#fde4e2" : colors.point)};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${({ $variant }) => ($variant === "danger" ? "#da3a30" : colors.white)};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
   cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const ActionButton = styled(BaseAction)``;
@@ -102,103 +211,230 @@ const ListButton = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 0;
-  background-color: #ececec;
-  padding: 0.95rem 1.5rem;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 600;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  border-radius: ${radii.radius15};
+  background-color: ${colors.point};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Section = styled.section`
-  & + & {
-    margin-top: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
   }
 `;
 
 const Label = styled.h2`
-  margin-bottom: 0.75rem;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 700;
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
   line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const SectionTitle = styled.h2`
-  margin-bottom: 1rem;
-  color: ${colors.text};
-  font-size: 1rem;
-  font-weight: 700;
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
   line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
 const Field = styled.div`
-  min-height: 4rem;
-  background-color: #f5f5f5;
-  padding: 1.15rem 1.25rem;
-  color: ${colors.text};
-  font-size: 0.95rem;
-  font-weight: 500;
-  line-height: ${typography.lineHeight150};
+  display: flex;
+  align-items: center;
+  min-height: 2.6875rem;
+  min-width: 0;
+  background-color: #f7f7f7;
+  padding: 0.8125rem ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  overflow-wrap: anywhere;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const InlineGrid = styled.div`
+const InfoRow = styled.div`
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 1rem;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
 
-  @media (max-width: ${layout.breakpointTablet}) {
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
     grid-template-columns: 1fr;
   }
 `;
 
-const InlineGroup = styled.div`
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: 0.75rem;
-`;
-
 const InlineLabel = styled.span`
-  color: ${colors.text};
-  font-size: 0.95rem;
-  font-weight: 700;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
   line-height: ${typography.lineHeight130};
   white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
 `;
 
-const InlineField = styled.div`
-  min-height: 4rem;
-  background-color: #f5f5f5;
-  padding: 1.15rem 1.25rem;
-  color: ${colors.text};
-  font-size: 0.95rem;
-  font-weight: 500;
-  line-height: ${typography.lineHeight150};
+const InlineField = styled(Field)``;
+
+const DetailItemList = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
-const LargeField = styled.div`
-  min-height: 9.5rem;
-  background-color: #f5f5f5;
-  padding: 1.15rem 1.25rem;
-  color: ${colors.text};
-  font-size: 0.95rem;
-  font-weight: 500;
-  line-height: ${typography.lineHeight150};
+const DetailItemRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(9.25rem, 13.75rem) auto minmax(0, 1fr) auto minmax(
+      5.875rem,
+      6.25rem
+    );
+  align-items: flex-start;
+  gap: ${spacing.space12};
+  padding-bottom: ${spacing.space20};
+  border-bottom: 1px solid #d4d4d4;
+
+  & + & {
+    padding-top: ${spacing.space20};
+  }
+
+  @media (min-width: 120rem) {
+    grid-template-columns: auto 17.25rem auto minmax(0, 1fr) auto 7.875rem;
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
-const StatusField = styled.div`
+const DetailLabel = styled(InlineLabel)`
+  min-height: 2.6875rem;
+  display: inline-flex;
+  align-items: center;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+  }
+`;
+
+const DetailField = styled(Field)`
+  color: #7b7b7b;
+`;
+
+const ReasonField = styled(DetailField)`
+  align-items: flex-start;
+`;
+
+const ReceiptList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.3125rem;
+  min-width: 0;
+  background-color: ${colors.background};
+  padding: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+  }
+`;
+
+const ReceiptLink = styled(Link)`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1.5rem;
+  align-items: center;
+  gap: ${spacing.space8};
+  min-width: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (min-width: 120rem) {
+    grid-template-columns: minmax(0, 1fr) 2.25rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ReceiptIcon = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 7.5rem;
-  min-height: 4rem;
-  background-color: #f5f5f5;
-  padding: 0.75rem 1.25rem;
-  color: ${colors.text};
-  font-size: 0.95rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background-color: ${colors.point};
+  color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
+
+    svg {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+`;
+
+const StatusField = styled(Field)`
+  width: fit-content;
+  justify-content: center;
+  border-radius: ${radii.radius15};
+  background-color: #fbf4d7;
+  padding-inline: ${spacing.space20};
+  color: #e5ad34;
   font-weight: 600;
-  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
+  }
 `;

--- a/components/staff/FinanceRequestListPage.tsx
+++ b/components/staff/FinanceRequestListPage.tsx
@@ -1,10 +1,7 @@
 import styled from "styled-components";
 import ListPanel from "@/components/staff/ListPanel";
 import StaffSidebar from "@/components/staff/StaffSidebar";
-import {
-  FINANCE_REQUESTS_PER_PAGE,
-  type FinanceRequest,
-} from "@/mocks/staffFinance";
+import { FINANCE_REQUESTS_PER_PAGE, type FinanceRequest } from "@/mocks/staffFinance";
 import { colors, layout } from "@/styles/tokens";
 
 type FinanceRequestListPageProps = {
@@ -45,6 +42,7 @@ export default function FinanceRequestListPage({
             totalPages={totalPages}
             showMineOnlyToggle={false}
             emptyMessage="결제 신청 내역이 없습니다."
+            headerTone="finance"
           />
         </Content>
       </Stage>

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -13,6 +13,8 @@ export type ListPanelRow = {
   detailHref: string;
 };
 
+type ListPanelTone = "default" | "journal" | "finance";
+
 type ListPanelProps = {
   title: string;
   writeLabel: string;
@@ -24,7 +26,7 @@ type ListPanelProps = {
   mineOnly?: boolean;
   showMineOnlyToggle?: boolean;
   emptyMessage?: string;
-  headerTone?: "default" | "journal";
+  headerTone?: ListPanelTone;
 };
 
 type QueryValue = string | number | boolean;
@@ -76,20 +78,20 @@ export default function ListPanel({
         <Table>
           <thead>
             <tr>
-              <Th $width720="3.75rem" $width1080="5.5rem">
+              <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone}>
                 no.
               </Th>
-              <Th $width720="7.125rem" $width1080="10.75rem">
+              <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
                 반
               </Th>
-              <Th>제목</Th>
-              <Th $width720="5rem" $width1080="7.375rem">
+              <Th $tone={headerTone}>제목</Th>
+              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                 작성자
               </Th>
-              <Th $width720="10.875rem" $width1080="16.3125rem">
+              <Th $width720="10.875rem" $width1080="16.3125rem" $tone={headerTone}>
                 작성일
               </Th>
-              <Th $width720="5rem" $width1080="7.375rem">
+              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                 신청 현황
               </Th>
             </tr>
@@ -98,7 +100,7 @@ export default function ListPanel({
           <tbody>
             {rows.length > 0 ? (
               rows.map((row) => (
-                <Tr key={row.id}>
+                <Tr key={row.id} $tone={headerTone}>
                   <Td $width720="3.75rem" $width1080="5.5rem">
                     {row.no}
                   </Td>
@@ -120,7 +122,7 @@ export default function ListPanel({
                 </Tr>
               ))
             ) : (
-              <Tr>
+              <Tr $tone={headerTone}>
                 <EmptyTd colSpan={6}>{emptyMessage}</EmptyTd>
               </Tr>
             )}
@@ -145,7 +147,10 @@ export default function ListPanel({
 
         <Pagination aria-label="페이지 이동">
           <PageArrow
-            href={buildHref(listPath, { ...baseQuery, page: prevPage === 1 ? undefined : prevPage })}
+            href={buildHref(listPath, {
+              ...baseQuery,
+              page: prevPage === 1 ? undefined : prevPage,
+            })}
             aria-label="이전 페이지"
             $isDisabled={currentPage === 1}
           >
@@ -169,7 +174,10 @@ export default function ListPanel({
             );
           })}
           <PageArrow
-            href={buildHref(listPath, { ...baseQuery, page: nextPage === 1 ? undefined : nextPage })}
+            href={buildHref(listPath, {
+              ...baseQuery,
+              page: nextPage === 1 ? undefined : nextPage,
+            })}
             aria-label="다음 페이지"
             $isDisabled={currentPage === totalPages}
           >
@@ -209,29 +217,38 @@ const HeaderRow = styled.div`
   }
 `;
 
-const Title = styled.h1<{ $tone: "default" | "journal" }>`
+const Title = styled.h1<{ $tone: ListPanelTone }>`
   margin: 0;
   color: #000000;
-  font-size: ${({ $tone }) => ($tone === "journal" ? "1.625rem" : typography.fontSize24)};
-  font-weight: ${({ $tone }) => ($tone === "journal" ? 600 : 700)};
+  font-size: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" ? "1.625rem" : typography.fontSize24};
+  font-weight: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? 600 : 700)};
   line-height: ${typography.lineHeight130};
 
   @media (min-width: 120rem) {
-    font-size: ${({ $tone }) => ($tone === "journal" ? "2.5rem" : typography.fontSize24)};
+    font-size: ${({ $tone }) =>
+      $tone === "journal" || $tone === "finance" ? "2.5rem" : typography.fontSize24};
   }
 `;
 
-const WriteButton = styled(Link)<{ $tone: "default" | "journal" }>`
+const WriteButton = styled(Link)<{ $tone: ListPanelTone }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: ${({ $tone }) => ($tone === "journal" ? "auto" : "7.75rem")};
-  min-height: ${({ $tone }) => ($tone === "journal" ? "2.6875rem" : "2.75rem")};
-  padding: ${({ $tone }) => ($tone === "journal" ? `0.8125rem ${spacing.space20}` : `0.75rem ${spacing.space20}`)};
+  min-width: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "auto" : "7.75rem")};
+  min-height: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" ? "2.6875rem" : "2.75rem"};
+  padding: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance"
+      ? `0.8125rem ${spacing.space20}`
+      : `0.75rem ${spacing.space20}`};
   border: 0;
-  border-radius: ${({ $tone }) => ($tone === "journal" ? radii.radius15 : "0")};
-  background: ${({ $tone }) => ($tone === "journal" ? colors.point : "#e4e4e4")};
-  color: ${({ $tone }) => ($tone === "journal" ? colors.white : colors.text)};
+  border-radius: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" ? radii.radius15 : "0"};
+  background: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" ? colors.point : "#e4e4e4"};
+  color: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" ? colors.white : colors.text};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -240,13 +257,17 @@ const WriteButton = styled(Link)<{ $tone: "default" | "journal" }>`
   cursor: pointer;
 
   &:hover {
-    background: ${({ $tone }) => ($tone === "journal" ? "#76bd49" : "#d9d9d9")};
+    background: ${({ $tone }) =>
+      $tone === "journal" || $tone === "finance" ? "#76bd49" : "#d9d9d9"};
   }
 
   @media (min-width: 120rem) {
-    min-width: ${({ $tone }) => ($tone === "journal" ? "auto" : "9.375rem")};
-    min-height: ${({ $tone }) => ($tone === "journal" ? "4rem" : "4.25rem")};
-    padding: ${({ $tone }) => ($tone === "journal" ? `${spacing.space20} 1.875rem` : `0.75rem ${spacing.space20}`)};
+    min-width: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "auto" : "9.375rem")};
+    min-height: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "4rem" : "4.25rem")};
+    padding: ${({ $tone }) =>
+      $tone === "journal" || $tone === "finance"
+        ? `${spacing.space20} 1.875rem`
+        : `0.75rem ${spacing.space20}`};
     font-size: ${typography.fontSize20};
   }
 `;
@@ -261,10 +282,10 @@ const Table = styled.table`
   table-layout: fixed;
 `;
 
-const Th = styled.th<{ $width720?: string; $width1080?: string }>`
+const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanelTone }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
   padding: 0.625rem ${spacing.space12};
-  border-bottom: 1px solid #6d6d6d;
+  border-bottom: 1px solid ${({ $tone }) => ($tone === "finance" ? colors.muted : "#6d6d6d")};
   font-size: ${typography.fontSize16};
   font-weight: 700;
   text-align: center;
@@ -277,8 +298,8 @@ const Th = styled.th<{ $width720?: string; $width1080?: string }>`
   }
 `;
 
-const Tr = styled.tr`
-  border-bottom: 1px solid #6d6d6d;
+const Tr = styled.tr<{ $tone: ListPanelTone }>`
+  border-bottom: 1px solid ${({ $tone }) => ($tone === "finance" ? colors.muted : "#6d6d6d")};
 `;
 
 const Td = styled.td<{ $width720?: string; $width1080?: string }>`


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

결제 신청 관련 페이지의 UI를 개선 및 구현하였습니다.
1920x1080 및 1280x720 레이아웃을 별도로 구성하여, 다양한 크기의 CSS viewport 및 여러 OS 배율에서도 디자인 시안의 의도대로 화면이 구성되도록 반응형 UI로 구현하였습니다.

<img width="1915" height="864" alt="스크린샷 2026-05-02 042849" src="https://github.com/user-attachments/assets/f1b007f9-11a4-48ad-9e9f-9c02c41da5da" />

<img width="1897" height="868" alt="스크린샷 2026-05-02 042911" src="https://github.com/user-attachments/assets/b986519f-cba7-4bfb-96a5-c5be008b3f83" />

<img width="1899" height="866" alt="스크린샷 2026-05-02 042932" src="https://github.com/user-attachments/assets/a4512c4c-8a9e-4113-9b0d-3f15b96d07f9" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #33 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
