### PR TITLE
[FEAT] 게시판 섹션 UI 구현

### DIFF
--- a/api/post/post.dto.ts
+++ b/api/post/post.dto.ts
@@ -50,13 +50,13 @@ export interface PostSummaryResponseDto {
   authorName?: string;
   isPinned?: boolean;
   viewCount?: number;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface PostDetailResponseDto extends PostSummaryResponseDto {
   contentHtml?: string;
   allowComment?: boolean;
-  createdAt?: string;
-  updatedAt?: string;
 }
 
 export interface PostListResponseDto {

--- a/app/board/[postId]/page.tsx
+++ b/app/board/[postId]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import BoardDetailPageClient from "@/components/board/BoardDetailPageClient";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+  searchParams?: Promise<{
+    channelId?: string;
+  }>;
+};
+
+export default async function Page({ params, searchParams }: PageProps) {
+  const { postId } = await params;
+  const resolvedSearchParams = await searchParams;
+  const parsedPostId = Number(postId);
+  const rawChannelId = resolvedSearchParams?.channelId;
+  const parsedChannelId = rawChannelId ? Number(rawChannelId) : undefined;
+
+  if (!Number.isInteger(parsedPostId) || parsedPostId < 1) {
+    notFound();
+  }
+
+  return (
+    <BoardDetailPageClient
+      postId={parsedPostId}
+      channelId={
+        Number.isInteger(parsedChannelId) && parsedChannelId && parsedChannelId > 0
+          ? parsedChannelId
+          : undefined
+      }
+    />
+  );
+}

--- a/app/board/new/page.tsx
+++ b/app/board/new/page.tsx
@@ -1,0 +1,5 @@
+import BoardCreatePageClient from "@/components/board/BoardCreatePageClient";
+
+export default function Page() {
+  return <BoardCreatePageClient />;
+}

--- a/app/board/page.tsx
+++ b/app/board/page.tsx
@@ -1,0 +1,15 @@
+import BoardListPageClient from "@/components/board/BoardListPageClient";
+
+type PageProps = {
+  searchParams?: Promise<{
+    page?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const rawPage = resolvedSearchParams?.page;
+  const initialPage = rawPage ? Number(rawPage) : 1;
+
+  return <BoardListPageClient initialPage={initialPage} />;
+}

--- a/components/board/BoardCreatePageClient.tsx
+++ b/components/board/BoardCreatePageClient.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { IconPaperclip } from "@tabler/icons-react";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { createPost } from "@/api/post/post.api";
+import BoardDropdown from "@/components/board/BoardDropdown";
+import {
+  BOARD_WRITE_TYPE_OPTIONS,
+  type BoardWriteType,
+  getBoardChannelId,
+  getBoardWriteScopeOptions,
+} from "@/components/board/boardOptions";
+import BoardShell from "@/components/board/BoardShell";
+import {
+  ActionButton,
+  BoardSelectRow,
+  DocumentSection,
+  FileSelectLabel,
+  FileUploadPanel,
+  Form,
+  HiddenFileInput,
+  Input,
+  Label,
+  PageTitle,
+  StateMessage,
+  Textarea,
+  Toolbar,
+} from "@/components/board/BoardDocument.styles";
+
+type OpenDropdown = "type" | "scope" | null;
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function toContentHtml(value: string) {
+  return escapeHtml(value).replaceAll("\n", "<br />");
+}
+
+export default function BoardCreatePageClient() {
+  const router = useRouter();
+  const [boardType, setBoardType] = useState<BoardWriteType>("CLASSROOM");
+  const [boardScope, setBoardScope] = useState("cherry-blossom");
+  const [openDropdown, setOpenDropdown] = useState<OpenDropdown>(null);
+  const [title, setTitle] = useState("");
+  const [author, setAuthor] = useState("홍길동");
+  const [content, setContent] = useState("");
+  const [fileNames, setFileNames] = useState<string[]>([]);
+
+  const scopeOptions = getBoardWriteScopeOptions(boardType);
+
+  const { mutate, isPending, isError } = useMutation({
+    mutationFn: () =>
+      createPost(
+        { channelId: getBoardChannelId(boardType, boardScope) },
+        {
+          title: title.trim(),
+          contentHtml: toContentHtml(content.trim()),
+          postType: "GENERAL",
+          status: "PUBLISHED",
+          allowComment: true,
+        },
+      ),
+    onSuccess: () => {
+      router.push("/board");
+    },
+  });
+
+  const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !isPending;
+
+  return (
+    <BoardShell>
+      <DocumentSection>
+        <Toolbar>
+          <PageTitle>글쓰기</PageTitle>
+          <ActionButton type="submit" form="board-create-form" disabled={!canSubmit}>
+            작성 완료
+          </ActionButton>
+        </Toolbar>
+
+        <Form
+          id="board-create-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canSubmit) mutate();
+          }}
+        >
+          <BoardSelectRow aria-label="게시판 선택">
+            <BoardDropdown
+              label="게시판 유형"
+              options={BOARD_WRITE_TYPE_OPTIONS}
+              value={boardType}
+              isOpen={openDropdown === "type"}
+              onToggle={() => setOpenDropdown((current) => (current === "type" ? null : "type"))}
+              onSelect={(nextValue) => {
+                setBoardType(nextValue);
+                setBoardScope(getBoardWriteScopeOptions(nextValue)[0].value);
+                setOpenDropdown(null);
+              }}
+              width="wide"
+            />
+            <BoardDropdown
+              label="게시판 선택"
+              options={scopeOptions}
+              value={boardScope}
+              isOpen={openDropdown === "scope"}
+              onToggle={() => setOpenDropdown((current) => (current === "scope" ? null : "scope"))}
+              onSelect={(nextValue) => {
+                setBoardScope(nextValue);
+                setOpenDropdown(null);
+              }}
+              width="wide"
+            />
+          </BoardSelectRow>
+
+          <Label as="label" htmlFor="board-title">
+            제목
+          </Label>
+          <Input
+            id="board-title"
+            name="title"
+            placeholder="제목"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+
+          <Label as="label" htmlFor="board-author">
+            작성자
+          </Label>
+          <Input
+            id="board-author"
+            name="author"
+            placeholder="홍길동"
+            value={author}
+            onChange={(event) => setAuthor(event.target.value)}
+          />
+
+          <Label as="label" htmlFor="board-content">
+            내용
+          </Label>
+          <Textarea
+            id="board-content"
+            name="content"
+            placeholder="내용"
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+          />
+
+          <Label>자료</Label>
+          <FileUploadPanel>
+            {fileNames.length > 0 ? (
+              fileNames.map((fileName) => <span key={fileName}>{fileName}</span>)
+            ) : (
+              <span>선택된 파일이 없습니다.</span>
+            )}
+            <FileSelectLabel>
+              <IconPaperclip aria-hidden="true" size={16} stroke={2.25} />
+              <span>파일 선택</span>
+              <HiddenFileInput
+                type="file"
+                name="files"
+                multiple
+                onChange={(event) => {
+                  setFileNames(Array.from(event.target.files ?? []).map((file) => file.name));
+                }}
+              />
+            </FileSelectLabel>
+          </FileUploadPanel>
+
+          {isError ? <StateMessage>게시글 작성에 실패했습니다.</StateMessage> : null}
+        </Form>
+      </DocumentSection>
+    </BoardShell>
+  );
+}

