### PR TITLE
[FEAT] Apps script를 통한 google sheet와 수업 일지 출석부 연동 기능 구현

### DIFF
--- a/components/staff/ClassJournalCreatePage.tsx
+++ b/components/staff/ClassJournalCreatePage.tsx
@@ -5,8 +5,9 @@ import styled from "styled-components";
 import {
   buildSendClassNotePayloadFromFormData,
   formatPhone,
-} from "@/lib/googleSheet/classJournalSheetPayload";
-import { sendClassNoteInfoToGoogleSheet } from "@/lib/googleSheet/sendClassNoteInfoToGoogleSheet";
+} from "@/lib/googleSheet/classJournal/classJournalSheetPayload";
+import { sendClassAttendanceToGoogleSheet } from "@/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet";
+import { sendClassJournalToGoogleSheet } from "@/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const teacherFields = [
@@ -32,6 +33,19 @@ export default function ClassJournalCreatePage() {
     const form = event.currentTarget;
     const formData = new FormData(form);
     const payload = buildSendClassNotePayloadFromFormData(formData);
+    const className = String(formData.get("className") || "").trim();
+
+    const attendances = Array.from({ length: 10 }, (_, index) => {
+      const name = String(formData.get(`studentName${index + 1}`) || "").trim();
+      const status = String(formData.get(`attendanceStatus${index + 1}`) || "").trim();
+
+      if (!name) return null;
+
+      return {
+        name,
+        status: status || "출석",
+      };
+    }).filter((attendance): attendance is { name: string; status: string } => attendance !== null);
 
     if (!payload.date) {
       window.alert("활동 일자를 입력해 주세요.");
@@ -51,8 +65,17 @@ export default function ClassJournalCreatePage() {
     setIsSubmitting(true);
 
     try {
-      await sendClassNoteInfoToGoogleSheet(payload);
-      window.alert("수업 일지가 구글 시트에 저장되었습니다.");
+      await sendClassJournalToGoogleSheet(payload);
+
+      if (attendances.length > 0) {
+        await sendClassAttendanceToGoogleSheet({
+          date: payload.date,
+          className,
+          attendances,
+        });
+      }
+
+      window.alert("수업 일지와 출석부가 구글 시트에 저장되었습니다.");
       form.reset();
     } catch (err) {
       const message = err instanceof Error ? err.message : "수업 일지 전송에 실패했습니다.";

--- a/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
+++ b/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
@@ -1,0 +1,23 @@
+const GOOGLE_APPS_SCRIPT_URL =
+  "https://script.google.com/macros/s/AKfycbxZ9VY6A9rXkNInZnXt_cSO6SVgkd196DV7_mfqeXJViUmFSVgSRfvM9tX9oOy63P-n7Q/exec";
+
+export async function sendClassAttendanceToGoogleSheet(payload: {
+  date: string;
+  className: string;
+  attendances: {
+    name: string;
+    status: string;
+  }[];
+}) {
+  const response = await fetch(GOOGLE_APPS_SCRIPT_URL, {
+    method: "POST",
+    redirect: "follow",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error("출석 저장 실패");
+  }
+
+  return response.json();
+}

--- a/lib/googleSheet/classJournal/classJournalSheetPayload.ts
+++ b/lib/googleSheet/classJournal/classJournalSheetPayload.ts
@@ -1,4 +1,4 @@
-import type { SendClassNoteInfoToGoogleSheetPayload } from "@/lib/googleSheet/sendClassNoteInfoToGoogleSheet";
+import type { SendClassJournalToGoogleSheetPayload } from "@/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet";
 
 export function getDayLabel(dateValue: string) {
   if (!dateValue) return "";
@@ -22,7 +22,7 @@ export function formatPhone(value: string) {
 
 export function buildSendClassNotePayloadFromFormData(
   formData: FormData,
-): SendClassNoteInfoToGoogleSheetPayload {
+): SendClassJournalToGoogleSheetPayload {
   const activityDate = String(formData.get("activityDate") ?? "").trim();
 
   return {

--- a/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
+++ b/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
@@ -1,4 +1,4 @@
-export type SendClassNoteInfoToGoogleSheetPayload = {
+export type SendClassJournalToGoogleSheetPayload = {
   name: string;
   birth: string;
   phone: string;
@@ -15,9 +15,7 @@ export type SendClassNoteInfoToGoogleSheetPayload = {
 const GOOGLE_APPS_SCRIPT_URL =
   "https://script.google.com/macros/s/AKfycbxAQTwUuRT6X7Hysjhxnx1rp_Env0P-0xPIVuoUXjJtP-EZruBJOEEqDxXbRVpJkxpxFg/exec";
 
-export async function sendClassNoteInfoToGoogleSheet(
-  payload: SendClassNoteInfoToGoogleSheetPayload,
-) {
+export async function sendClassJournalToGoogleSheet(payload: SendClassJournalToGoogleSheetPayload) {
   const res = await fetch(GOOGLE_APPS_SCRIPT_URL, {
     method: "POST",
     redirect: "follow",


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 구글 시트에서 출석부 기본 템플릿을 제작하고 **새로운 연도 / 월 / 반의 수업 일지가 등록되면 해당 템플릿이 자동으로 복사되어 새로운 시트 `0000-00-00반` 이름으로 저장되도록 구현**하였습니다.
<img width="1550" height="131" alt="스크린샷 2026-05-07 오전 1 31 25" src="https://github.com/user-attachments/assets/0350e635-9900-4555-a1a0-eec13b6dadab" />

- 템플릿을 기준으로 수업 연도와 월을 읽어 5행에는 1일부터 해당 월의 마지막 일까지, 6행에는 1일의 요일부터 월의 마지막 요일까지 자동으로 생성되도록 구현하였습니다.

- 출석부에 새로운 학생 이름이 있다면 마지막 순번으로 기록되며, 해당 일자의 출결이 기록되도록 구현하였습니다.
- 출석부에 기존의 학생의 경우, 해당 순번의 행에 해당 일자의 출결이 기록되도록 구현하였습니다.


[기존 저장 포멧]
<img width="1105" height="289" alt="스크린샷 2026-05-07 오전 1 29 18" src="https://github.com/user-attachments/assets/bf1db294-c7c2-4ace-b510-bc08b66f9fd1" />

[현재 저장 포멧]
<img width="1515" height="206" alt="스크린샷 2026-05-07 오전 1 27 50" src="https://github.com/user-attachments/assets/18b98f2d-27bd-4a2d-a12e-46f158c51b0f" />

## 🔍 관련 이슈

Closes #47 

## 💬 기타 사항

N/A

## 📂 참고 자료

<img width="890" height="906" alt="스크린샷 2026-05-07 오전 1 38 32" src="https://github.com/user-attachments/assets/e88b9b3b-ad15-4177-b088-81ee6e383812" />

