### PR TITLE
[FEAT] Apps script를 통한 google sheet와 수업 일지 연동 기능 구현

### DIFF
--- a/components/staff/ClassJournalCreatePage.tsx
+++ b/components/staff/ClassJournalCreatePage.tsx
@@ -3,9 +3,10 @@
 import { useState, type FormEvent } from "react";
 import styled from "styled-components";
 import {
-  sendClassNoteInfoToGoogleSheet,
-  type SendClassNoteInfoToGoogleSheetPayload,
-} from "@/lib/sendClassNoteInfoToGoogleSheet";
+  buildSendClassNotePayloadFromFormData,
+  formatPhone,
+} from "@/lib/googleSheet/classJournalSheetPayload";
+import { sendClassNoteInfoToGoogleSheet } from "@/lib/googleSheet/sendClassNoteInfoToGoogleSheet";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const teacherFields = [
@@ -20,26 +21,6 @@ const teacherFields = [
 const lessonPeriods = [1, 2, 3] as const;
 const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
 
-function getDayLabel(dateValue: string) {
-  if (!dateValue) return "";
-
-  const date = new Date(dateValue);
-  if (Number.isNaN(date.getTime())) return "";
-
-  return ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
-}
-
-function formatPhone(value: string) {
-  const numbers = value.replace(/\D/g, "");
-
-  if (numbers.length < 4) return numbers;
-  if (numbers.length < 8) {
-    return numbers.replace(/(\d{3})(\d+)/, "$1-$2");
-  }
-
-  return numbers.replace(/(\d{3})(\d{4})(\d+)/, "$1-$2-$3");
-}
-
 export default function ClassJournalCreatePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -50,22 +31,7 @@ export default function ClassJournalCreatePage() {
 
     const form = event.currentTarget;
     const formData = new FormData(form);
-
-    const activityDate = String(formData.get("activityDate") ?? "").trim();
-
-    const payload: SendClassNoteInfoToGoogleSheetPayload = {
-      name: String(formData.get("writer") ?? "").trim(),
-      birth: String(formData.get("birthPrefix") ?? "").trim(),
-      phone: String(formData.get("phone") ?? "").trim(),
-      volunteerNote: String(formData.get("className") ?? "").trim(),
-      agree: formData.get("privacyConsent") ? "동의" : "미동의",
-      date: activityDate,
-      time: String(formData.get("activityTime") ?? "").trim(),
-      day: getDayLabel(activityDate),
-      period1: String(formData.get("lesson1") ?? "").trim(),
-      period2: String(formData.get("lesson2") ?? "").trim(),
-      period3: String(formData.get("lesson3") ?? "").trim(),
-    };
+    const payload = buildSendClassNotePayloadFromFormData(formData);
 
     if (!payload.date) {
       window.alert("활동 일자를 입력해 주세요.");

--- a/components/staff/ClassJournalCreatePage.tsx
+++ b/components/staff/ClassJournalCreatePage.tsx
@@ -1,6 +1,11 @@
 "use client";
 
+import { useState, type FormEvent } from "react";
 import styled from "styled-components";
+import {
+  sendClassNoteInfoToGoogleSheet,
+  type SendClassNoteInfoToGoogleSheetPayload,
+} from "@/lib/sendClassNoteInfoToGoogleSheet";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const teacherFields = [
@@ -15,7 +20,82 @@ const teacherFields = [
 const lessonPeriods = [1, 2, 3] as const;
 const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
 
+function getDayLabel(dateValue: string) {
+  if (!dateValue) return "";
+
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+}
+
+function formatPhone(value: string) {
+  const numbers = value.replace(/\D/g, "");
+
+  if (numbers.length < 4) return numbers;
+  if (numbers.length < 8) {
+    return numbers.replace(/(\d{3})(\d+)/, "$1-$2");
+  }
+
+  return numbers.replace(/(\d{3})(\d{4})(\d+)/, "$1-$2-$3");
+}
+
 export default function ClassJournalCreatePage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isSubmitting) return;
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const activityDate = String(formData.get("activityDate") ?? "").trim();
+
+    const payload: SendClassNoteInfoToGoogleSheetPayload = {
+      name: String(formData.get("writer") ?? "").trim(),
+      birth: String(formData.get("birthPrefix") ?? "").trim(),
+      phone: String(formData.get("phone") ?? "").trim(),
+      volunteerNote: String(formData.get("className") ?? "").trim(),
+      agree: formData.get("privacyConsent") ? "동의" : "미동의",
+      date: activityDate,
+      time: String(formData.get("activityTime") ?? "").trim(),
+      day: getDayLabel(activityDate),
+      period1: String(formData.get("lesson1") ?? "").trim(),
+      period2: String(formData.get("lesson2") ?? "").trim(),
+      period3: String(formData.get("lesson3") ?? "").trim(),
+    };
+
+    if (!payload.date) {
+      window.alert("활동 일자를 입력해 주세요.");
+      return;
+    }
+
+    if (!payload.name) {
+      window.alert("성명을 입력해 주세요.");
+      return;
+    }
+
+    if (!payload.agree || payload.agree === "미동의") {
+      window.alert("개인정보 제공 동의가 필요합니다.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await sendClassNoteInfoToGoogleSheet(payload);
+      window.alert("수업 일지가 구글 시트에 저장되었습니다.");
+      form.reset();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "수업 일지 전송에 실패했습니다.";
+      window.alert(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <PageSection>
       <HeaderRow>
@@ -25,18 +105,30 @@ export default function ClassJournalCreatePage() {
             <ConsentCheckbox type="checkbox" name="privacyConsent" form="class-journal-form" />
             <span>정보 제공 동의</span>
           </ConsentLabel>
-          <SubmitButton type="submit" form="class-journal-form">
-            수업 일지 제출하기
+          <SubmitButton type="submit" form="class-journal-form" disabled={isSubmitting}>
+            {isSubmitting ? "제출 중..." : "수업 일지 제출하기"}
           </SubmitButton>
         </HeaderActions>
       </HeaderRow>
 
-      <Form id="class-journal-form">
+      <Form id="class-journal-form" onSubmit={handleSubmit}>
         <InfoGrid>
           {teacherFields.map((field) => (
             <InfoField key={field.id}>
               <FieldLabel htmlFor={field.id}>{field.label}</FieldLabel>
-              <FieldInput id={field.id} name={field.id} placeholder={field.placeholder} />
+              <FieldInput
+                id={field.id}
+                name={field.id}
+                type={field.id === "activityDate" ? "date" : "text"}
+                placeholder={field.placeholder}
+                onChange={
+                  field.id === "phone"
+                    ? (e) => {
+                        e.target.value = formatPhone(e.target.value);
+                      }
+                    : undefined
+                }
+              />
             </InfoField>
           ))}
         </InfoGrid>

--- a/lib/googleSheet/classJournalSheetPayload.ts
+++ b/lib/googleSheet/classJournalSheetPayload.ts
@@ -1,0 +1,41 @@
+import type { SendClassNoteInfoToGoogleSheetPayload } from "@/lib/googleSheet/sendClassNoteInfoToGoogleSheet";
+
+export function getDayLabel(dateValue: string) {
+  if (!dateValue) return "";
+
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+}
+
+export function formatPhone(value: string) {
+  const numbers = value.replace(/\D/g, "");
+
+  if (numbers.length < 4) return numbers;
+  if (numbers.length < 8) {
+    return numbers.replace(/(\d{3})(\d+)/, "$1-$2");
+  }
+
+  return numbers.replace(/(\d{3})(\d{4})(\d+)/, "$1-$2-$3");
+}
+
+export function buildSendClassNotePayloadFromFormData(
+  formData: FormData,
+): SendClassNoteInfoToGoogleSheetPayload {
+  const activityDate = String(formData.get("activityDate") ?? "").trim();
+
+  return {
+    name: String(formData.get("writer") ?? "").trim(),
+    birth: String(formData.get("birthPrefix") ?? "").trim(),
+    phone: String(formData.get("phone") ?? "").trim(),
+    volunteerNote: String(formData.get("className") ?? "").trim(),
+    agree: formData.get("privacyConsent") ? "동의" : "미동의",
+    date: activityDate,
+    time: String(formData.get("activityTime") ?? "").trim(),
+    day: getDayLabel(activityDate),
+    period1: String(formData.get("lesson1") ?? "").trim(),
+    period2: String(formData.get("lesson2") ?? "").trim(),
+    period3: String(formData.get("lesson3") ?? "").trim(),
+  };
+}

--- a/lib/googleSheet/sendClassNoteInfoToGoogleSheet.ts
+++ b/lib/googleSheet/sendClassNoteInfoToGoogleSheet.ts
@@ -34,7 +34,7 @@ export async function sendClassNoteInfoToGoogleSheet(
   try {
     data = JSON.parse(text);
   } catch {
-    throw new Error("응답이 JSON이 아님");
+    throw new Error("응답이 JSON이 아닙니다");
   }
 
   if (!data.success) {

--- a/lib/sendClassNoteInfoToGoogleSheet.ts
+++ b/lib/sendClassNoteInfoToGoogleSheet.ts
@@ -1,0 +1,45 @@
+export type SendClassNoteInfoToGoogleSheetPayload = {
+  name: string;
+  birth: string;
+  phone: string;
+  volunteerNote: string;
+  agree: string;
+  date: string;
+  time: string;
+  day: string;
+  period1: string;
+  period2: string;
+  period3: string;
+};
+
+const GOOGLE_APPS_SCRIPT_URL =
+  "https://script.google.com/macros/s/AKfycbxAQTwUuRT6X7Hysjhxnx1rp_Env0P-0xPIVuoUXjJtP-EZruBJOEEqDxXbRVpJkxpxFg/exec";
+
+export async function sendClassNoteInfoToGoogleSheet(
+  payload: SendClassNoteInfoToGoogleSheetPayload,
+) {
+  const res = await fetch(GOOGLE_APPS_SCRIPT_URL, {
+    method: "POST",
+    redirect: "follow",
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new Error(`요청 실패: ${res.status}`);
+  }
+
+  const text = await res.text();
+
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error("응답이 JSON이 아님");
+  }
+
+  if (!data.success) {
+    throw new Error(data.message ?? "구글 시트 저장 실패");
+  }
+
+  return data;
+}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 수업 일지 작성 폼 구현
- 폼 입력값 → JSON payload 변환 후 Apps Script로 POST 요청
- Apps Script를 통해 Google Spreadsheet에 데이터 저장
- 필수값 및 개인정보 동의 여부 검증 로직 추가
- Google Sheet 전송 로직을 `lib/googleSheet`로 분리
 
[기존 저장 포멧]
<img width="987" height="263" alt="스크린샷 2026-05-06 오전 12 26 44" src="https://github.com/user-attachments/assets/cd159543-99e2-4d81-a303-dd0dd9bbc34e" />

[현재 저장 포멧]
<img width="1363" height="402" alt="스크린샷 2026-05-06 오전 12 26 20" src="https://github.com/user-attachments/assets/e6aec09e-2f97-4401-8e34-6ff076cccf96" />

- 순번 1-7까지는 실험 중 데이터이고, 8-10은 확정된 데이터 포멧입니다. 

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

- Closes #44 

## 💬 기타 사항

- 시트에서의 저장은 년도와 월이 `2026-05` 이름으로 저장되며, 새로운 달로 넘어갈 시 새로운 시트를 자동으로 생성하고 최초의 경우에만 헤더가 생성되도록 구현하였습니다.
- 주민번호 앞자리/연락처의 앞자리 `0`이 google sheet에서 자동으로 숫자로 감지되어 000805로 입력시 805로 자동 저장되는 문제가 발생하여 맨 앞의 0이 유지되도록 문자열 처리 및 시트 텍스트 포맷을 적용하였습니다.
- 활동일자를 기반으로 요일을 계산하여 함께 저장하였습니다.
- 출석부는 추가의 sheet에 새로 구현할 예정입니다. 

## 📂 참고 자료

> N/A