--- a/components/board/BoardDetailPageClient.tsx
+++ b/components/board/BoardDetailPageClient.tsx
@@ -21,6 +21,7 @@ import {
   ToolbarRight,
 } from "@/components/board/BoardDocument.styles";
 import { queryKeys } from "@/lib/queryKeys";
+import { getBoardMockPostById } from "@/mocks/boardPosts";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type BoardDetailPageClientProps = {
@@ -47,18 +48,21 @@ export default function BoardDetailPageClient({ postId, channelId }: BoardDetail
     retry: false,
   });
 
-  const metaLabel = data?.channelName ?? "교무기획부";
-  const date = formatUtcToKstShortDate(data?.createdAt ?? data?.updatedAt);
-  const title = data?.title ?? "제목";
-  const author = data?.authorName ?? "홍길동";
-  const content = toPlainText(data?.contentHtml);
-  const stateMessage = !hasChannelId
-    ? "게시글 채널 정보가 없어 상세 내용을 불러오지 못했습니다."
-    : isLoading
-      ? "게시글을 불러오는 중입니다."
-      : isError
-        ? "게시글을 불러오지 못했습니다."
-        : "";
+  const fallbackPost = getBoardMockPostById(postId);
+  const visiblePost = data ?? fallbackPost;
+  const metaLabel = visiblePost?.channelName ?? "교무기획부";
+  const date = formatUtcToKstShortDate(visiblePost?.createdAt ?? visiblePost?.updatedAt);
+  const title = visiblePost?.title ?? "제목";
+  const author = visiblePost?.authorName ?? "홍길동";
+  const content = toPlainText(visiblePost?.contentHtml);
+  const stateMessage =
+    !visiblePost && !hasChannelId
+      ? "게시글 채널 정보가 없어 상세 내용을 불러오지 못했습니다."
+      : isLoading
+        ? "게시글을 불러오는 중입니다."
+        : isError && !visiblePost
+          ? "게시글을 불러오지 못했습니다."
+          : "";
 
   return (
     <BoardShell>

--- a/components/board/BoardDetailPageClient.tsx
+++ b/components/board/BoardDetailPageClient.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { IconDownload } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { getPost } from "@/api/post/post.api";
+import BoardShell from "@/components/board/BoardShell";
+import {
+  ActionButton,
+  ActionLink,
+  ContentStack,
+  DocumentSection,
+  DownloadBadge,
+  FieldBox,
+  FileLink,
+  FileList,
+  Label,
+  MetaBar,
+  StateMessage,
+  TextBox,
+  Toolbar,
+  ToolbarRight,
+} from "@/components/board/BoardDocument.styles";
+import { queryKeys } from "@/lib/queryKeys";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+type BoardDetailPageClientProps = {
+  postId: number;
+  channelId?: number;
+};
+
+function toPlainText(contentHtml?: string) {
+  if (!contentHtml) return "내용";
+
+  return contentHtml
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+}
+
+export default function BoardDetailPageClient({ postId, channelId }: BoardDetailPageClientProps) {
+  const hasChannelId = typeof channelId === "number" && Number.isFinite(channelId);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.posts.boardDetail(channelId ?? 0, postId),
+    queryFn: () => getPost({ channelId: channelId ?? 0, postId }),
+    enabled: hasChannelId,
+    retry: false,
+  });
+
+  const metaLabel = data?.channelName ?? "교무기획부";
+  const date = formatUtcToKstShortDate(data?.createdAt ?? data?.updatedAt);
+  const title = data?.title ?? "제목";
+  const author = data?.authorName ?? "홍길동";
+  const content = toPlainText(data?.contentHtml);
+  const stateMessage = !hasChannelId
+    ? "게시글 채널 정보가 없어 상세 내용을 불러오지 못했습니다."
+    : isLoading
+      ? "게시글을 불러오는 중입니다."
+      : isError
+        ? "게시글을 불러오지 못했습니다."
+        : "";
+
+  return (
+    <BoardShell>
+      <DocumentSection>
+        <Toolbar>
+          <ActionLink href="/board" $variant="muted">
+            목록
+          </ActionLink>
+
+          <ToolbarRight>
+            <ActionButton type="button" $variant="danger">
+              삭제
+            </ActionButton>
+            <ActionLink href="/board/new">수정</ActionLink>
+          </ToolbarRight>
+        </Toolbar>
+
+        {stateMessage ? <StateMessage>{stateMessage}</StateMessage> : null}
+
+        <ContentStack>
+          <MetaBar>
+            <span>{metaLabel}</span>
+            <span>{date}</span>
+          </MetaBar>
+
+          <Label>제목</Label>
+          <FieldBox>{title}</FieldBox>
+
+          <Label>작성자</Label>
+          <FieldBox>{author}</FieldBox>
+
+          <Label>내용</Label>
+          <TextBox>{content}</TextBox>
+
+          <Label>자료</Label>
+          <FileList>
+            <FileLink href="#" aria-label="자료.pdf 다운로드">
+              <span>자료.pdf</span>
+              <DownloadBadge aria-hidden="true">
+                <IconDownload size={16} stroke={2.25} />
+              </DownloadBadge>
+            </FileLink>
+          </FileList>
+        </ContentStack>
+      </DocumentSection>
+    </BoardShell>
+  );
+}

