### PR TITLE
[FEAT] 자료실 섹션 UI 구현

### DIFF
--- a/app/staff/archive/contact/page.tsx
+++ b/app/staff/archive/contact/page.tsx
@@ -1,0 +1,5 @@
+import ContactPage from "@/components/archive/ContactPage";
+
+export default function Page() {
+  return <ContactPage />;
+}

--- a/app/staff/archive/exam/[postId]/page.tsx
+++ b/app/staff/archive/exam/[postId]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import ArchiveDocumentDetailPage from "@/components/archive/ArchiveDocumentDetailPage";
+import {
+  archiveDocumentConfigs,
+  getArchiveDocumentById,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.exam;
+
+export function generateStaticParams() {
+  return getArchiveDocuments("exam").map((document) => ({
+    postId: String(document.id),
+  }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { postId } = await params;
+  const document = getArchiveDocumentById("exam", Number(postId));
+
+  if (!document) {
+    notFound();
+  }
+
+  return <ArchiveDocumentDetailPage config={config} document={document} />;
+}

--- a/app/staff/archive/exam/new/page.tsx
+++ b/app/staff/archive/exam/new/page.tsx
@@ -1,0 +1,6 @@
+import ArchiveDocumentFormPage from "@/components/archive/ArchiveDocumentFormPage";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
+
+export default function Page() {
+  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.exam} />;
+}

--- a/app/staff/archive/exam/page.tsx
+++ b/app/staff/archive/exam/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import ArchiveDocumentListPage from "@/components/archive/ArchiveDocumentListPage";
+import {
+  ARCHIVE_DOCUMENTS_PER_PAGE,
+  archiveDocumentConfigs,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  searchParams?: Promise<{
+    mineOnly?: string;
+    page?: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.exam;
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const parsedPage = resolvedSearchParams?.page ? Number(resolvedSearchParams.page) : 1;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const filteredDocuments = mineOnly
+    ? getArchiveDocuments("exam").filter((document) => document.author === "홍길동")
+    : getArchiveDocuments("exam");
+  const totalPages = Math.max(1, Math.ceil(filteredDocuments.length / ARCHIVE_DOCUMENTS_PER_PAGE));
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages) {
+    redirect(config.listPath);
+  }
+
+  const startIndex = (parsedPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE;
+  const documents = filteredDocuments.slice(startIndex, startIndex + ARCHIVE_DOCUMENTS_PER_PAGE);
+
+  return (
+    <ArchiveDocumentListPage
+      config={config}
+      currentPage={parsedPage}
+      documents={documents}
+      mineOnly={mineOnly}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/app/staff/archive/forms/[postId]/page.tsx
+++ b/app/staff/archive/forms/[postId]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import ArchiveDocumentDetailPage from "@/components/archive/ArchiveDocumentDetailPage";
+import {
+  archiveDocumentConfigs,
+  getArchiveDocumentById,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.forms;
+
+export function generateStaticParams() {
+  return getArchiveDocuments("forms").map((document) => ({
+    postId: String(document.id),
+  }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { postId } = await params;
+  const document = getArchiveDocumentById("forms", Number(postId));
+
+  if (!document) {
+    notFound();
+  }
+
+  return <ArchiveDocumentDetailPage config={config} document={document} />;
+}

--- a/app/staff/archive/forms/new/page.tsx
+++ b/app/staff/archive/forms/new/page.tsx
@@ -1,0 +1,6 @@
+import ArchiveDocumentFormPage from "@/components/archive/ArchiveDocumentFormPage";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
+
+export default function Page() {
+  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.forms} />;
+}

--- a/app/staff/archive/forms/page.tsx
+++ b/app/staff/archive/forms/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import ArchiveDocumentListPage from "@/components/archive/ArchiveDocumentListPage";
+import {
+  ARCHIVE_DOCUMENTS_PER_PAGE,
+  archiveDocumentConfigs,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  searchParams?: Promise<{
+    mineOnly?: string;
+    page?: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.forms;
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const parsedPage = resolvedSearchParams?.page ? Number(resolvedSearchParams.page) : 1;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const filteredDocuments = mineOnly
+    ? getArchiveDocuments("forms").filter((document) => document.author === "홍길동")
+    : getArchiveDocuments("forms");
+  const totalPages = Math.max(1, Math.ceil(filteredDocuments.length / ARCHIVE_DOCUMENTS_PER_PAGE));
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages) {
+    redirect(config.listPath);
+  }
+
+  const startIndex = (parsedPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE;
+  const documents = filteredDocuments.slice(startIndex, startIndex + ARCHIVE_DOCUMENTS_PER_PAGE);
+
+  return (
+    <ArchiveDocumentListPage
+      config={config}
+      currentPage={parsedPage}
+      documents={documents}
+      mineOnly={mineOnly}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/app/staff/archive/handover/[postId]/page.tsx
+++ b/app/staff/archive/handover/[postId]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import ArchiveDocumentDetailPage from "@/components/archive/ArchiveDocumentDetailPage";
+import {
+  archiveDocumentConfigs,
+  getArchiveDocumentById,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.handover;
+
+export function generateStaticParams() {
+  return getArchiveDocuments("handover").map((document) => ({
+    postId: String(document.id),
+  }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { postId } = await params;
+  const document = getArchiveDocumentById("handover", Number(postId));
+
+  if (!document) {
+    notFound();
+  }
+
+  return <ArchiveDocumentDetailPage config={config} document={document} />;
+}

--- a/app/staff/archive/handover/new/page.tsx
+++ b/app/staff/archive/handover/new/page.tsx
@@ -1,0 +1,6 @@
+import ArchiveDocumentFormPage from "@/components/archive/ArchiveDocumentFormPage";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
+
+export default function Page() {
+  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.handover} />;
+}

--- a/app/staff/archive/handover/page.tsx
+++ b/app/staff/archive/handover/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import ArchiveDocumentListPage from "@/components/archive/ArchiveDocumentListPage";
+import {
+  ARCHIVE_DOCUMENTS_PER_PAGE,
+  archiveDocumentConfigs,
+  getArchiveDocuments,
+} from "@/mocks/archiveDocuments";
+
+type PageProps = {
+  searchParams?: Promise<{
+    mineOnly?: string;
+    page?: string;
+  }>;
+};
+
+const config = archiveDocumentConfigs.handover;
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const parsedPage = resolvedSearchParams?.page ? Number(resolvedSearchParams.page) : 1;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const filteredDocuments = mineOnly
+    ? getArchiveDocuments("handover").filter((document) => document.author === "홍길동")
+    : getArchiveDocuments("handover");
+  const totalPages = Math.max(1, Math.ceil(filteredDocuments.length / ARCHIVE_DOCUMENTS_PER_PAGE));
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages) {
+    redirect(config.listPath);
+  }
+
+  const startIndex = (parsedPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE;
+  const documents = filteredDocuments.slice(startIndex, startIndex + ARCHIVE_DOCUMENTS_PER_PAGE);
+
+  return (
+    <ArchiveDocumentListPage
+      config={config}
+      currentPage={parsedPage}
+      documents={documents}
+      mineOnly={mineOnly}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/app/staff/archive/layout.tsx
+++ b/app/staff/archive/layout.tsx
@@ -6,7 +6,7 @@ export default function ArchiveLayout({ children }: { children: React.ReactNode 
   return (
     <ArchiveShell>
       <ArchiveStage>
-        <StaffSidebar mode="expanded" />
+        <StaffSidebar />
         <ArchiveContent>{children}</ArchiveContent>
       </ArchiveStage>
     </ArchiveShell>

--- a/app/staff/archive/layout.tsx
+++ b/app/staff/archive/layout.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import StaffSidebar from "@/components/staff/StaffSidebar";
+import { colors, layout } from "@/styles/tokens";
+
+export default function ArchiveLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ArchiveShell>
+      <ArchiveStage>
+        <StaffSidebar mode="expanded" />
+        <ArchiveContent>{children}</ArchiveContent>
+      </ArchiveStage>
+    </ArchiveShell>
+  );
+}
+
+const ArchiveShell = styled.div`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.white};
+`;
+
+const ArchiveStage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const ArchiveContent = styled.main`
+  flex: 1;
+  min-width: 0;
+`;

--- a/app/staff/archive/meeting/[postId]/page.tsx
+++ b/app/staff/archive/meeting/[postId]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import MeetingMinuteDetailPage from "@/components/archive/MeetingMinuteDetailPage";
+import {
+  getMeetingMinuteById,
+  meetingMinutes,
+} from "@/mocks/archiveMeeting";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+};
+
+export function generateStaticParams() {
+  return meetingMinutes.map((minute) => ({
+    postId: String(minute.id),
+  }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { postId } = await params;
+  const meetingMinute = getMeetingMinuteById(Number(postId));
+
+  if (!meetingMinute) {
+    notFound();
+  }
+
+  return <MeetingMinuteDetailPage meetingMinute={meetingMinute} />;
+}

--- a/app/staff/archive/meeting/new/page.tsx
+++ b/app/staff/archive/meeting/new/page.tsx
@@ -1,0 +1,5 @@
+import MeetingMinuteFormPage from "@/components/archive/MeetingMinuteFormPage";
+
+export default function Page() {
+  return <MeetingMinuteFormPage />;
+}

--- a/app/staff/archive/meeting/page.tsx
+++ b/app/staff/archive/meeting/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from "next/navigation";
+import MeetingMinutesPage from "@/components/archive/MeetingMinutesPage";
+import {
+  MEETING_MINUTES_PER_PAGE,
+  meetingMinutes,
+} from "@/mocks/archiveMeeting";
+
+type PageProps = {
+  searchParams?: Promise<{
+    mineOnly?: string;
+    page?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const rawPage = resolvedSearchParams?.page;
+  const parsedPage = rawPage ? Number(rawPage) : 1;
+  const mineOnly = resolvedSearchParams?.mineOnly === "1";
+  const filteredMeetingMinutes = mineOnly
+    ? meetingMinutes.filter((minute) => minute.author === "홍길동")
+    : meetingMinutes;
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredMeetingMinutes.length / MEETING_MINUTES_PER_PAGE),
+  );
+  const isInvalidPage =
+    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
+
+  if (isInvalidPage) {
+    redirect("/staff/archive/meeting");
+  }
+
+  const startIndex = (parsedPage - 1) * MEETING_MINUTES_PER_PAGE;
+  const visibleMeetingMinutes = filteredMeetingMinutes.slice(
+    startIndex,
+    startIndex + MEETING_MINUTES_PER_PAGE,
+  );
+
+  return (
+    <MeetingMinutesPage
+      currentPage={parsedPage}
+      meetingMinutes={visibleMeetingMinutes}
+      mineOnly={mineOnly}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/app/staff/archive/rules/page.tsx
+++ b/app/staff/archive/rules/page.tsx
@@ -1,0 +1,5 @@
+import SchoolRulesPage from "@/components/archive/SchoolRulesPage";
+
+export default function Page() {
+  return <SchoolRulesPage />;
+}

--- a/components/archive/ArchiveDocumentDetailPage.tsx
+++ b/components/archive/ArchiveDocumentDetailPage.tsx
@@ -1,0 +1,74 @@
+import { IconDownload } from "@tabler/icons-react";
+import {
+  ActionButton,
+  ActionLink,
+  ContentStack,
+  DateBar,
+  DocumentSection,
+  FieldBox,
+  Label,
+  TextBox,
+  Toolbar,
+  ToolbarRight,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+import {
+  DownloadBadge,
+  FileLink,
+  FileList,
+} from "@/components/archive/ArchiveDocumentPages.styles";
+import type {
+  ArchiveDocument,
+  ArchiveDocumentConfig,
+} from "@/mocks/archiveDocuments";
+
+type ArchiveDocumentDetailPageProps = {
+  config: ArchiveDocumentConfig;
+  document: ArchiveDocument;
+};
+
+export default function ArchiveDocumentDetailPage({
+  config,
+  document,
+}: ArchiveDocumentDetailPageProps) {
+  return (
+    <DocumentSection>
+      <Toolbar>
+        <ActionLink href={config.listPath} $variant="muted">
+          목록
+        </ActionLink>
+
+        <ToolbarRight>
+          <ActionButton type="button" $variant="danger">
+            삭제
+          </ActionButton>
+          <ActionButton type="button">수정</ActionButton>
+        </ToolbarRight>
+      </Toolbar>
+
+      <ContentStack>
+        <DateBar>{document.date}</DateBar>
+
+        <Label>제목</Label>
+        <FieldBox>{document.title}</FieldBox>
+
+        <Label>작성자</Label>
+        <FieldBox>{document.author}</FieldBox>
+
+        <Label>설명</Label>
+        <TextBox>{document.description}</TextBox>
+
+        <Label>자료</Label>
+        <FileList>
+          {document.files.map((file) => (
+            <FileLink key={file} href="#" aria-label={`${file} 다운로드`}>
+              <span>{file}</span>
+              <DownloadBadge aria-hidden="true">
+                <IconDownload size={16} stroke={2.25} />
+              </DownloadBadge>
+            </FileLink>
+          ))}
+        </FileList>
+      </ContentStack>
+    </DocumentSection>
+  );
+}

--- a/components/archive/ArchiveDocumentFormPage.tsx
+++ b/components/archive/ArchiveDocumentFormPage.tsx
@@ -1,0 +1,63 @@
+import { IconPaperclip } from "@tabler/icons-react";
+import {
+  ActionButton,
+  DocumentSection,
+  Form,
+  Input,
+  Label,
+  PageTitle,
+  Textarea,
+  Toolbar,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+import {
+  FileLink,
+  FileSelectLabel,
+  FileUploadPanel,
+  HiddenFileInput,
+} from "@/components/archive/ArchiveDocumentPages.styles";
+import type { ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+
+type ArchiveDocumentFormPageProps = {
+  config: ArchiveDocumentConfig;
+};
+
+export default function ArchiveDocumentFormPage({ config }: ArchiveDocumentFormPageProps) {
+  return (
+    <DocumentSection>
+      <Toolbar>
+        <PageTitle>{config.writeTitle}</PageTitle>
+        <ActionButton type="submit" form={`${config.category}-form`}>
+          작성 완료
+        </ActionButton>
+      </Toolbar>
+
+      <Form id={`${config.category}-form`}>
+        <Label as="label" htmlFor={`${config.category}-title`}>
+          제목
+        </Label>
+        <Input id={`${config.category}-title`} name="title" placeholder="제목" />
+
+        <Label as="label" htmlFor={`${config.category}-author`}>
+          작성자
+        </Label>
+        <Input id={`${config.category}-author`} name="author" placeholder="홍길동" />
+
+        <Label as="label" htmlFor={`${config.category}-description`}>
+          설명
+        </Label>
+        <Textarea id={`${config.category}-description`} name="description" placeholder="설명" />
+
+        <Label>자료</Label>
+        <FileUploadPanel>
+          <FileLink href="#">{config.fileBaseName}.pdf</FileLink>
+          <FileLink href="#">{config.fileBaseName}.png</FileLink>
+          <FileSelectLabel>
+            <IconPaperclip aria-hidden="true" size={16} stroke={2.25} />
+            <span>파일 선택</span>
+            <HiddenFileInput type="file" name="files" multiple />
+          </FileSelectLabel>
+        </FileUploadPanel>
+      </Form>
+    </DocumentSection>
+  );
+}

--- a/components/archive/ArchiveDocumentListPage.tsx
+++ b/components/archive/ArchiveDocumentListPage.tsx
@@ -1,0 +1,50 @@
+import ListPanel, { type ListPanelRow } from "@/components/staff/ListPanel";
+import {
+  ARCHIVE_DOCUMENTS_PER_PAGE,
+  type ArchiveDocument,
+  type ArchiveDocumentConfig,
+} from "@/mocks/archiveDocuments";
+
+type ArchiveDocumentListPageProps = {
+  config: ArchiveDocumentConfig;
+  currentPage: number;
+  documents: ArchiveDocument[];
+  mineOnly: boolean;
+  totalPages: number;
+};
+
+export default function ArchiveDocumentListPage({
+  config,
+  currentPage,
+  documents,
+  mineOnly,
+  totalPages,
+}: ArchiveDocumentListPageProps) {
+  const rows: ListPanelRow[] = documents.map((document, index) => ({
+    id: document.id,
+    no: String((currentPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE + index + 1).padStart(2, "0"),
+    className: "",
+    title: document.title,
+    author: document.author,
+    date: document.date,
+    status: "",
+    detailHref: `${config.listPath}/${document.id}`,
+  }));
+
+  return (
+    <ListPanel
+      title={config.title}
+      writeLabel={config.writeLabel}
+      writeHref={`${config.listPath}/new`}
+      listPath={config.listPath}
+      rows={rows}
+      currentPage={currentPage}
+      totalPages={totalPages}
+      mineOnly={mineOnly}
+      emptyMessage={config.emptyMessage}
+      headerTone="archive"
+      showClassColumn={false}
+      showStatusColumn={false}
+    />
+  );
+}

--- a/components/archive/ArchiveDocumentPages.styles.ts
+++ b/components/archive/ArchiveDocumentPages.styles.ts
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import styled from "styled-components";
+import { colors, radii, spacing, typography } from "@/styles/tokens";
+
+export const FileList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space16};
+`;
+
+export const FileLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const DownloadBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background-color: ${colors.point};
+  color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+  }
+`;
+
+export const FileUploadPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space20};
+  width: 100%;
+  background-color: ${colors.background};
+  padding: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    padding: ${spacing.space20};
+  }
+`;
+
+export const FileSelectLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3125rem;
+  min-height: 2.1875rem;
+  border: 1px solid ${colors.point};
+  border-radius: ${radii.radius15};
+  background-color: #eef9e6;
+  padding: 0.625rem 0.9375rem;
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 2.9375rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const HiddenFileInput = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+`;

--- a/components/archive/ContactPage.styles.ts
+++ b/components/archive/ContactPage.styles.ts
@@ -1,0 +1,446 @@
+import styled from "styled-components";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export const ContactPageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 2.9375rem 4rem 3.125rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+export const PageTitle = styled.h1`
+  margin: 0 0 2.1875rem;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+    font-size: 2.5rem;
+  }
+`;
+
+export const ContactGroup = styled.section`
+  width: 100%;
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius15};
+  background-color: ${colors.white};
+  padding: ${spacing.space12} ${spacing.space20} ${spacing.space20};
+
+  & + & {
+    margin-top: 2.5rem;
+  }
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20} 1.875rem 1.875rem;
+
+    & + & {
+      margin-top: 5rem;
+    }
+  }
+`;
+
+export const PanelHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+  margin-bottom: 1.25rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 1.875rem;
+  }
+`;
+
+export const SectionLabel = styled.h2`
+  min-width: 5.375rem;
+  margin: 0;
+  border-top: 1px solid ${colors.point};
+  border-bottom: 1px solid ${colors.point};
+  padding: 0 ${spacing.space20};
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: 2.125rem;
+  text-align: center;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    min-width: 7.8125rem;
+    padding: 0 1.875rem;
+    font-size: ${typography.fontSize20};
+    line-height: 3.125rem;
+  }
+`;
+
+export const EditText = styled.span`
+  margin-top: 0.625rem;
+  color: #b3b3b3;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    margin-top: 1.0625rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const EditTextButton = styled.button`
+  margin-top: 0.625rem;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #b3b3b3;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    margin-top: 1.0625rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const CompleteEditButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.125rem;
+  border: 0;
+  border-radius: 0.625rem;
+  padding: 0.625rem ${spacing.space20};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    border-radius: ${radii.radius15};
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const ContactGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space8} ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12} 1.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const ContactCard = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: ${spacing.space12};
+  min-width: 0;
+  padding: ${spacing.space8};
+  color: #000000;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: 2.125rem;
+  white-space: nowrap;
+
+  strong {
+    font-weight: 700;
+  }
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding: ${spacing.space12};
+    font-size: ${typography.fontSize20};
+    line-height: 3.125rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    white-space: normal;
+  }
+`;
+
+export const Divider = styled.span`
+  display: block;
+  flex: 0 0 auto;
+  width: 1px;
+  height: 0.875rem;
+  background-color: #000000;
+
+  @media (min-width: 120rem) {
+    height: 1.3125rem;
+  }
+`;
+
+export const ContactValue = styled.span`
+  min-width: 0;
+`;
+
+export const StudentClassList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+export const TeacherEditList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+export const StudentEditList = styled(TeacherEditList)`
+  margin-top: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    margin-top: 1.875rem;
+  }
+`;
+
+export const EditRow = styled.div<{ $columns: 2 | 3 }>`
+  display: grid;
+  grid-template-columns: repeat(${({ $columns }) => $columns}, minmax(0, 1fr)) 1.5rem;
+  align-items: center;
+  gap: ${spacing.space12};
+  width: 100%;
+  padding: ${spacing.space4};
+
+  @media (min-width: 120rem) {
+    grid-template-columns: repeat(${({ $columns }) => $columns}, minmax(0, 1fr)) 2.1875rem;
+    gap: ${spacing.space20};
+    padding: ${spacing.space8};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const EditRowInput = styled.input`
+  width: 100%;
+  min-width: 0;
+  min-height: 2.125rem;
+  border: 1px solid ${colors.border};
+  padding: 0.3125rem ${spacing.space12};
+  background-color: ${colors.white};
+  color: #000000;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.75rem;
+    padding: 0.3125rem ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const RemoveRowButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 50%;
+  background-color: #eef9e6;
+  color: ${colors.point};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight100};
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+
+  @media (min-width: 120rem) {
+    width: 2.1875rem;
+    height: 2.1875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const AddRowButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(100% - 2.25rem);
+  min-height: 2.125rem;
+  border: 1px solid ${colors.border};
+  padding: 0 ${spacing.space20};
+  background-color: ${colors.background};
+  color: #000000;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    width: calc(100% - 3.4375rem);
+    min-height: 3.125rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;
+
+export const SectionBody = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space8};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12};
+  }
+`;
+
+export const ClassHeader = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  align-self: flex-start;
+`;
+
+export const ClassHeaderButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  align-self: flex-start;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+`;
+
+export const ClassName = styled.span`
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: 2.125rem;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+    line-height: 3.125rem;
+  }
+`;
+
+export const ClassTabList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: ${spacing.space8};
+  width: 100%;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+export const ClassTab = styled.button<{ $isActive: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.125rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.625rem;
+  padding: 0 ${spacing.space8};
+  background-color: ${({ $isActive }) => ($isActive ? colors.point : colors.white)};
+  color: ${({ $isActive }) => ($isActive ? colors.white : "#000000")};
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 3.125rem;
+    border-radius: ${radii.radius15};
+    padding: 0 ${spacing.space12};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const ToggleIcon = styled.span<{ $isOpen: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.875rem;
+  color: #777777;
+  font-size: ${typography.fontSize13};
+  transform: rotate(${({ $isOpen }) => ($isOpen ? "90deg" : "0deg")});
+
+  @media (min-width: 120rem) {
+    width: 1.25rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const StudentGrid = styled(ContactGrid)`
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;

--- a/components/archive/ContactPage.tsx
+++ b/components/archive/ContactPage.tsx
@@ -1,0 +1,43 @@
+import StudentContactSection from "@/components/archive/StudentContactSection";
+import TeacherContactSection from "@/components/archive/TeacherContactSection";
+import { ContactPageSection, PageTitle } from "@/components/archive/ContactPage.styles";
+import type { StudentClass, TeacherContact } from "@/components/archive/ContactPage.types";
+
+const teacherContacts: TeacherContact[] = Array.from({ length: 8 }, (_, index) => ({
+  id: index + 1,
+  name: "최양진",
+  className: "00 0000반",
+  phone: "000-0000-0000",
+}));
+
+const studentClasses: StudentClass[] = [
+  {
+    id: "gaenari",
+    name: "개나리반",
+    isOpen: true,
+    students: Array.from({ length: 6 }, (_, index) => ({
+      id: index + 1,
+      name: "최양진",
+      phone: "000-0000-0000",
+    })),
+  },
+  { id: "cherry", name: "벚꽃반", isOpen: false, students: [] },
+  { id: "dandelion", name: "민들레반", isOpen: false, students: [] },
+  { id: "chrysanthemum", name: "국화반", isOpen: false, students: [] },
+  { id: "camellia", name: "동백반", isOpen: false, students: [] },
+  { id: "sunflower", name: "해바라기반", isOpen: false, students: [] },
+  { id: "weekend-english", name: "주말 영어반", isOpen: false, students: [] },
+  { id: "weekend-phone", name: "주말 스마트폰반", isOpen: false, students: [] },
+  { id: "winter", name: "겨울반", isOpen: false, students: [] },
+];
+
+export default function ContactPage() {
+  return (
+    <ContactPageSection>
+      <PageTitle>연락망</PageTitle>
+
+      <TeacherContactSection initialContacts={teacherContacts} />
+      <StudentContactSection initialClasses={studentClasses} />
+    </ContactPageSection>
+  );
+}

--- a/components/archive/ContactPage.types.ts
+++ b/components/archive/ContactPage.types.ts
@@ -1,0 +1,19 @@
+export type TeacherContact = {
+  id: number;
+  name: string;
+  className: string;
+  phone: string;
+};
+
+export type StudentContact = {
+  id: number;
+  name: string;
+  phone: string;
+};
+
+export type StudentClass = {
+  id: string;
+  name: string;
+  isOpen: boolean;
+  students: StudentContact[];
+};

--- a/components/archive/MeetingMinuteAbsenceSection.tsx
+++ b/components/archive/MeetingMinuteAbsenceSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { AbsenceReport } from "@/mocks/archiveMeeting";
+import {
+  AbsenceBox,
+  AbsenceBoxLabel,
+  AbsenceHeader,
+  AbsenceInput,
+  AbsenceStack,
+  AbsenceTextarea,
+  AbsenceTitle,
+  ActionButton,
+  Divider,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+
+type DraftAbsenceReport = {
+  author: string;
+  reason: string;
+  opinion: string;
+};
+
+type MeetingMinuteAbsenceSectionProps = {
+  initialReports: AbsenceReport[];
+};
+
+const initialDraft: DraftAbsenceReport = {
+  author: "",
+  reason: "",
+  opinion: "",
+};
+
+export default function MeetingMinuteAbsenceSection({
+  initialReports,
+}: MeetingMinuteAbsenceSectionProps) {
+  const [draft, setDraft] = useState<DraftAbsenceReport>(initialDraft);
+  const [reports, setReports] = useState(initialReports);
+  const canSubmit = Object.values(draft).some((value) => value.trim().length > 0);
+
+  const updateDraft = (key: keyof DraftAbsenceReport, value: string) => {
+    setDraft((currentDraft) => ({
+      ...currentDraft,
+      [key]: value,
+    }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!canSubmit) return;
+
+    setReports((currentReports) => [
+      {
+        id: Date.now(),
+        author: draft.author.trim() || "작성자",
+        reason: draft.reason.trim() || "불참 사유",
+        opinion: draft.opinion.trim() || "의견",
+      },
+      ...currentReports,
+    ]);
+    setDraft(initialDraft);
+  };
+
+  return (
+    <>
+      <AbsenceHeader>
+        <AbsenceTitle>불참 사유서</AbsenceTitle>
+        <ActionButton
+          type="submit"
+          form="absence-report-form"
+          disabled={!canSubmit}
+        >
+          작성 완료
+        </ActionButton>
+      </AbsenceHeader>
+
+      <AbsenceStack as="form" id="absence-report-form" onSubmit={handleSubmit}>
+        <AbsenceBox as="label" $tone="draft" $height="short">
+          <AbsenceInput
+            name="author"
+            value={draft.author}
+            onChange={(event) => updateDraft("author", event.target.value)}
+            placeholder="작성자"
+          />
+        </AbsenceBox>
+        <AbsenceBox as="label" $tone="draft" $height="large">
+          <AbsenceTextarea
+            name="reason"
+            value={draft.reason}
+            onChange={(event) => updateDraft("reason", event.target.value)}
+            placeholder="불참사유"
+          />
+        </AbsenceBox>
+        <AbsenceBox as="label" $tone="draft" $height="medium">
+          <AbsenceTextarea
+            name="opinion"
+            value={draft.opinion}
+            onChange={(event) => updateDraft("opinion", event.target.value)}
+            placeholder="의견"
+          />
+        </AbsenceBox>
+      </AbsenceStack>
+
+      {reports.map((report) => (
+        <AbsenceStack key={report.id}>
+          <Divider />
+          <AbsenceBox $height="short">
+            <AbsenceBoxLabel>작성자</AbsenceBoxLabel>
+            <span>{report.author}</span>
+          </AbsenceBox>
+          <AbsenceBox $height="large">
+            <AbsenceBoxLabel>불참사유</AbsenceBoxLabel>
+            <span>{report.reason}</span>
+          </AbsenceBox>
+          <AbsenceBox $height="medium">
+            <AbsenceBoxLabel>의견</AbsenceBoxLabel>
+            <span>{report.opinion}</span>
+          </AbsenceBox>
+        </AbsenceStack>
+      ))}
+    </>
+  );
+}

--- a/components/archive/MeetingMinuteDetailPage.tsx
+++ b/components/archive/MeetingMinuteDetailPage.tsx
@@ -1,0 +1,62 @@
+import type { MeetingMinute } from "@/mocks/archiveMeeting";
+import MeetingMinuteAbsenceSection from "@/components/archive/MeetingMinuteAbsenceSection";
+import {
+  ActionButton,
+  ActionLink,
+  ContentStack,
+  DateBar,
+  Divider,
+  DocumentSection,
+  FieldBox,
+  Label,
+  TextBox,
+  Toolbar,
+  ToolbarRight,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+
+type MeetingMinuteDetailPageProps = {
+  meetingMinute: MeetingMinute;
+};
+
+export default function MeetingMinuteDetailPage({
+  meetingMinute,
+}: MeetingMinuteDetailPageProps) {
+  return (
+    <DocumentSection>
+      <Toolbar>
+        <ActionLink href="/staff/archive/meeting" $variant="muted">
+          목록
+        </ActionLink>
+
+        <ToolbarRight>
+          <ActionButton type="button" $variant="danger">
+            삭제
+          </ActionButton>
+          <ActionButton type="button">수정</ActionButton>
+        </ToolbarRight>
+      </Toolbar>
+
+      <ContentStack>
+        <DateBar>{meetingMinute.date}</DateBar>
+
+        <Label>제목</Label>
+        <FieldBox>{meetingMinute.title}</FieldBox>
+
+        <Label>작성자</Label>
+        <FieldBox>{meetingMinute.author}</FieldBox>
+
+        <Label>안건</Label>
+        <TextBox>{meetingMinute.agenda}</TextBox>
+
+        <Label>논의 사항</Label>
+        <TextBox $isMuted>{meetingMinute.discussion}</TextBox>
+
+        <Label>건의 사항</Label>
+        <TextBox $isMuted>{meetingMinute.suggestion}</TextBox>
+
+        <Divider />
+        <MeetingMinuteAbsenceSection initialReports={meetingMinute.absenceReports} />
+      </ContentStack>
+    </DocumentSection>
+  );
+}

--- a/components/archive/MeetingMinuteDocument.styles.ts
+++ b/components/archive/MeetingMinuteDocument.styles.ts
@@ -1,0 +1,365 @@
+import Link from "next/link";
+import styled, { css } from "styled-components";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export const DocumentSection = styled.section`
+  min-height: 0;
+  overflow: visible;
+  padding: 1.8125rem 3.125rem 4rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+export const Toolbar = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+  margin-bottom: 2.1875rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
+`;
+
+export const ToolbarRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
+`;
+
+const actionStyle = css<{ $variant?: "default" | "danger" | "muted" }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  border: ${({ $variant }) => ($variant === "muted" ? `1px solid ${colors.border}` : 0)};
+  border-radius: ${radii.radius15};
+  background-color: ${({ $variant }) =>
+    $variant === "danger"
+      ? "#fde4e2"
+      : $variant === "muted"
+        ? colors.background
+        : colors.point};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${({ $variant }) =>
+    $variant === "danger" ? "#da3a30" : $variant === "muted" ? colors.text : colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.97);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const ActionLink = styled(Link)<{ $variant?: "default" | "danger" | "muted" }>`
+  ${actionStyle}
+`;
+
+export const ActionButton = styled.button<{ $variant?: "default" | "danger" | "muted" }>`
+  ${actionStyle}
+`;
+
+export const PageTitle = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+export const DateBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid #b4b4b4;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const ContentStack = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+export const Label = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const FieldBox = styled.div<{ $isMuted?: boolean }>`
+  display: flex;
+  align-items: center;
+  min-height: 2.6875rem;
+  min-width: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${({ $isMuted }) => ($isMuted ? "#949494" : "#000000")};
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  overflow-wrap: anywhere;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const TextBox = styled(FieldBox)`
+  align-items: flex-start;
+  min-height: 6.875rem;
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+  }
+`;
+
+export const Divider = styled.hr`
+  width: 100%;
+  margin: ${spacing.space8} 0;
+  border: 0;
+  border-top: 1px solid ${colors.border};
+
+  @media (min-width: 120rem) {
+    margin: ${spacing.space12} 0;
+  }
+`;
+
+export const AbsenceHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+export const AbsenceTitle = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: 1.375rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+export const AbsenceStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+export const AbsenceBox = styled.div<{ $tone?: "draft" | "submitted"; $height?: "short" | "medium" | "large" }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: ${({ $height }) => ($height === "short" ? "center" : "flex-start")};
+  gap: ${spacing.space8};
+  min-height: ${({ $height }) =>
+    $height === "large" ? "7.5rem" : $height === "medium" ? "6.75rem" : "2.6875rem"};
+  border: ${({ $tone }) => ($tone === "draft" ? `1px solid ${colors.border}` : 0)};
+  background-color: ${({ $tone }) => ($tone === "draft" ? "#eef9e6" : colors.background)};
+  padding: 0.8125rem ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    gap: 0.625rem;
+    min-height: ${({ $height }) =>
+      $height === "large" ? "11.375rem" : $height === "medium" ? "10.0625rem" : "4rem"};
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const AbsenceBoxLabel = styled.strong<{ $draft?: boolean }>`
+  color: ${({ $draft }) => ($draft ? "#9c9c9c" : "#a1a1a1")};
+  font-weight: 600;
+`;
+
+export const AbsenceInput = styled.input`
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #000000;
+  font: inherit;
+  outline: none;
+
+  &::placeholder {
+    color: #9c9c9c;
+  }
+`;
+
+export const AbsenceTextarea = styled.textarea`
+  width: 100%;
+  min-height: 100%;
+  resize: vertical;
+  border: 0;
+  background: transparent;
+  color: #000000;
+  font: inherit;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  &::placeholder {
+    color: #9c9c9c;
+  }
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+export const TabRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+export const TabButton = styled.button<{ $active?: boolean }>`
+  min-width: 0;
+  min-height: 2.6875rem;
+  border: 1px solid ${colors.point};
+  background-color: ${({ $active }) => ($active ? colors.point : colors.white)};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${({ $active }) => ($active ? colors.white : "#000000")};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-align: left;
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  min-height: 2.6875rem;
+  border: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: #000000;
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: #949494;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  min-height: 6.875rem;
+  resize: vertical;
+  border: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: #000000;
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: #949494;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/archive/MeetingMinuteFormFields.tsx
+++ b/components/archive/MeetingMinuteFormFields.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Form,
+  Input,
+  Label,
+  TabButton,
+  TabRow,
+  Textarea,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+
+type MeetingPhase = "before" | "after";
+
+export default function MeetingMinuteFormFields() {
+  const [meetingPhase, setMeetingPhase] = useState<MeetingPhase>("before");
+  const isBeforeMeeting = meetingPhase === "before";
+
+  return (
+    <Form id="meeting-minute-form">
+      <TabRow role="tablist" aria-label="회의록 작성 구분">
+        <TabButton
+          type="button"
+          role="tab"
+          aria-selected={isBeforeMeeting}
+          $active={isBeforeMeeting}
+          onClick={() => setMeetingPhase("before")}
+        >
+          회의 전
+        </TabButton>
+        <TabButton
+          type="button"
+          role="tab"
+          aria-selected={!isBeforeMeeting}
+          $active={!isBeforeMeeting}
+          onClick={() => setMeetingPhase("after")}
+        >
+          회의 후
+        </TabButton>
+      </TabRow>
+      <input type="hidden" name="meetingPhase" value={meetingPhase} />
+
+      <Label as="label" htmlFor="meeting-title">
+        제목
+      </Label>
+      <Input id="meeting-title" name="title" placeholder="제목" />
+
+      <Label as="label" htmlFor="meeting-author">
+        작성자
+      </Label>
+      <Input id="meeting-author" name="author" placeholder="홍길동" />
+
+      <Label as="label" htmlFor="meeting-agenda">
+        안건
+      </Label>
+      <Textarea id="meeting-agenda" name="agenda" placeholder="안건" />
+
+      {!isBeforeMeeting ? (
+        <>
+          <Label as="label" htmlFor="meeting-discussion">
+            논의 사항
+          </Label>
+          <Textarea id="meeting-discussion" name="discussion" placeholder="논의 사항" />
+
+          <Label as="label" htmlFor="meeting-suggestion">
+            건의 사항
+          </Label>
+          <Textarea id="meeting-suggestion" name="suggestion" placeholder="건의 사항" />
+        </>
+      ) : null}
+    </Form>
+  );
+}

--- a/components/archive/MeetingMinuteFormPage.tsx
+++ b/components/archive/MeetingMinuteFormPage.tsx
@@ -1,0 +1,22 @@
+import MeetingMinuteFormFields from "@/components/archive/MeetingMinuteFormFields";
+import {
+  ActionButton,
+  DocumentSection,
+  PageTitle,
+  Toolbar,
+} from "@/components/archive/MeetingMinuteDocument.styles";
+
+export default function MeetingMinuteFormPage() {
+  return (
+    <DocumentSection>
+      <Toolbar>
+        <PageTitle>교학 회의록 작성하기</PageTitle>
+        <ActionButton type="submit" form="meeting-minute-form">
+          작성 완료
+        </ActionButton>
+      </Toolbar>
+
+      <MeetingMinuteFormFields />
+    </DocumentSection>
+  );
+}

--- a/components/archive/MeetingMinutesPage.tsx
+++ b/components/archive/MeetingMinutesPage.tsx
@@ -1,0 +1,49 @@
+import { IconEdit } from "@tabler/icons-react";
+import ListPanel, { type ListPanelRow } from "@/components/staff/ListPanel";
+import {
+  MEETING_MINUTES_PER_PAGE,
+  type MeetingMinute,
+} from "@/mocks/archiveMeeting";
+
+type MeetingMinutesPageProps = {
+  currentPage: number;
+  meetingMinutes: MeetingMinute[];
+  mineOnly: boolean;
+  totalPages: number;
+};
+
+export default function MeetingMinutesPage({
+  currentPage,
+  meetingMinutes,
+  mineOnly,
+  totalPages,
+}: MeetingMinutesPageProps) {
+  const rows: ListPanelRow[] = meetingMinutes.map((minute, index) => ({
+    id: minute.id,
+    no: String((currentPage - 1) * MEETING_MINUTES_PER_PAGE + index + 1).padStart(2, "0"),
+    className: "",
+    title: minute.title,
+    author: minute.author,
+    date: minute.date,
+    status: minute.status,
+    detailHref: `/staff/archive/meeting/${minute.id}`,
+  }));
+
+  return (
+    <ListPanel
+      title="교학 회의록"
+      writeLabel="교학 회의록 작성하기"
+      writeHref="/staff/archive/meeting/new"
+      listPath="/staff/archive/meeting"
+      rows={rows}
+      currentPage={currentPage}
+      totalPages={totalPages}
+      mineOnly={mineOnly}
+      emptyMessage="교학 회의록이 없습니다."
+      headerTone="archive"
+      showClassColumn={false}
+      statusHeader="구분"
+      writeIcon={<IconEdit aria-hidden="true" size={16} stroke={2} />}
+    />
+  );
+}

--- a/components/archive/SchoolRulesEditor.tsx
+++ b/components/archive/SchoolRulesEditor.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+import {
+  CompleteEditButton,
+  EditButton,
+  RuleInput,
+  RuleItem,
+  RulesList,
+  RulesPanel,
+} from "@/components/archive/SchoolRulesPage.styles";
+
+type SchoolRulesEditorContextValue = {
+  completeEditing: () => void;
+  draftRules: string[];
+  isEditing: boolean;
+  rules: string[];
+  startEditing: () => void;
+  updateDraftRule: (index: number, value: string) => void;
+};
+
+const SchoolRulesEditorContext = createContext<SchoolRulesEditorContextValue | null>(null);
+
+function useSchoolRulesEditor() {
+  const context = useContext(SchoolRulesEditorContext);
+
+  if (!context) {
+    throw new Error("SchoolRulesEditor components must be used within SchoolRulesEditorProvider.");
+  }
+
+  return context;
+}
+
+type SchoolRulesEditorProviderProps = {
+  children: ReactNode;
+  initialRules: readonly string[];
+};
+
+export function SchoolRulesEditorProvider({
+  children,
+  initialRules,
+}: SchoolRulesEditorProviderProps) {
+  const [rules, setRules] = useState<string[]>([...initialRules]);
+  const [draftRules, setDraftRules] = useState<string[]>([...initialRules, ""]);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const startEditing = () => {
+    setDraftRules([...rules, ""]);
+    setIsEditing(true);
+  };
+
+  const updateDraftRule = (index: number, value: string) => {
+    setDraftRules((currentRules) => {
+      const nextRules = [...currentRules];
+      nextRules[index] = value;
+
+      const hasEmptyLastRule = nextRules[nextRules.length - 1]?.trim() === "";
+      return hasEmptyLastRule ? nextRules : [...nextRules, ""];
+    });
+  };
+
+  const completeEditing = () => {
+    const nextRules = draftRules.map((rule) => rule.trim()).filter(Boolean);
+
+    setRules(nextRules);
+    setDraftRules([...nextRules, ""]);
+    setIsEditing(false);
+  };
+
+  return (
+    <SchoolRulesEditorContext.Provider
+      value={{
+        completeEditing,
+        draftRules,
+        isEditing,
+        rules,
+        startEditing,
+        updateDraftRule,
+      }}
+    >
+      {children}
+    </SchoolRulesEditorContext.Provider>
+  );
+}
+
+export function SchoolRulesEditAction() {
+  const { completeEditing, isEditing, startEditing } = useSchoolRulesEditor();
+
+  return isEditing ? (
+    <CompleteEditButton type="button" onClick={completeEditing}>
+      편집 완료
+    </CompleteEditButton>
+  ) : (
+    <EditButton type="button" onClick={startEditing}>
+      편집
+    </EditButton>
+  );
+}
+
+export function SchoolRulesListPanel() {
+  const { draftRules, isEditing, rules, updateDraftRule } = useSchoolRulesEditor();
+
+  return (
+    <RulesPanel aria-label="교칙 목록">
+      <RulesList>
+        {isEditing
+          ? draftRules.map((rule, index) => (
+              <RuleItem key={`draft-rule-${index}`}>
+                <RuleInput
+                  aria-label={`${index + 1}번째 교칙`}
+                  value={rule}
+                  onChange={(event) => updateDraftRule(index, event.target.value)}
+                />
+              </RuleItem>
+            ))
+          : rules.map((rule) => <RuleItem key={rule}>{rule}</RuleItem>)}
+      </RulesList>
+    </RulesPanel>
+  );
+}

--- a/components/archive/SchoolRulesPage.styles.ts
+++ b/components/archive/SchoolRulesPage.styles.ts
@@ -1,0 +1,154 @@
+import styled from "styled-components";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 2.9375rem 4rem 3.125rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+export const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: 2.1875rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.1875rem;
+  }
+`;
+
+export const Title = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: 2.5rem;
+  }
+`;
+
+export const EditButton = styled.button`
+  margin-top: 0.375rem;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #b3b3b3;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    margin-top: 0.5625rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const CompleteEditButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.125rem;
+  border: 0;
+  border-radius: 0.625rem;
+  padding: 0.625rem ${spacing.space20};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    border-radius: ${radii.radius15};
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const RulesPanel = styled.section`
+  width: 100%;
+  border-radius: ${radii.radius15};
+  background-color: #eef9e6;
+  padding: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+  }
+`;
+
+export const RulesList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.6875rem;
+  margin: 0;
+  padding-left: ${spacing.space20};
+  list-style: disc;
+
+  @media (min-width: 120rem) {
+    gap: 1.125rem;
+    padding-left: 1.875rem;
+  }
+`;
+
+export const RuleItem = styled.li`
+  color: #000000;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const RuleInput = styled.textarea`
+  display: block;
+  width: 100%;
+  min-height: 1.25rem;
+  border: 0;
+  padding: 0;
+  resize: vertical;
+  overflow: hidden;
+  background: transparent;
+  color: #000000;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  outline: none;
+
+  &:focus {
+    outline: 1px solid rgba(136, 205, 90, 0.65);
+    outline-offset: 0.125rem;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 1.875rem;
+  }
+`;

--- a/components/archive/SchoolRulesPage.tsx
+++ b/components/archive/SchoolRulesPage.tsx
@@ -1,0 +1,28 @@
+import {
+  SchoolRulesEditAction,
+  SchoolRulesEditorProvider,
+  SchoolRulesListPanel,
+} from "@/components/archive/SchoolRulesEditor";
+import { HeaderRow, PageSection, Title } from "@/components/archive/SchoolRulesPage.styles";
+
+const SCHOOL_RULES = [
+  "제5조(학습의 의무) 학생은 학교의 교육 활동에 성실히 참여하고 수업 질서를 존중해야 한다.",
+  "제6조(시설물 아끼기) 학생은 학교의 시설과 설비를 소중히 다루어야 하며, 파손 시 변상 책임을 질 수 있다.",
+  "제7조(타인 존중) 동급생 및 상하급생 간에 폭언, 폭행, 따돌림 등 인권을 침해하는 행위를 해서는 안 된다.",
+  "제8조(소지품 제한) 수업에 방해가 되는 물품이나 안전을 위협하는 인화 물질 등의 소지를 금지한다.",
+  "제9조(정보 윤리) 교내외에서 타인의 정보를 무단으로 유출하거나 사이버 폭력을 행사해서는 안 된다.",
+] as const;
+
+export default function SchoolRulesPage() {
+  return (
+    <PageSection>
+      <SchoolRulesEditorProvider initialRules={SCHOOL_RULES}>
+        <HeaderRow>
+          <Title>교칙</Title>
+          <SchoolRulesEditAction />
+        </HeaderRow>
+        <SchoolRulesListPanel />
+      </SchoolRulesEditorProvider>
+    </PageSection>
+  );
+}

--- a/components/archive/StudentContactSection.tsx
+++ b/components/archive/StudentContactSection.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AddRowButton,
+  ClassHeaderButton,
+  ClassName,
+  ClassTab,
+  ClassTabList,
+  CompleteEditButton,
+  ContactCard,
+  ContactGroup,
+  ContactValue,
+  Divider,
+  EditTextButton,
+  EditRow,
+  EditRowInput,
+  PanelHeader,
+  RemoveRowButton,
+  SectionBody,
+  SectionLabel,
+  StudentClassList,
+  StudentEditList,
+  StudentGrid,
+  ToggleIcon,
+} from "@/components/archive/ContactPage.styles";
+import type { StudentClass, StudentContact } from "@/components/archive/ContactPage.types";
+
+type StudentContactSectionProps = {
+  initialClasses: StudentClass[];
+};
+
+const createStudentContact = (id: number): StudentContact => ({
+  id,
+  name: "",
+  phone: "",
+});
+
+export default function StudentContactSection({ initialClasses }: StudentContactSectionProps) {
+  const [classes, setClasses] = useState<StudentClass[]>(initialClasses);
+  const [draftClasses, setDraftClasses] = useState<StudentClass[]>(initialClasses);
+  const [openClassIds, setOpenClassIds] = useState<Set<string>>(
+    () => new Set(initialClasses.filter((studentClass) => studentClass.isOpen).map(({ id }) => id)),
+  );
+  const [selectedClassId, setSelectedClassId] = useState(initialClasses[0]?.id ?? "");
+  const [isEditing, setIsEditing] = useState(false);
+
+  const toggleClass = (classId: string) => {
+    setOpenClassIds((currentIds) => {
+      const nextIds = new Set(currentIds);
+
+      if (nextIds.has(classId)) {
+        nextIds.delete(classId);
+      } else {
+        nextIds.add(classId);
+      }
+
+      return nextIds;
+    });
+  };
+
+  const startEditing = () => {
+    setDraftClasses(classes);
+    setSelectedClassId(classes[0]?.id ?? "");
+    setIsEditing(true);
+  };
+
+  const updateDraftStudent = (
+    classId: string,
+    studentId: number,
+    field: keyof Omit<StudentContact, "id">,
+    value: string,
+  ) => {
+    setDraftClasses((currentClasses) =>
+      currentClasses.map((studentClass) =>
+        studentClass.id === classId
+          ? {
+              ...studentClass,
+              students: studentClass.students.map((student) =>
+                student.id === studentId ? { ...student, [field]: value } : student,
+              ),
+            }
+          : studentClass,
+      ),
+    );
+  };
+
+  const removeDraftStudent = (classId: string, studentId: number) => {
+    setDraftClasses((currentClasses) =>
+      currentClasses.map((studentClass) =>
+        studentClass.id === classId
+          ? {
+              ...studentClass,
+              students: studentClass.students.filter((student) => student.id !== studentId),
+            }
+          : studentClass,
+      ),
+    );
+  };
+
+  const addDraftStudent = (classId: string) => {
+    setDraftClasses((currentClasses) =>
+      currentClasses.map((studentClass) =>
+        studentClass.id === classId
+          ? {
+              ...studentClass,
+              students: [...studentClass.students, createStudentContact(Date.now())],
+            }
+          : studentClass,
+      ),
+    );
+  };
+
+  const completeEditing = () => {
+    setClasses(
+      draftClasses.map((studentClass) => ({
+        ...studentClass,
+        students: studentClass.students.filter((student) =>
+          [student.name, student.phone].some((value) => value.trim()),
+        ),
+      })),
+    );
+    setIsEditing(false);
+  };
+
+  const selectedClass = draftClasses.find((studentClass) => studentClass.id === selectedClassId);
+
+  return (
+    <ContactGroup aria-labelledby="student-contact-title">
+      <PanelHeader>
+        <SectionLabel id="student-contact-title">학생 연락망</SectionLabel>
+        {isEditing ? (
+          <CompleteEditButton type="button" onClick={completeEditing}>
+            편집 완료
+          </CompleteEditButton>
+        ) : (
+          <EditTextButton type="button" onClick={startEditing}>
+            편집
+          </EditTextButton>
+        )}
+      </PanelHeader>
+      {isEditing && selectedClass ? (
+        <>
+          <ClassTabList aria-label="편집할 반 선택">
+            {draftClasses.map((studentClass) => (
+              <ClassTab
+                key={studentClass.id}
+                type="button"
+                $isActive={studentClass.id === selectedClassId}
+                onClick={() => setSelectedClassId(studentClass.id)}
+              >
+                {studentClass.name}
+              </ClassTab>
+            ))}
+          </ClassTabList>
+          <StudentEditList>
+            {selectedClass.students.map((student) => (
+              <EditRow key={student.id} $columns={2}>
+                <EditRowInput
+                  aria-label="학생 이름"
+                  value={student.name}
+                  onChange={(event) =>
+                    updateDraftStudent(selectedClass.id, student.id, "name", event.target.value)
+                  }
+                />
+                <EditRowInput
+                  aria-label="학생 연락처"
+                  value={student.phone}
+                  onChange={(event) =>
+                    updateDraftStudent(selectedClass.id, student.id, "phone", event.target.value)
+                  }
+                />
+                <RemoveRowButton
+                  type="button"
+                  onClick={() => removeDraftStudent(selectedClass.id, student.id)}
+                >
+                  -
+                </RemoveRowButton>
+              </EditRow>
+            ))}
+            <AddRowButton type="button" onClick={() => addDraftStudent(selectedClass.id)}>
+              + 추가하기
+            </AddRowButton>
+          </StudentEditList>
+        </>
+      ) : (
+        <StudentClassList>
+          {classes.map((studentClass) => {
+            const isOpen = openClassIds.has(studentClass.id);
+
+            return (
+              <SectionBody key={studentClass.id}>
+                <ClassHeaderButton
+                  type="button"
+                  onClick={() => toggleClass(studentClass.id)}
+                  aria-expanded={isOpen}
+                >
+                  <ClassName>{studentClass.name}</ClassName>
+                  <ToggleIcon aria-hidden="true" $isOpen={isOpen}>
+                    ▶
+                  </ToggleIcon>
+                </ClassHeaderButton>
+                {isOpen && (
+                  <StudentGrid>
+                    {studentClass.students.map((student) => (
+                      <StudentContactCard key={student.id} contact={student} />
+                    ))}
+                  </StudentGrid>
+                )}
+              </SectionBody>
+            );
+          })}
+        </StudentClassList>
+      )}
+    </ContactGroup>
+  );
+}
+
+function StudentContactCard({ contact }: { contact: StudentContact }) {
+  return (
+    <ContactCard>
+      <strong>{contact.name}</strong>
+      <Divider aria-hidden="true" />
+      <ContactValue>{contact.phone}</ContactValue>
+    </ContactCard>
+  );
+}

--- a/components/archive/TeacherContactSection.tsx
+++ b/components/archive/TeacherContactSection.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AddRowButton,
+  CompleteEditButton,
+  ContactCard,
+  ContactGrid,
+  ContactGroup,
+  ContactValue,
+  Divider,
+  EditTextButton,
+  EditRow,
+  EditRowInput,
+  PanelHeader,
+  RemoveRowButton,
+  SectionLabel,
+  TeacherEditList,
+} from "@/components/archive/ContactPage.styles";
+import type { TeacherContact } from "@/components/archive/ContactPage.types";
+
+type TeacherContactSectionProps = {
+  initialContacts: TeacherContact[];
+};
+
+const createTeacherContact = (id: number): TeacherContact => ({
+  id,
+  name: "",
+  className: "",
+  phone: "",
+});
+
+export default function TeacherContactSection({ initialContacts }: TeacherContactSectionProps) {
+  const [contacts, setContacts] = useState<TeacherContact[]>(initialContacts);
+  const [draftContacts, setDraftContacts] = useState<TeacherContact[]>(initialContacts);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const startEditing = () => {
+    setDraftContacts(contacts);
+    setIsEditing(true);
+  };
+
+  const updateDraftContact = (
+    contactId: number,
+    field: keyof Omit<TeacherContact, "id">,
+    value: string,
+  ) => {
+    setDraftContacts((currentContacts) =>
+      currentContacts.map((contact) =>
+        contact.id === contactId ? { ...contact, [field]: value } : contact,
+      ),
+    );
+  };
+
+  const removeDraftContact = (contactId: number) => {
+    setDraftContacts((currentContacts) =>
+      currentContacts.filter((contact) => contact.id !== contactId),
+    );
+  };
+
+  const addDraftContact = () => {
+    setDraftContacts((currentContacts) => [
+      ...currentContacts,
+      createTeacherContact(Date.now()),
+    ]);
+  };
+
+  const completeEditing = () => {
+    setContacts(
+      draftContacts.filter((contact) =>
+        [contact.name, contact.className, contact.phone].some((value) => value.trim()),
+      ),
+    );
+    setIsEditing(false);
+  };
+
+  return (
+    <ContactGroup aria-labelledby="teacher-contact-title">
+      <PanelHeader>
+        <SectionLabel id="teacher-contact-title">교사 연락망</SectionLabel>
+        {isEditing ? (
+          <CompleteEditButton type="button" onClick={completeEditing}>
+            편집 완료
+          </CompleteEditButton>
+        ) : (
+          <EditTextButton type="button" onClick={startEditing}>
+            편집
+          </EditTextButton>
+        )}
+      </PanelHeader>
+      {isEditing ? (
+        <TeacherEditList>
+          {draftContacts.map((contact) => (
+            <EditRow key={contact.id} $columns={3}>
+              <EditRowInput
+                aria-label="교사 이름"
+                value={contact.name}
+                onChange={(event) => updateDraftContact(contact.id, "name", event.target.value)}
+              />
+              <EditRowInput
+                aria-label="담당 반"
+                value={contact.className}
+                onChange={(event) =>
+                  updateDraftContact(contact.id, "className", event.target.value)
+                }
+              />
+              <EditRowInput
+                aria-label="교사 연락처"
+                value={contact.phone}
+                onChange={(event) => updateDraftContact(contact.id, "phone", event.target.value)}
+              />
+              <RemoveRowButton type="button" onClick={() => removeDraftContact(contact.id)}>
+                -
+              </RemoveRowButton>
+            </EditRow>
+          ))}
+          <AddRowButton type="button" onClick={addDraftContact}>
+            + 추가하기
+          </AddRowButton>
+        </TeacherEditList>
+      ) : (
+        <ContactGrid>
+          {contacts.map((contact) => (
+            <TeacherContactCard key={contact.id} contact={contact} />
+          ))}
+        </ContactGrid>
+      )}
+    </ContactGroup>
+  );
+}
+
+function TeacherContactCard({ contact }: { contact: TeacherContact }) {
+  return (
+    <ContactCard>
+      <strong>{contact.name}</strong>
+      <Divider aria-hidden="true" />
+      <ContactValue>{contact.className}</ContactValue>
+      <Divider aria-hidden="true" />
+      <ContactValue>{contact.phone}</ContactValue>
+    </ContactCard>
+  );
+}

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -29,6 +29,7 @@ type ListPanelProps = {
   emptyMessage?: string;
   headerTone?: ListPanelTone;
   showClassColumn?: boolean;
+  showStatusColumn?: boolean;
   statusHeader?: string;
   writeIcon?: ReactNode;
 };
@@ -64,6 +65,7 @@ export default function ListPanel({
   emptyMessage = "목록이 없습니다.",
   headerTone = "default",
   showClassColumn = true,
+  showStatusColumn = true,
   statusHeader = "신청 현황",
   writeIcon,
 }: ListPanelProps) {
@@ -101,9 +103,11 @@ export default function ListPanel({
               <Th $width720="10.875rem" $width1080="16.3125rem" $tone={headerTone}>
                 작성일
               </Th>
-              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
-                {statusHeader}
-              </Th>
+              {showStatusColumn ? (
+                <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
+                  {statusHeader}
+                </Th>
+              ) : null}
             </tr>
           </thead>
 
@@ -128,14 +132,18 @@ export default function ListPanel({
                   <Td $width720="10.875rem" $width1080="16.3125rem">
                     {row.date}
                   </Td>
-                  <Td $width720="5rem" $width1080="7.375rem">
-                    {row.status}
-                  </Td>
+                  {showStatusColumn ? (
+                    <Td $width720="5rem" $width1080="7.375rem">
+                      {row.status}
+                    </Td>
+                  ) : null}
                 </Tr>
               ))
             ) : (
               <Tr $tone={headerTone}>
-                <EmptyTd colSpan={showClassColumn ? 6 : 5}>{emptyMessage}</EmptyTd>
+                <EmptyTd colSpan={2 + Number(showClassColumn) + 2 + Number(showStatusColumn)}>
+                  {emptyMessage}
+                </EmptyTd>
               </Tr>
             )}
           </tbody>

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import styled from "styled-components";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
@@ -13,7 +14,7 @@ export type ListPanelRow = {
   detailHref: string;
 };
 
-type ListPanelTone = "default" | "journal" | "finance";
+type ListPanelTone = "default" | "journal" | "finance" | "archive";
 
 type ListPanelProps = {
   title: string;
@@ -27,6 +28,9 @@ type ListPanelProps = {
   showMineOnlyToggle?: boolean;
   emptyMessage?: string;
   headerTone?: ListPanelTone;
+  showClassColumn?: boolean;
+  statusHeader?: string;
+  writeIcon?: ReactNode;
 };
 
 type QueryValue = string | number | boolean;
@@ -59,6 +63,9 @@ export default function ListPanel({
   showMineOnlyToggle = true,
   emptyMessage = "목록이 없습니다.",
   headerTone = "default",
+  showClassColumn = true,
+  statusHeader = "신청 현황",
+  writeIcon,
 }: ListPanelProps) {
   const prevPage = Math.max(1, currentPage - 1);
   const nextPage = Math.min(totalPages, currentPage + 1);
@@ -70,7 +77,8 @@ export default function ListPanel({
       <HeaderRow>
         <Title $tone={headerTone}>{title}</Title>
         <WriteButton href={writeHref} $tone={headerTone}>
-          {writeLabel}
+          <span>{writeLabel}</span>
+          {writeIcon}
         </WriteButton>
       </HeaderRow>
 
@@ -81,9 +89,11 @@ export default function ListPanel({
               <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone}>
                 no.
               </Th>
-              <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
-                반
-              </Th>
+              {showClassColumn ? (
+                <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
+                  반
+                </Th>
+              ) : null}
               <Th $tone={headerTone}>제목</Th>
               <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                 작성자
@@ -92,7 +102,7 @@ export default function ListPanel({
                 작성일
               </Th>
               <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
-                신청 현황
+                {statusHeader}
               </Th>
             </tr>
           </thead>
@@ -104,9 +114,11 @@ export default function ListPanel({
                   <Td $width720="3.75rem" $width1080="5.5rem">
                     {row.no}
                   </Td>
-                  <Td $width720="7.125rem" $width1080="10.75rem">
-                    {row.className}
-                  </Td>
+                  {showClassColumn ? (
+                    <Td $width720="7.125rem" $width1080="10.75rem">
+                      {row.className}
+                    </Td>
+                  ) : null}
                   <TitleTd>
                     <TitleLink href={row.detailHref}>{row.title}</TitleLink>
                   </TitleTd>
@@ -123,7 +135,7 @@ export default function ListPanel({
               ))
             ) : (
               <Tr $tone={headerTone}>
-                <EmptyTd colSpan={6}>{emptyMessage}</EmptyTd>
+                <EmptyTd colSpan={showClassColumn ? 6 : 5}>{emptyMessage}</EmptyTd>
               </Tr>
             )}
           </tbody>
@@ -221,13 +233,18 @@ const Title = styled.h1<{ $tone: ListPanelTone }>`
   margin: 0;
   color: #000000;
   font-size: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance" ? "1.625rem" : typography.fontSize24};
-  font-weight: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? 600 : 700)};
+    $tone === "journal" || $tone === "finance" || $tone === "archive"
+      ? "1.625rem"
+      : typography.fontSize24};
+  font-weight: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" || $tone === "archive" ? 600 : 700};
   line-height: ${typography.lineHeight130};
 
   @media (min-width: 120rem) {
     font-size: ${({ $tone }) =>
-      $tone === "journal" || $tone === "finance" ? "2.5rem" : typography.fontSize24};
+      $tone === "journal" || $tone === "finance" || $tone === "archive"
+        ? "2.5rem"
+        : typography.fontSize24};
   }
 `;
 
@@ -235,20 +252,30 @@ const WriteButton = styled(Link)<{ $tone: ListPanelTone }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "auto" : "7.75rem")};
+  gap: ${spacing.space8};
+  min-width: ${({ $tone }) =>
+    $tone === "journal" || $tone === "finance" || $tone === "archive" ? "auto" : "7.75rem"};
   min-height: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance" ? "2.6875rem" : "2.75rem"};
+    $tone === "journal" || $tone === "finance" || $tone === "archive" ? "2.6875rem" : "2.75rem"};
   padding: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance"
+    $tone === "journal" || $tone === "finance" || $tone === "archive"
       ? `0.8125rem ${spacing.space20}`
       : `0.75rem ${spacing.space20}`};
-  border: 0;
+  border: ${({ $tone }) => ($tone === "archive" ? `1px solid ${colors.point}` : "0")};
   border-radius: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance" ? radii.radius15 : "0"};
+    $tone === "journal" || $tone === "finance" || $tone === "archive" ? radii.radius15 : "0"};
   background: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance" ? colors.point : "#e4e4e4"};
+    $tone === "archive"
+      ? colors.white
+      : $tone === "journal" || $tone === "finance"
+        ? colors.point
+        : "#e4e4e4"};
   color: ${({ $tone }) =>
-    $tone === "journal" || $tone === "finance" ? colors.white : colors.text};
+    $tone === "archive"
+      ? colors.point
+      : $tone === "journal" || $tone === "finance"
+        ? colors.white
+        : colors.text};
   font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
@@ -256,19 +283,34 @@ const WriteButton = styled(Link)<{ $tone: ListPanelTone }>`
   white-space: nowrap;
   cursor: pointer;
 
+  svg {
+    flex: 0 0 auto;
+  }
+
   &:hover {
     background: ${({ $tone }) =>
-      $tone === "journal" || $tone === "finance" ? "#76bd49" : "#d9d9d9"};
+      $tone === "archive"
+        ? "#eef9e6"
+        : $tone === "journal" || $tone === "finance"
+          ? "#76bd49"
+          : "#d9d9d9"};
   }
 
   @media (min-width: 120rem) {
-    min-width: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "auto" : "9.375rem")};
-    min-height: ${({ $tone }) => ($tone === "journal" || $tone === "finance" ? "4rem" : "4.25rem")};
+    min-width: ${({ $tone }) =>
+      $tone === "journal" || $tone === "finance" || $tone === "archive" ? "auto" : "9.375rem"};
+    min-height: ${({ $tone }) =>
+      $tone === "journal" || $tone === "finance" || $tone === "archive" ? "4rem" : "4.25rem"};
     padding: ${({ $tone }) =>
-      $tone === "journal" || $tone === "finance"
+      $tone === "journal" || $tone === "finance" || $tone === "archive"
         ? `${spacing.space20} 1.875rem`
         : `0.75rem ${spacing.space20}`};
     font-size: ${typography.fontSize20};
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
   }
 `;
 
@@ -285,7 +327,8 @@ const Table = styled.table`
 const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanelTone }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
   padding: 0.625rem ${spacing.space12};
-  border-bottom: 1px solid ${({ $tone }) => ($tone === "finance" ? colors.muted : "#6d6d6d")};
+  border-bottom: 1px solid
+    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
   font-size: ${typography.fontSize16};
   font-weight: 700;
   text-align: center;
@@ -299,7 +342,8 @@ const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanel
 `;
 
 const Tr = styled.tr<{ $tone: ListPanelTone }>`
-  border-bottom: 1px solid ${({ $tone }) => ($tone === "finance" ? colors.muted : "#6d6d6d")};
+  border-bottom: 1px solid
+    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
 `;
 
 const Td = styled.td<{ $width720?: string; $width1080?: string }>`

--- a/components/staff/StaffSidebar.tsx
+++ b/components/staff/StaffSidebar.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import styled from "styled-components";
 import { colors, layout, typography } from "@/styles/tokens";
-
-const SIDEBAR_STORAGE_KEY = "staff-sidebar-open-sections";
 
 const staffSections = [
   {
@@ -42,29 +40,6 @@ const staffSections = [
   },
 ];
 
-function getClosedSections() {
-  return Object.fromEntries(staffSections.map((section) => [section.title, false]));
-}
-
-function getStoredOpenSections() {
-  const storedValue = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
-  if (!storedValue) return getClosedSections();
-
-  try {
-    const parsedValue = JSON.parse(storedValue) as Record<string, boolean>;
-
-    return {
-      ...getClosedSections(),
-      ...Object.fromEntries(
-        staffSections.map((section) => [section.title, Boolean(parsedValue[section.title])]),
-      ),
-    };
-  } catch {
-    window.localStorage.removeItem(SIDEBAR_STORAGE_KEY);
-    return getClosedSections();
-  }
-}
-
 function isCurrentStaffPath(pathname: string, href: string) {
   if (href === "/staff/class") {
     return (
@@ -83,30 +58,29 @@ function getCurrentSectionTitle(pathname: string) {
   )?.title;
 }
 
+function getOpenSectionsForTitle(title?: string) {
+  return Object.fromEntries(
+    staffSections.map((section) => [section.title, Boolean(title && section.title === title)]),
+  );
+}
+
+function getOpenSectionsForPath(pathname: string) {
+  return getOpenSectionsForTitle(getCurrentSectionTitle(pathname));
+}
+
 type StaffSidebarProps = {
   mode?: "accordion" | "expanded";
 };
 
 export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) {
   const pathname = usePathname();
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>(getClosedSections);
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
+    getOpenSectionsForPath(pathname),
+  );
+  const [overridePathname, setOverridePathname] = useState<string | null>(null);
   const isExpandedMode = mode === "expanded";
-
-  useEffect(() => {
-    if (isExpandedMode) {
-      return;
-    }
-
-    const timerId = window.setTimeout(() => {
-      const currentSectionTitle = getCurrentSectionTitle(pathname);
-      setOpenSections({
-        ...getStoredOpenSections(),
-        ...(currentSectionTitle ? { [currentSectionTitle]: true } : {}),
-      });
-    }, 0);
-
-    return () => window.clearTimeout(timerId);
-  }, [isExpandedMode, pathname]);
+  const routeOpenSections = getOpenSectionsForPath(pathname);
+  const visibleOpenSections = overridePathname === pathname ? openSections : routeOpenSections;
 
   const isCurrent = (href: string) => {
     return isCurrentStaffPath(pathname, href);
@@ -114,23 +88,22 @@ export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) 
 
   const toggleSection = (title: string) => {
     setOpenSections((current) => {
+      const sourceOpenSections = overridePathname === pathname ? current : routeOpenSections;
       const nextOpenSections = {
-        ...current,
-        [title]: !current[title],
+        ...sourceOpenSections,
+        [title]: !sourceOpenSections[title],
       };
-
-      window.localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(nextOpenSections));
 
       return nextOpenSections;
     });
+    setOverridePathname(pathname);
   };
 
   const keepOnlySectionOpen = (title: string) => {
-    const nextOpenSections = Object.fromEntries(
-      staffSections.map((section) => [section.title, section.title === title]),
-    );
+    const nextOpenSections = getOpenSectionsForTitle(title);
 
-    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, JSON.stringify(nextOpenSections));
+    setOpenSections(nextOpenSections);
+    setOverridePathname(pathname);
   };
 
   return (
@@ -138,7 +111,7 @@ export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) 
       <SidebarHeader>교원</SidebarHeader>
       <SidebarContent>
         {staffSections.map((section, sectionIndex) => {
-          const isOpen = isExpandedMode || (openSections[section.title] ?? false);
+          const isOpen = isExpandedMode || (visibleOpenSections[section.title] ?? false);
           const sectionId = `staff-sidebar-section-${sectionIndex}`;
 
           return (

--- a/components/staff/StaffSidebar.tsx
+++ b/components/staff/StaffSidebar.tsx
@@ -24,12 +24,12 @@ const staffSections = [
   {
     title: "자료실",
     items: [
-      { label: "교칙", href: "/docs/rules" },
-      { label: "연락망", href: "/docs/contact" },
-      { label: "교학 회의록", href: "/docs/meeting" },
-      { label: "인수인계서", href: "/docs/handover" },
-      { label: "시험 문제 자료", href: "/docs/exam" },
-      { label: "서류 양식", href: "/docs/forms" },
+      { label: "교칙", href: "/staff/archive/rules" },
+      { label: "연락망", href: "/staff/archive/contact" },
+      { label: "교학 회의록", href: "/staff/archive/meeting" },
+      { label: "인수인계서", href: "/staff/archive/handover" },
+      { label: "시험 문제 자료", href: "/staff/archive/exam" },
+      { label: "서류 양식", href: "/staff/archive/forms" },
     ],
   },
   {
@@ -83,11 +83,20 @@ function getCurrentSectionTitle(pathname: string) {
   )?.title;
 }
 
-export default function StaffSidebar() {
+type StaffSidebarProps = {
+  mode?: "accordion" | "expanded";
+};
+
+export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) {
   const pathname = usePathname();
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(getClosedSections);
+  const isExpandedMode = mode === "expanded";
 
   useEffect(() => {
+    if (isExpandedMode) {
+      return;
+    }
+
     const timerId = window.setTimeout(() => {
       const currentSectionTitle = getCurrentSectionTitle(pathname);
       setOpenSections({
@@ -97,7 +106,7 @@ export default function StaffSidebar() {
     }, 0);
 
     return () => window.clearTimeout(timerId);
-  }, [pathname]);
+  }, [isExpandedMode, pathname]);
 
   const isCurrent = (href: string) => {
     return isCurrentStaffPath(pathname, href);
@@ -129,22 +138,26 @@ export default function StaffSidebar() {
       <SidebarHeader>교원</SidebarHeader>
       <SidebarContent>
         {staffSections.map((section, sectionIndex) => {
-          const isOpen = openSections[section.title] ?? false;
+          const isOpen = isExpandedMode || (openSections[section.title] ?? false);
           const sectionId = `staff-sidebar-section-${sectionIndex}`;
 
           return (
             <SectionBlock key={section.title}>
-              <SectionButton
-                type="button"
-                onClick={() => toggleSection(section.title)}
-                aria-expanded={isOpen}
-                aria-controls={sectionId}
-              >
-                <span>{section.title}</span>
-                <Chevron aria-hidden="true" $isOpen={isOpen}>
-                  ▾
-                </Chevron>
-              </SectionButton>
+              {isExpandedMode ? (
+                <SectionLabel>{section.title}</SectionLabel>
+              ) : (
+                <SectionButton
+                  type="button"
+                  onClick={() => toggleSection(section.title)}
+                  aria-expanded={isOpen}
+                  aria-controls={sectionId}
+                >
+                  <span>{section.title}</span>
+                  <Chevron aria-hidden="true" $isOpen={isOpen}>
+                    ▾
+                  </Chevron>
+                </SectionButton>
+              )}
               <SectionList id={sectionId} $isOpen={isOpen}>
                 {section.items.map((item) => {
                   const current = isCurrent(item.href);
@@ -241,6 +254,19 @@ const SectionButton = styled.button`
   &:hover {
     color: ${colors.text};
   }
+
+  @media (min-width: 120rem) {
+    padding: 0 2.5rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SectionLabel = styled.p`
+  padding: 0 1.625rem;
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
 
   @media (min-width: 120rem) {
     padding: 0 2.5rem;

--- a/mocks/archiveDocuments.ts
+++ b/mocks/archiveDocuments.ts
@@ -1,0 +1,90 @@
+export type ArchiveDocumentCategory = "handover" | "exam" | "forms";
+
+export type ArchiveDocument = {
+  id: number;
+  category: ArchiveDocumentCategory;
+  title: string;
+  author: string;
+  date: string;
+  description: string;
+  files: string[];
+};
+
+export type ArchiveDocumentConfig = {
+  category: ArchiveDocumentCategory;
+  listPath: string;
+  title: string;
+  writeTitle: string;
+  writeLabel: string;
+  emptyMessage: string;
+  titleTemplate: string;
+  fileBaseName: string;
+};
+
+export const ARCHIVE_DOCUMENTS_PER_PAGE = 9;
+
+export const archiveDocumentConfigs: Record<ArchiveDocumentCategory, ArchiveDocumentConfig> = {
+  handover: {
+    category: "handover",
+    listPath: "/staff/archive/handover",
+    title: "인수인계서",
+    writeTitle: "인수인계서 작성하기",
+    writeLabel: "인수인계서 작성하기",
+    emptyMessage: "인수인계서가 없습니다.",
+    titleTemplate: "00반 인수인계서 입니다",
+    fileBaseName: "00반 인수인계자료",
+  },
+  exam: {
+    category: "exam",
+    listPath: "/staff/archive/exam",
+    title: "시험 문제 자료",
+    writeTitle: "시험 문제 자료 작성하기",
+    writeLabel: "시험 문제 자료 작성하기",
+    emptyMessage: "시험 문제 자료가 없습니다.",
+    titleTemplate: "00반 시험 문제 자료 입니다",
+    fileBaseName: "00반 시험문제자료",
+  },
+  forms: {
+    category: "forms",
+    listPath: "/staff/archive/forms",
+    title: "서류 양식",
+    writeTitle: "서류 양식 작성하기",
+    writeLabel: "서류 양식 작성하기",
+    emptyMessage: "서류 양식이 없습니다.",
+    titleTemplate: "서류 양식 자료 입니다",
+    fileBaseName: "서류양식자료",
+  },
+};
+
+function createDocuments(category: ArchiveDocumentCategory) {
+  const config = archiveDocumentConfigs[category];
+
+  return Array.from({ length: 45 }, (_, index): ArchiveDocument => {
+    const id = index + 1;
+    const day = String((index % 24) + 1).padStart(2, "0");
+
+    return {
+      id,
+      category,
+      title: config.titleTemplate,
+      author: id % 4 === 0 ? "홍길동" : "작성자",
+      date: `26.04.${day}`,
+      description: `${config.title} 관련 자료 설명입니다.`,
+      files: [`${config.fileBaseName}.pdf`, `${config.fileBaseName}.png`],
+    };
+  });
+}
+
+export const archiveDocuments: Record<ArchiveDocumentCategory, ArchiveDocument[]> = {
+  handover: createDocuments("handover"),
+  exam: createDocuments("exam"),
+  forms: createDocuments("forms"),
+};
+
+export function getArchiveDocuments(category: ArchiveDocumentCategory) {
+  return archiveDocuments[category];
+}
+
+export function getArchiveDocumentById(category: ArchiveDocumentCategory, id: number) {
+  return archiveDocuments[category].find((document) => document.id === id);
+}

--- a/mocks/archiveMeeting.ts
+++ b/mocks/archiveMeeting.ts
@@ -1,0 +1,90 @@
+export type AbsenceReport = {
+  id: number;
+  author: string;
+  reason: string;
+  opinion: string;
+};
+
+export type MeetingMinute = {
+  id: number;
+  title: string;
+  author: string;
+  date: string;
+  status: "회의 전" | "회의 후";
+  agenda: string;
+  discussion: string;
+  suggestion: string;
+  absenceReports: AbsenceReport[];
+};
+
+export const MEETING_MINUTES_PER_PAGE = 9;
+
+const meetingTemplates: Omit<MeetingMinute, "id">[] = [
+  {
+    title: "26.04.05 교학 회의록 입니다",
+    author: "홍길동",
+    date: "26.04.05",
+    status: "회의 전",
+    agenda: "4월 수업 운영 현황과 학사 일정 공유",
+    discussion: "반별 출석 현황, 보강 일정, 신규 학생 적응 상황을 점검합니다.",
+    suggestion: "수업 자료 공유 방식과 회의 후 후속 업무 담당자를 정리합니다.",
+    absenceReports: [
+      {
+        id: 1,
+        author: "김민지",
+        reason: "개인 일정으로 회의 참석이 어렵습니다.",
+        opinion: "회의 자료 확인 후 필요한 의견은 별도로 전달하겠습니다.",
+      },
+      {
+        id: 2,
+        author: "박서준",
+        reason: "동시간대 보강 수업 진행 예정입니다.",
+        opinion: "보강 결과는 회의록 확인 후 공유하겠습니다.",
+      },
+    ],
+  },
+  {
+    title: "26.04.12 교학 회의록 입니다",
+    author: "김민지",
+    date: "26.04.12",
+    status: "회의 후",
+    agenda: "중간 점검 및 반별 학생 관리 방안 논의",
+    discussion: "학습 부진 학생 지원 계획과 상담 일정 배정을 논의했습니다.",
+    suggestion: "상담 기록 양식을 통일하고 다음 회의에서 진행 상황을 확인합니다.",
+    absenceReports: [
+      {
+        id: 1,
+        author: "이도윤",
+        reason: "외부 연수 참여",
+        opinion: "공유된 안건에 동의합니다.",
+      },
+    ],
+  },
+  {
+    title: "26.04.19 교학 회의록 입니다",
+    author: "박서준",
+    date: "26.04.19",
+    status: "회의 전",
+    agenda: "5월 행사 준비 및 수업 일정 조율",
+    discussion: "행사 전후 수업 변경 가능성과 자료 준비 현황을 확인합니다.",
+    suggestion: "행사 담당자별 준비 항목을 회의 후 공지합니다.",
+    absenceReports: [],
+  },
+];
+
+export const meetingMinutes: MeetingMinute[] = Array.from({ length: 45 }, (_, index) => {
+  const template = meetingTemplates[index % meetingTemplates.length];
+  const id = index + 1;
+
+  return {
+    ...template,
+    id,
+    title: `26.04.${String((index % 24) + 1).padStart(2, "0")} 교학 회의록 입니다`,
+    date: `26.04.${String((index % 24) + 1).padStart(2, "0")}`,
+    status: index % 3 === 0 ? "회의 전" : "회의 후",
+  };
+});
+
+export function getMeetingMinuteById(id: number) {
+  return meetingMinutes.find((minute) => minute.id === id);
+}

--- a/mocks/home.ts
+++ b/mocks/home.ts
@@ -23,7 +23,7 @@ export const headerMenus: HeaderDropdownMenu[] = [
     items: [
       { label: "수업 관리", href: "/staff/class" },
       { label: "재무 관리", href: "/staff/finance" },
-      { label: "자료실", href: "/staff/resources" },
+      { label: "자료실", href: "/staff/archive/rules" },
       { label: "게시판", href: "/staff/board" },
       { label: "학사일정", href: "/staff/calendar" },
     ],


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 자료실 관련 페이지의 UI를 구현하였습니다.
   1920x1080 및 1280x720 레이아웃을 별도로 구성하여, 다양한 크기의 CSS viewport 및 여러 OS 배율에서도 디자인 시안의 의도대로 화면이 구성되도록 반응형 UI로 구현하였습니다.

   1\) 교칙 페이지

   <img width="1917" height="867" alt="스크린샷 2026-05-04 004529" src="https://github.com/user-attachments/assets/4f179566-d9ef-460f-81b1-bf76cb1d51b9" />

   <img width="1919" height="865" alt="스크린샷 2026-05-04 004600" src="https://github.com/user-attachments/assets/a0639e36-3d39-4d18-b002-6969bf8621de" />

   2\) 연락망

   <img width="1898" height="867" alt="스크린샷 2026-05-04 004846" src="https://github.com/user-attachments/assets/3707bfe1-f591-48e6-a845-882494b9a285" />

   <img width="1900" height="863" alt="스크린샷 2026-05-04 004906" src="https://github.com/user-attachments/assets/b181f171-aa9b-4d73-b847-220c4c923de6" />

   <img width="1900" height="866" alt="스크린샷 2026-05-04 004928" src="https://github.com/user-attachments/assets/89ae961a-5033-4568-9c63-c3e6f668dba7" />

   3\) 교학 회의록

   <img width="1919" height="865" alt="스크린샷 2026-05-04 005039" src="https://github.com/user-attachments/assets/a13e1b8c-3bb2-4b88-99a4-d0779d01c65a" />

   <img width="1899" height="866" alt="스크린샷 2026-05-04 005052" src="https://github.com/user-attachments/assets/35a4a900-723f-40fa-bdf5-b0d205112d50" />

   <img width="1899" height="867" alt="스크린샷 2026-05-04 005121" src="https://github.com/user-attachments/assets/86341e1f-7733-4bda-aace-2c7d5eda8be7" />

   <img width="1919" height="867" alt="스크린샷 2026-05-04 005206" src="https://github.com/user-attachments/assets/3e9b0687-90e1-4b65-936c-ebdf2a78507a" />

   4\) 인수인계서, 시험 문제 자료, 서류 양식 (UI 구조 동일)

   <img width="1919" height="865" alt="스크린샷 2026-05-04 005739" src="https://github.com/user-attachments/assets/63fe5760-3e92-40e3-880c-c1d126d11a33" />

   <img width="1900" height="865" alt="스크린샷 2026-05-04 005751" src="https://github.com/user-attachments/assets/da59a720-386a-4f80-9776-338c359a3f7f" />

   <img width="1898" height="867" alt="스크린샷 2026-05-04 005806" src="https://github.com/user-attachments/assets/513ab8e4-16ee-413f-b7e9-e37b5c81b616" />

3. 사이드바, 상단 메뉴 인터랙션을 개선하였습니다.
   섹션 간 페이지 이동 시, 이동한 섹션의 하위 메뉴가 다시 열리고 닫히는 인터랙션을 제거하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #37 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