--- a/components/board/BoardDocument.styles.ts
+++ b/components/board/BoardDocument.styles.ts
@@ -1,0 +1,347 @@
+import Link from "next/link";
+import styled, { css } from "styled-components";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export const DocumentSection = styled.section`
+  min-height: 0;
+  overflow: visible;
+  padding: 1.8125rem 3.125rem 4rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    padding: 2.75rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+export const Toolbar = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+  margin-bottom: 2rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+  }
+`;
+
+export const ToolbarRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
+`;
+
+const actionStyle = css<{ $variant?: "default" | "danger" | "muted" }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  border: ${({ $variant }) =>
+    $variant === "muted" || $variant === "default" ? `1px solid ${colors.border}` : 0};
+  border-radius: ${radii.radius15};
+  background-color: ${({ $variant }) =>
+    $variant === "danger"
+      ? colors.noticeSoft
+      : $variant === "muted"
+        ? colors.background
+        : colors.point};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${({ $variant }) =>
+    $variant === "danger" ? colors.notice : $variant === "muted" ? colors.text : colors.white};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.97);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const ActionLink = styled(Link)<{ $variant?: "default" | "danger" | "muted" }>`
+  ${actionStyle}
+`;
+
+export const ActionButton = styled.button<{ $variant?: "default" | "danger" | "muted" }>`
+  ${actionStyle}
+`;
+
+export const PageTitle = styled.h1`
+  margin: 0;
+  color: ${colors.text};
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+export const ContentStack = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+export const MetaBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border-bottom: 1px solid ${colors.borderStrong};
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const Label = styled.h2`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const FieldBox = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 2.6875rem;
+  min-width: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.placeholder};
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  overflow-wrap: anywhere;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const TextBox = styled(FieldBox)`
+  align-items: flex-start;
+  min-height: 6.875rem;
+  white-space: pre-wrap;
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+  }
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+  }
+`;
+
+export const BoardSelectRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    align-items: stretch;
+    flex-direction: column;
+  }
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  min-height: 2.6875rem;
+  border: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  min-height: 6.875rem;
+  resize: vertical;
+  border: 0;
+  background-color: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const FileUploadPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space20};
+  width: 100%;
+  background-color: ${colors.background};
+  padding: ${spacing.space20};
+`;
+
+export const FileSelectLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space8};
+  min-height: 2.1875rem;
+  border: 1px solid ${colors.point};
+  border-radius: ${radii.radius15};
+  background-color: ${colors.pointSoft};
+  padding: 0.625rem 0.9375rem;
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 2.9375rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const HiddenFileInput = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+`;
+
+export const FileList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space16};
+`;
+
+export const FileLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  border: 0;
+  background: transparent;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+export const DownloadBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background-color: ${colors.point};
+  color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+  }
+`;
+
+export const StateMessage = styled.p`
+  margin: 0;
+  padding: ${spacing.space32} 0;
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/board/BoardDropdown.tsx
+++ b/components/board/BoardDropdown.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { IconChevronDown } from "@tabler/icons-react";
+import styled from "styled-components";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+
+export type DropdownOption<T extends string> = {
+  label: string;
+  value: T;
+};
+
+type BoardDropdownProps<T extends string> = {
+  label: string;
+  options: readonly DropdownOption<T>[];
+  value: T;
+  disabled?: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+  onSelect: (value: T) => void;
+  width?: "compact" | "default" | "wide";
+};
+
+export default function BoardDropdown<T extends string>({
+  label,
+  options,
+  value,
+  disabled = false,
+  isOpen,
+  onToggle,
+  onSelect,
+  width = "default",
+}: BoardDropdownProps<T>) {
+  const selectedOption = options.find((option) => option.value === value) ?? options[0];
+
+  return (
+    <DropdownControl $width={width}>
+      <DropdownLabel>{label}</DropdownLabel>
+      <DropdownButton
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        disabled={disabled}
+        onClick={onToggle}
+      >
+        <DropdownButtonText>{selectedOption.label}</DropdownButtonText>
+        <SelectIcon aria-hidden="true" size={18} />
+      </DropdownButton>
+
+      {isOpen ? (
+        <DropdownMenu role="listbox" aria-label={label}>
+          {options.map((option) => (
+            <DropdownOptionButton
+              key={option.value}
+              type="button"
+              role="option"
+              aria-selected={option.value === value}
+              $isSelected={option.value === value}
+              onClick={() => onSelect(option.value)}
+            >
+              {option.label}
+            </DropdownOptionButton>
+          ))}
+        </DropdownMenu>
+      ) : null}
+    </DropdownControl>
+  );
+}
+
+const dropdownWidth = {
+  compact: "9rem",
+  default: "10.5rem",
+  wide: "12rem",
+} as const;
+
+const dropdownWidthLarge = {
+  compact: "12.1875rem",
+  default: "12.5rem",
+  wide: "14.5rem",
+} as const;
+
+const DropdownControl = styled.div<{ $width: "compact" | "default" | "wide" }>`
+  position: relative;
+  z-index: 2;
+  width: ${({ $width }) => dropdownWidth[$width]};
+
+  @media (min-width: 120rem) {
+    width: ${({ $width }) => dropdownWidthLarge[$width]};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;
+
+const DropdownLabel = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+`;
+
+const DropdownButton = styled.button`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 2.1875rem;
+  border: 1px solid ${colors.point};
+  border-radius: 8px;
+  background-color: ${colors.white};
+  color: ${colors.text};
+  cursor: pointer;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  padding: 0.5rem ${spacing.space16};
+  text-align: left;
+
+  &:disabled {
+    border-color: ${colors.border};
+    color: ${colors.muted};
+    cursor: not-allowed;
+  }
+
+  &:disabled svg {
+    color: ${colors.muted};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.75rem;
+    padding: 0.625rem ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const DropdownButtonText = styled.span`
+  min-width: 0;
+  overflow: visible;
+  white-space: nowrap;
+`;
+
+const SelectIcon = styled(IconChevronDown)`
+  flex: 0 0 auto;
+  color: ${colors.point};
+`;
+
+const DropdownMenu = styled.div`
+  position: absolute;
+  left: 0;
+  top: calc(100% + 1px);
+  width: 100%;
+  border: 1px solid ${colors.border};
+  background-color: ${colors.white};
+  box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 8%);
+`;
+
+const DropdownOptionButton = styled.button<{ $isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 2rem;
+  border: 0;
+  background-color: ${({ $isSelected }) => ($isSelected ? colors.pointSoft : colors.white)};
+  color: ${colors.text};
+  cursor: pointer;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  padding: ${spacing.space8} ${spacing.space16};
+  text-align: left;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.75rem;
+    padding: 0.625rem ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/board/BoardListPageClient.tsx
+++ b/components/board/BoardListPageClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
+import type { PostSummaryResponseDto } from "@/api/post/post.dto";
 import { getPosts } from "@/api/post/post.api";
 import BoardDropdown from "@/components/board/BoardDropdown";
 import BoardShell from "@/components/board/BoardShell";
@@ -13,6 +14,7 @@ import {
 } from "@/components/board/boardOptions";
 import ListPanel, { type ListPanelRow } from "@/components/staff/ListPanel";
 import { queryKeys } from "@/lib/queryKeys";
+import { getBoardMockPosts } from "@/mocks/boardPosts";
 import { layout, spacing } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -22,6 +24,31 @@ type OpenDropdown = "type" | "scope" | null;
 type BoardListPageClientProps = {
   initialPage: number;
 };
+
+function isNoticePost(post: PostSummaryResponseDto) {
+  return Boolean(post.isPinned) || post.postType === "NOTICE";
+}
+
+function getPostTime(post: PostSummaryResponseDto) {
+  const dateValue = post.createdAt ?? post.updatedAt;
+  if (!dateValue) return 0;
+
+  const time = new Date(dateValue).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function sortBoardPosts(posts: PostSummaryResponseDto[]) {
+  return [...posts].sort((a, b) => {
+    const aIsNotice = isNoticePost(a);
+    const bIsNotice = isNoticePost(b);
+
+    if (aIsNotice !== bIsNotice) {
+      return aIsNotice ? -1 : 1;
+    }
+
+    return getPostTime(a) - getPostTime(b);
+  });
+}
 
 export default function BoardListPageClient({ initialPage }: BoardListPageClientProps) {
   const [boardType, setBoardType] = useState<BoardType>("all");
@@ -43,17 +70,20 @@ export default function BoardListPageClient({ initialPage }: BoardListPageClient
     retry: false,
   });
 
-  const posts = data?.content ?? [];
-  const totalPages = Math.max(1, data?.totalPages ?? 1);
+  const posts = data?.content?.length ? data.content : getBoardMockPosts({ boardType, boardScope });
+  const sortedPosts = sortBoardPosts(posts);
+  const totalPages = Math.max(1, data?.totalPages ?? Math.ceil(posts.length / POSTS_PER_PAGE));
 
-  const rows: ListPanelRow[] = posts.map((post, index) => {
-    const isNotice = Boolean(post.isPinned) || post.postType === "NOTICE";
+  const generalPosts = sortedPosts.filter((post) => !isNoticePost(post));
+
+  const rows: ListPanelRow[] = sortedPosts.map((post, index) => {
+    const isNotice = isNoticePost(post);
+    const generalPostNumber =
+      (currentPage - 1) * POSTS_PER_PAGE + generalPosts.findIndex((item) => item === post) + 1;
 
     return {
       id: post.id ?? index + 1,
-      no: isNotice
-        ? "공지"
-        : String((currentPage - 1) * POSTS_PER_PAGE + index + 1).padStart(2, "0"),
+      no: isNotice ? "공지" : String(generalPostNumber).padStart(2, "0"),
       className: post.channelName ?? "-",
       title: post.title ?? "제목 없음",
       author: post.authorName ?? "-",
@@ -69,7 +99,7 @@ export default function BoardListPageClient({ initialPage }: BoardListPageClient
   const emptyMessage = isLoading
     ? "게시글을 불러오는 중입니다."
     : isError
-      ? "게시글을 불러오지 못했습니다."
+      ? "임시 게시글을 표시하고 있습니다."
       : "게시글이 없습니다.";
 
   return (

--- a/components/board/BoardListPageClient.tsx
+++ b/components/board/BoardListPageClient.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getPosts } from "@/api/post/post.api";
+import BoardDropdown from "@/components/board/BoardDropdown";
+import BoardShell from "@/components/board/BoardShell";
+import {
+  BOARD_TYPE_OPTIONS,
+  type BoardType,
+  getBoardScopeOptions,
+} from "@/components/board/boardOptions";
+import ListPanel, { type ListPanelRow } from "@/components/staff/ListPanel";
+import { queryKeys } from "@/lib/queryKeys";
+import { layout, spacing } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+const POSTS_PER_PAGE = 8;
+type OpenDropdown = "type" | "scope" | null;
+
+type BoardListPageClientProps = {
+  initialPage: number;
+};
+
+export default function BoardListPageClient({ initialPage }: BoardListPageClientProps) {
+  const [boardType, setBoardType] = useState<BoardType>("all");
+  const [boardScope, setBoardScope] = useState("all");
+  const [openDropdown, setOpenDropdown] = useState<OpenDropdown>(null);
+
+  const currentPage = Number.isInteger(initialPage) && initialPage >= 1 ? initialPage : 1;
+  const scopeOptions = getBoardScopeOptions(boardType);
+  const isScopeDisabled = boardType === "all";
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.posts.boardList(currentPage, boardType, boardScope),
+    queryFn: () =>
+      getPosts({
+        channelType: boardType === "all" ? undefined : boardType,
+        page: currentPage - 1,
+        size: POSTS_PER_PAGE,
+      }),
+    retry: false,
+  });
+
+  const posts = data?.content ?? [];
+  const totalPages = Math.max(1, data?.totalPages ?? 1);
+
+  const rows: ListPanelRow[] = posts.map((post, index) => {
+    const isNotice = Boolean(post.isPinned) || post.postType === "NOTICE";
+
+    return {
+      id: post.id ?? index + 1,
+      no: isNotice
+        ? "공지"
+        : String((currentPage - 1) * POSTS_PER_PAGE + index + 1).padStart(2, "0"),
+      className: post.channelName ?? "-",
+      title: post.title ?? "제목 없음",
+      author: post.authorName ?? "-",
+      date: formatUtcToKstShortDate(post.createdAt ?? post.updatedAt),
+      status: "",
+      detailHref: `/board/${post.id ?? ""}${
+        typeof post.channelId === "number" ? `?channelId=${post.channelId}` : ""
+      }`,
+      isNotice,
+    };
+  });
+
+  const emptyMessage = isLoading
+    ? "게시글을 불러오는 중입니다."
+    : isError
+      ? "게시글을 불러오지 못했습니다."
+      : "게시글이 없습니다.";
+
+  return (
+    <BoardShell>
+      <ListPanel
+        title="게시판"
+        writeLabel="글쓰기"
+        writeHref="/board/new"
+        listPath="/board"
+        rows={rows}
+        currentPage={Math.min(currentPage, totalPages)}
+        totalPages={totalPages}
+        showMineOnlyToggle={false}
+        showStatusColumn={false}
+        classHeader="부서"
+        emptyMessage={emptyMessage}
+        headerTone="archive"
+        filterSlot={
+          <FilterBar aria-label="게시판 필터">
+            <BoardDropdown
+              label="게시판 유형"
+              options={BOARD_TYPE_OPTIONS}
+              value={boardType}
+              isOpen={openDropdown === "type"}
+              onToggle={() => setOpenDropdown((current) => (current === "type" ? null : "type"))}
+              onSelect={(nextValue) => {
+                setBoardType(nextValue);
+                setBoardScope("all");
+                setOpenDropdown(null);
+              }}
+              width="compact"
+            />
+
+            <BoardDropdown
+              label="게시판 선택"
+              options={scopeOptions}
+              value={boardScope}
+              disabled={isScopeDisabled}
+              isOpen={openDropdown === "scope"}
+              onToggle={() =>
+                setOpenDropdown((current) =>
+                  current === "scope" || isScopeDisabled ? null : "scope",
+                )
+              }
+              onSelect={(nextValue) => {
+                setBoardScope(nextValue);
+                setOpenDropdown(null);
+              }}
+              width="compact"
+            />
+          </FilterBar>
+        }
+      />
+    </BoardShell>
+  );
+}
+
+const FilterBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    align-items: stretch;
+    flex-direction: column;
+  }
+`;

--- a/components/board/BoardShell.tsx
+++ b/components/board/BoardShell.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import styled from "styled-components";
+import StaffSidebar from "@/components/staff/StaffSidebar";
+import { colors, layout } from "@/styles/tokens";
+
+type BoardShellProps = {
+  children: ReactNode;
+};
+
+export default function BoardShell({ children }: BoardShellProps) {
+  return (
+    <Main>
+      <Stage>
+        <StaffSidebar />
+        <Content>{children}</Content>
+      </Stage>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.white};
+`;
+
+const Stage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const Content = styled.section`
+  flex: 1;
+  min-width: 0;
+`;

--- a/components/board/boardOptions.ts
+++ b/components/board/boardOptions.ts
@@ -1,0 +1,88 @@
+export const BOARD_TYPE_OPTIONS = [
+  { label: "전체", value: "all" },
+  { label: "반별", value: "CLASSROOM" },
+  { label: "부서별", value: "DEPARTMENT" },
+] as const;
+
+export const BOARD_WRITE_TYPE_OPTIONS = [
+  { label: "반별 게시판", value: "CLASSROOM" },
+  { label: "부서별 게시판", value: "DEPARTMENT" },
+] as const;
+
+export const CLASSROOM_SCOPE_OPTIONS = [
+  { label: "전체", value: "all" },
+  { label: "벛꽃반", value: "cherry-blossom" },
+  { label: "개나리반", value: "forsythia" },
+  { label: "민들레반", value: "dandelion" },
+  { label: "장미반", value: "rose" },
+  { label: "해바라기반", value: "sunflower" },
+  { label: "국화반", value: "chrysanthemum" },
+  { label: "씨앗반", value: "seed" },
+  { label: "새싹반", value: "sprout" },
+  { label: "나무반", value: "tree" },
+  { label: "열매반", value: "fruit" },
+  { label: "스마트폰반", value: "smartphone" },
+] as const;
+
+export const DEPARTMENT_SCOPE_OPTIONS = [
+  { label: "전체", value: "all" },
+  { label: "교무기획부", value: "academic-planning" },
+  { label: "교육연구부", value: "education-research" },
+  { label: "생활안전부", value: "student-safety" },
+  { label: "총무부", value: "general-affairs" },
+] as const;
+
+export const EMPTY_SCOPE_OPTIONS = [{ label: "전체", value: "all" }] as const;
+export const CLASSROOM_WRITE_SCOPE_OPTIONS = CLASSROOM_SCOPE_OPTIONS.filter(
+  (option) => option.value !== "all",
+);
+export const DEPARTMENT_WRITE_SCOPE_OPTIONS = DEPARTMENT_SCOPE_OPTIONS.filter(
+  (option) => option.value !== "all",
+);
+
+export type BoardType = (typeof BOARD_TYPE_OPTIONS)[number]["value"];
+export type BoardWriteType = (typeof BOARD_WRITE_TYPE_OPTIONS)[number]["value"];
+export type BoardDropdownValue =
+  | BoardType
+  | BoardWriteType
+  | (typeof CLASSROOM_SCOPE_OPTIONS)[number]["value"]
+  | (typeof DEPARTMENT_SCOPE_OPTIONS)[number]["value"];
+
+export function getBoardScopeOptions(boardType: BoardType | BoardWriteType) {
+  if (boardType === "CLASSROOM") return CLASSROOM_SCOPE_OPTIONS;
+  if (boardType === "DEPARTMENT") return DEPARTMENT_SCOPE_OPTIONS;
+  return EMPTY_SCOPE_OPTIONS;
+}
+
+export function getBoardWriteScopeOptions(boardType: BoardWriteType) {
+  return boardType === "CLASSROOM" ? CLASSROOM_WRITE_SCOPE_OPTIONS : DEPARTMENT_WRITE_SCOPE_OPTIONS;
+}
+
+const classroomChannelIds: Record<string, number> = {
+  all: 100,
+  "cherry-blossom": 101,
+  forsythia: 102,
+  dandelion: 103,
+  rose: 104,
+  sunflower: 105,
+  chrysanthemum: 106,
+  seed: 107,
+  sprout: 108,
+  tree: 109,
+  fruit: 110,
+  smartphone: 111,
+};
+
+const departmentChannelIds: Record<string, number> = {
+  all: 200,
+  "academic-planning": 201,
+  "education-research": 202,
+  "student-safety": 203,
+  "general-affairs": 204,
+};
+
+export function getBoardChannelId(boardType: BoardWriteType, boardScope: string) {
+  return boardType === "CLASSROOM"
+    ? (classroomChannelIds[boardScope] ?? classroomChannelIds.all)
+    : (departmentChannelIds[boardScope] ?? departmentChannelIds.all);
+}

--- a/components/staff/ListPanel.tsx
+++ b/components/staff/ListPanel.tsx
@@ -12,6 +12,7 @@ export type ListPanelRow = {
   date: string;
   status: string;
   detailHref: string;
+  isNotice?: boolean;
 };
 
 type ListPanelTone = "default" | "journal" | "finance" | "archive";
@@ -29,9 +30,11 @@ type ListPanelProps = {
   emptyMessage?: string;
   headerTone?: ListPanelTone;
   showClassColumn?: boolean;
+  classHeader?: string;
   showStatusColumn?: boolean;
   statusHeader?: string;
   writeIcon?: ReactNode;
+  filterSlot?: ReactNode;
 };
 
 type QueryValue = string | number | boolean;
@@ -65,9 +68,11 @@ export default function ListPanel({
   emptyMessage = "목록이 없습니다.",
   headerTone = "default",
   showClassColumn = true,
+  classHeader = "반",
   showStatusColumn = true,
   statusHeader = "신청 현황",
   writeIcon,
+  filterSlot,
 }: ListPanelProps) {
   const prevPage = Math.max(1, currentPage - 1);
   const nextPage = Math.min(totalPages, currentPage + 1);
@@ -84,6 +89,8 @@ export default function ListPanel({
         </WriteButton>
       </HeaderRow>
 
+      {filterSlot ? <FilterSlot>{filterSlot}</FilterSlot> : null}
+
       <TableSection>
         <Table>
           <thead>
@@ -93,7 +100,7 @@ export default function ListPanel({
               </Th>
               {showClassColumn ? (
                 <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
-                  반
+                  {classHeader}
                 </Th>
               ) : null}
               <Th $tone={headerTone}>제목</Th>
@@ -115,7 +122,7 @@ export default function ListPanel({
             {rows.length > 0 ? (
               rows.map((row) => (
                 <Tr key={row.id} $tone={headerTone}>
-                  <Td $width720="3.75rem" $width1080="5.5rem">
+                  <Td $width720="3.75rem" $width1080="5.5rem" $isNotice={row.isNotice}>
                     {row.no}
                   </Td>
                   {showClassColumn ? (
@@ -326,6 +333,14 @@ const TableSection = styled.section`
   width: 100%;
 `;
 
+const FilterSlot = styled.div`
+  margin-bottom: 1.25rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 1.875rem;
+  }
+`;
+
 const Table = styled.table`
   width: 100%;
   border-collapse: collapse;
@@ -354,10 +369,12 @@ const Tr = styled.tr<{ $tone: ListPanelTone }>`
     ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
 `;
 
-const Td = styled.td<{ $width720?: string; $width1080?: string }>`
+const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: boolean }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
   padding: 0.65625rem ${spacing.space12};
+  color: ${({ $isNotice }) => ($isNotice ? colors.notice : colors.text)};
   font-size: ${typography.fontSize14};
+  font-weight: ${({ $isNotice }) => ($isNotice ? 700 : 400)};
   text-align: center;
   white-space: nowrap;
 

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,6 +1,10 @@
 export const queryKeys = {
   posts: {
     noticeTop12: () => ["posts", "notice", "top12"] as const,
+    boardList: (page: number, channelType: string, boardScope: string) =>
+      ["posts", "board", { page, channelType, boardScope }] as const,
+    boardDetail: (channelId: number, postId: number) =>
+      ["posts", "board", "detail", { channelId, postId }] as const,
   },
   lessons: {
     weekly: (from: string, to: string) => ["lessons", "weekly", { from, to }] as const,

--- a/mocks/boardPosts.ts
+++ b/mocks/boardPosts.ts
@@ -1,0 +1,152 @@
+import type { ChannelType } from "@/api/channel/channel.dto";
+import type { PostDetailResponseDto, PostSummaryResponseDto } from "@/api/post/post.dto";
+
+export type BoardMockPost = PostDetailResponseDto & {
+  channelType: ChannelType;
+  boardScope: string;
+};
+
+export const boardMockPosts: BoardMockPost[] = [
+  {
+    id: 1,
+    channelId: 201,
+    channelName: "교무기획부",
+    channelType: "DEPARTMENT",
+    boardScope: "academic-planning",
+    title: "5월 교무 일정 공유드립니다",
+    postType: "NOTICE",
+    status: "PUBLISHED",
+    authorId: 1,
+    authorName: "김민정",
+    isPinned: true,
+    viewCount: 28,
+    contentHtml: "<p>5월 교무 일정과 제출 자료 마감일을 확인해 주세요.</p>",
+    allowComment: true,
+    createdAt: "2026-05-01T09:00:00",
+    updatedAt: "2026-05-01T09:00:00",
+  },
+  {
+    id: 2,
+    channelId: 202,
+    channelName: "교육연구부",
+    channelType: "DEPARTMENT",
+    boardScope: "education-research",
+    title: "기초 문해 수업 자료 회람",
+    postType: "GENERAL",
+    status: "PUBLISHED",
+    authorId: 2,
+    authorName: "박서연",
+    isPinned: false,
+    viewCount: 14,
+    contentHtml: "<p>이번 주 기초 문해 수업 자료를 공유합니다.</p>",
+    allowComment: true,
+    createdAt: "2026-05-02T13:30:00",
+    updatedAt: "2026-05-02T13:30:00",
+  },
+  {
+    id: 3,
+    channelId: 203,
+    channelName: "생활안전부",
+    channelType: "DEPARTMENT",
+    boardScope: "student-safety",
+    title: "야간 하교 지도 협조 요청",
+    postType: "GENERAL",
+    status: "PUBLISHED",
+    authorId: 3,
+    authorName: "이준호",
+    isPinned: false,
+    viewCount: 9,
+    contentHtml: "<p>야간 하교 시간 안전 지도를 위해 교실별 담당자를 확인해 주세요.</p>",
+    allowComment: true,
+    createdAt: "2026-05-03T18:10:00",
+    updatedAt: "2026-05-03T18:10:00",
+  },
+  {
+    id: 4,
+    channelId: 204,
+    channelName: "총무부",
+    channelType: "DEPARTMENT",
+    boardScope: "general-affairs",
+    title: "소모품 신청 내역 확인",
+    postType: "GENERAL",
+    status: "PUBLISHED",
+    authorId: 4,
+    authorName: "최유진",
+    isPinned: false,
+    viewCount: 7,
+    contentHtml: "<p>각 반에서 요청한 소모품 신청 내역을 확인했습니다.</p>",
+    allowComment: true,
+    createdAt: "2026-05-04T10:20:00",
+    updatedAt: "2026-05-04T10:20:00",
+  },
+  {
+    id: 5,
+    channelId: 102,
+    channelName: "개나리반",
+    channelType: "CLASSROOM",
+    boardScope: "forsythia",
+    title: "개나리반 수학 보충 자료",
+    postType: "GENERAL",
+    status: "PUBLISHED",
+    authorId: 5,
+    authorName: "홍길동",
+    isPinned: false,
+    viewCount: 11,
+    contentHtml: "<p>개나리반 수학 보충 자료와 다음 수업 준비물을 안내합니다.</p>",
+    allowComment: true,
+    createdAt: "2026-05-04T11:00:00",
+    updatedAt: "2026-05-04T11:00:00",
+  },
+  {
+    id: 6,
+    channelId: 104,
+    channelName: "장미반",
+    channelType: "CLASSROOM",
+    boardScope: "rose",
+    title: "장미반 받아쓰기 안내",
+    postType: "GENERAL",
+    status: "PUBLISHED",
+    authorId: 6,
+    authorName: "정하늘",
+    isPinned: false,
+    viewCount: 6,
+    contentHtml: "<p>이번 주 장미반 받아쓰기 범위와 연습 방법입니다.</p>",
+    allowComment: true,
+    createdAt: "2026-05-04T12:10:00",
+    updatedAt: "2026-05-04T12:10:00",
+  },
+];
+
+function getBoardPostTime(post: PostSummaryResponseDto) {
+  const time = new Date(post.createdAt ?? post.updatedAt ?? "").getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+export function getBoardMockPosts({
+  boardType,
+  boardScope,
+}: {
+  boardType: string;
+  boardScope: string;
+}): PostSummaryResponseDto[] {
+  return boardMockPosts
+    .filter((post) => {
+      const matchesType = boardType === "all" || post.channelType === boardType;
+      const matchesScope = boardScope === "all" || post.boardScope === boardScope;
+      return matchesType && matchesScope;
+    })
+    .sort((a, b) => {
+      const aIsNotice = Boolean(a.isPinned) || a.postType === "NOTICE";
+      const bIsNotice = Boolean(b.isPinned) || b.postType === "NOTICE";
+
+      if (aIsNotice !== bIsNotice) {
+        return aIsNotice ? -1 : 1;
+      }
+
+      return getBoardPostTime(a) - getBoardPostTime(b);
+    });
+}
+
+export function getBoardMockPostById(postId: number) {
+  return boardMockPosts.find((post) => post.id === postId);
+}

--- a/mocks/handlers/post.handlers.ts
+++ b/mocks/handlers/post.handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http, type RequestHandler } from "msw";
 
 import type { CreatePostRequestDto, UpdatePostRequestDto } from "../../api/post/post.dto";
+import { boardMockPosts, getBoardMockPostById, getBoardMockPosts } from "../boardPosts";
 import { API_BASE_URL, REFRESHED_ACCESS_TOKEN, VALID_ACCESS_TOKEN } from "./auth.handlers";
 
 export const POST_SUMMARY_RESPONSE = {
@@ -26,10 +27,10 @@ export const POST_DETAIL_RESPONSE = {
 };
 
 export const POST_LIST_RESPONSE = {
-  content: [POST_SUMMARY_RESPONSE],
+  content: boardMockPosts,
   page: 0,
-  size: 10,
-  totalElements: 1,
+  size: boardMockPosts.length,
+  totalElements: boardMockPosts.length,
   totalPages: 1,
 };
 
@@ -47,21 +48,45 @@ export const postHandlers: RequestHandler[] = [
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    return HttpResponse.json(POST_LIST_RESPONSE);
+    const url = new URL(request.url);
+    const channelType = url.searchParams.get("channelType") ?? "all";
+
+    const content = getBoardMockPosts({
+      boardType: channelType,
+      boardScope: "all",
+    });
+
+    return HttpResponse.json({
+      ...POST_LIST_RESPONSE,
+      content,
+      totalElements: content.length,
+      totalPages: 1,
+    });
   }),
   http.get(`${API_BASE_URL}/api/v1/channels/:channelId/posts`, ({ request, params }) => {
     if (!hasValidAuthorization(request)) {
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
+    const channelId = Number(params.channelId);
+    const matchedPosts = boardMockPosts
+      .filter((post) => post.channelId === channelId)
+      .map((post) => ({ ...post, channelId }));
+    const content =
+      matchedPosts.length > 0
+        ? matchedPosts
+        : [
+            {
+              ...POST_SUMMARY_RESPONSE,
+              channelId,
+            },
+          ];
+
     return HttpResponse.json({
       ...POST_LIST_RESPONSE,
-      content: [
-        {
-          ...POST_SUMMARY_RESPONSE,
-          channelId: Number(params.channelId),
-        },
-      ],
+      content,
+      totalElements: content.length,
+      totalPages: 1,
     });
   }),
   http.post(`${API_BASE_URL}/api/v1/channels/:channelId/posts`, async ({ request, params }) => {
@@ -87,10 +112,20 @@ export const postHandlers: RequestHandler[] = [
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
+    const postId = Number(params.postId);
+    const channelId = Number(params.channelId);
+
+    if (channelId === 1 && postId === 1) {
+      return HttpResponse.json(POST_DETAIL_RESPONSE);
+    }
+
+    const mockPost = getBoardMockPostById(postId);
+
     return HttpResponse.json({
       ...POST_DETAIL_RESPONSE,
-      channelId: Number(params.channelId),
-      id: Number(params.postId),
+      ...mockPost,
+      channelId,
+      id: postId,
     });
   }),
   http.put(

--- a/mocks/home.ts
+++ b/mocks/home.ts
@@ -19,22 +19,19 @@ export const headerMenus: HeaderDropdownMenu[] = [
   },
   {
     label: "교원",
-    href: "/staff",
+    href: "/staff/class",
     items: [
       { label: "수업 관리", href: "/staff/class" },
       { label: "재무 관리", href: "/staff/finance" },
       { label: "자료실", href: "/staff/archive/rules" },
-      { label: "게시판", href: "/staff/board" },
+      { label: "게시판", href: "/board" },
       { label: "학사일정", href: "/staff/calendar" },
     ],
   },
   {
     label: "신규 등록",
     href: "/register",
-    items: [
-      { label: "교사 신청", href: "/register/teacher" },
-      { label: "학생 등록", href: "/register/student" },
-    ],
+    items: [{ label: "교사 신청", href: "/register/teacher" }],
   },
 ];
 

--- a/styles/tokens.ts
+++ b/styles/tokens.ts
@@ -2,9 +2,14 @@ export const colors = {
   white: "#FFFFFF",
   background: "#F8F8F8",
   point: "#88CD5A",
+  pointSoft: "#EEF9E6",
+  noticeSoft: "#FDE4E2",
   border: "#D3D3D3",
+  borderStrong: "#B4B4B4",
   muted: "#C0C0C0",
+  placeholder: "#949494",
   text: "#222222",
+  notice: "#DA3A30",
 };
 
 export const spacing = {


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 교원 게시판 UI를 구현하였습니다.
   1920x1080 및 1280x720 레이아웃을 별도로 구성하여, 다양한 크기의 CSS viewport 및 여러 OS 배율에서도 디자인 시안의 의도대로 화면이 구성되도록 반응형 UI로 구현하였습니다.

   1\) 목록

   <img width="1919" height="866" alt="스크린샷 2026-05-04 145502" src="https://github.com/user-attachments/assets/4dc7213b-7ff7-4636-8605-f123183f794f" />

   <img width="1919" height="864" alt="스크린샷 2026-05-04 145816" src="https://github.com/user-attachments/assets/fa754042-1209-4b08-979f-acf44ab8ba0a" />

   2\) 본문

   <img width="1898" height="866" alt="스크린샷 2026-05-04 145531" src="https://github.com/user-attachments/assets/0713819d-bb07-4abe-938d-c7ac7e5475be" />

   3\) 글쓰기

   <img width="1898" height="869" alt="스크린샷 2026-05-04 144518" src="https://github.com/user-attachments/assets/ab6431b5-7f82-43ea-8471-05525dde901d" />

2. 상단 메뉴 링크 수정
   상단 `교원` 메뉴 클릭 시 `/staff/class`로 이동하도록 변경하였습니다.
   교원 드롭다운의 `게시판` 링크를 `/board`로 변경하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #40 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
