### PR TITLE
[FEAT] 결제 신청 API 연동

### DIFF
--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -1,8 +1,9 @@
 export interface SignupRequestDto {
-  username: string;
   password: string;
+  nickname: string;
   name: string;
-  email?: string;
+  email: string;
+  profileImageUrl?: string;
   phoneNumber?: string;
 }
 

--- a/api/channel/channel.api.test.ts
+++ b/api/channel/channel.api.test.ts
@@ -8,7 +8,7 @@ import { CHANNEL_LIST_RESPONSE, CHANNEL_RESPONSE } from "../../mocks/handlers/ch
 import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
-import { createChannel, getChannel, getChannels, hideChannel } from "./channel.api";
+import { createChannel, getChannel, getChannels, updateChannel } from "./channel.api";
 
 describe("channel.api", () => {
   it("returns channels with authorization header and query params", async () => {
@@ -25,11 +25,11 @@ describe("channel.api", () => {
       }),
     );
 
-    const response = await getChannels({ channelType: "ALL", isActive: true });
+    const response = await getChannels({ channelType: "NOTICE", isActive: true });
 
     expect(response).toEqual(CHANNEL_LIST_RESPONSE);
     expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
-    expect(observedQueryString).toContain("channelType=ALL");
+    expect(observedQueryString).toContain("channelType=NOTICE");
     expect(observedQueryString).toContain("isActive=true");
   });
 
@@ -47,9 +47,7 @@ describe("channel.api", () => {
 
     const body = {
       name: "Board",
-      slug: "board",
-      channelType: "ALL",
-      writerPolicy: "ADMIN_MANAGER_ONLY",
+      accessLevel: "READ_WRITE",
     };
 
     const response = await createChannel(body);
@@ -58,11 +56,11 @@ describe("channel.api", () => {
     expect(observedBody).toEqual(body);
   });
 
-  it("uses detail and visibility endpoints", async () => {
+  it("uses detail and update endpoints", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     await expect(getChannel({ id: 1 })).resolves.toMatchObject({ id: 1 });
-    await expect(hideChannel({ id: 1 })).resolves.toMatchObject({
+    await expect(updateChannel({ id: 1 }, { isActive: false })).resolves.toMatchObject({
       id: 1,
       isActive: false,
     });

--- a/api/channel/channel.api.ts
+++ b/api/channel/channel.api.ts
@@ -45,19 +45,3 @@ export async function updateChannel(
 export async function deleteChannel(pathParams: ChannelPathParamsDto) {
   await authClient.delete(`/api/v1/channels/${pathParams.id}`);
 }
-
-// 숨김 상태의 특정 채널을 다시 표시하는 요청
-export async function showChannel(pathParams: ChannelPathParamsDto) {
-  const response = await authClient.patch<ChannelResponseDto>(
-    `/api/v1/channels/${pathParams.id}/show`,
-  );
-  return response.data;
-}
-
-// 특정 채널을 숨김 처리하는 요청
-export async function hideChannel(pathParams: ChannelPathParamsDto) {
-  const response = await authClient.patch<ChannelResponseDto>(
-    `/api/v1/channels/${pathParams.id}/hide`,
-  );
-  return response.data;
-}

--- a/api/channel/channel.dto.ts
+++ b/api/channel/channel.dto.ts
@@ -1,15 +1,12 @@
-export type ChannelType = "ALL" | "CLASSROOM" | "DEPARTMENT" | "CUSTOM" | string;
+export type ChannelType = "NOTICE" | "CLASSROOM" | "DEPARTMENT" | "CUSTOM" | string;
 
-export type ChannelWriterPolicy =
-  | "ALL_AUTHENTICATED"
-  | "ADMIN_MANAGER_ONLY"
-  | "CLASSROOM_MANAGER_TEACHER_ONLY"
-  | "DEPARTMENT_MEMBER_OR_ADMIN"
-  | string;
+export type ChannelBindingType = "STANDALONE" | "DOMAIN_LINKED" | string;
+export type ChannelAccessLevel = "CLOSED" | "READ_ONLY" | "READ_COMMENT" | "READ_WRITE" | string;
 
 export interface ChannelListQueryParamsDto {
   name?: string;
   channelType?: ChannelType;
+  bindingType?: ChannelBindingType;
   isActive?: boolean;
   isDefault?: boolean;
   classroomId?: number;
@@ -19,42 +16,31 @@ export interface ChannelListQueryParamsDto {
 
 export interface CreateChannelRequestDto {
   name: string;
-  slug: string;
   description?: string;
-  channelType: ChannelType;
-  classroomId?: number;
-  departmentId?: number;
-  customRefId?: number;
-  writerPolicy?: ChannelWriterPolicy;
+  accessLevel: ChannelAccessLevel;
+  allowGuestRead?: boolean;
   isDefault?: boolean;
   isActive?: boolean;
-  sortOrder?: number;
 }
 
 export interface UpdateChannelRequestDto {
   name?: string;
-  slug?: string;
   description?: string;
-  channelType?: ChannelType;
-  classroomId?: number;
-  departmentId?: number;
-  customRefId?: number;
-  writerPolicy?: ChannelWriterPolicy;
+  accessLevel?: ChannelAccessLevel;
+  allowGuestRead?: boolean;
   isDefault?: boolean;
   isActive?: boolean;
-  sortOrder?: number;
 }
 
 export interface ChannelResponseDto {
   id?: number;
   name?: string;
-  slug?: string;
   description?: string;
   channelType?: ChannelType;
-  classroomId?: number | null;
-  departmentId?: number | null;
-  customRefId?: number | null;
-  writerPolicy?: ChannelWriterPolicy;
+  bindingType?: ChannelBindingType;
+  refId?: number | null;
+  accessLevel?: ChannelAccessLevel;
+  allowGuestRead?: boolean;
   isDefault?: boolean;
   isActive?: boolean;
   lastPostedAt?: string | null;

--- a/api/classroom/classroom.api.ts
+++ b/api/classroom/classroom.api.ts
@@ -35,7 +35,7 @@ export async function updateClassroom(
   pathParams: ClassroomPathParamsDto,
   body: UpdateClassroomRequestDto,
 ) {
-  const response = await authClient.put<ClassroomDetailResponseDto>(
+  const response = await authClient.patch<ClassroomDetailResponseDto>(
     `/api/v1/classrooms/${pathParams.id}`,
     body,
   );

--- a/api/classroom/classroom.dto.ts
+++ b/api/classroom/classroom.dto.ts
@@ -1,4 +1,4 @@
-export type ClassroomType = string;
+export type ClassroomType = "WEEKDAY" | "WEEKEND" | string;
 
 export interface ClassroomListQueryParamsDto {
   name?: string;

--- a/api/comment/comment.api.ts
+++ b/api/comment/comment.api.ts
@@ -4,6 +4,7 @@ import type {
   CommentPathParamsDto,
   CommentResponseDto,
   CreateCommentRequestDto,
+  UpdateCommentRequestDto,
 } from "./comment.dto";
 
 // 특정 게시글의 댓글 목록을 조회하는 요청
@@ -21,6 +22,18 @@ export async function createComment(
 ) {
   const response = await authClient.post<CommentResponseDto>(
     `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/comments`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 게시글의 특정 댓글을 수정하는 요청
+export async function updateComment(
+  pathParams: CommentPathParamsDto,
+  body: UpdateCommentRequestDto,
+) {
+  const response = await authClient.put<CommentResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/comments/${pathParams.commentId}`,
     body,
   );
   return response.data;

--- a/api/comment/comment.dto.ts
+++ b/api/comment/comment.dto.ts
@@ -5,6 +5,10 @@ export interface CreateCommentRequestDto {
   parentCommentId?: number;
 }
 
+export interface UpdateCommentRequestDto {
+  content: string;
+}
+
 export interface CommentResponseDto {
   id?: number;
   postId?: number;

--- a/api/department/department.dto.ts
+++ b/api/department/department.dto.ts
@@ -4,19 +4,23 @@ export interface DepartmentResponseDto {
   description?: string;
 }
 
-export interface RoleResponseDto {
+export interface PermissionResponseDto {
   name?: string;
-  level?: string | number;
-  code?: number;
+  code?: string;
+}
+
+export interface DepartmentPermissionRequestDto {
+  permissionCode?: string;
 }
 
 export interface DepartmentUserSummaryDto {
   id?: number;
-  username?: string;
   name?: string;
+  nickname?: string;
   email?: string;
   phoneNumber?: string;
-  roles?: RoleResponseDto[];
+  role?: string;
+  departmentId?: number | null;
 }
 
 export interface DepartmentListResponseDto {
@@ -24,8 +28,10 @@ export interface DepartmentListResponseDto {
 }
 
 export interface DepartmentDetailResponseDto extends DepartmentResponseDto {
-  assignedRole?: RoleResponseDto;
+  permissions?: PermissionResponseDto[];
   users?: DepartmentUserSummaryDto[];
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export type DepartmentListItemDto = DepartmentResponseDto;
@@ -33,12 +39,16 @@ export type DepartmentListItemDto = DepartmentResponseDto;
 export interface CreateDepartmentRequestDto {
   name: string;
   description: string;
+  permissions?: DepartmentPermissionRequestDto[];
 }
 
 export interface UpdateDepartmentRequestDto {
   name?: string;
   description?: string;
+  permissions?: DepartmentPermissionRequestDto[];
 }
+
+export type RoleResponseDto = PermissionResponseDto;
 
 export interface DepartmentPathParamsDto {
   id: number;

--- a/api/lesson/lesson.dto.ts
+++ b/api/lesson/lesson.dto.ts
@@ -1,5 +1,5 @@
 export type LessonStatus = "SCHEDULED" | "COMPLETED" | "CANCELED";
-export type AttendanceStatus = "PRESENT" | "ABSENT" | "LATE";
+export type AttendanceStatus = "PRESENT" | "ABSENT" | "LATE" | "EXCUSED";
 export type TeacherAttendanceStatus = AttendanceStatus;
 
 export interface LessonRangeQueryParamsDto {

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -2,10 +2,17 @@ export type LessonExchangeRequestStatus =
   | "PENDING"
   | "APPROVED"
   | "REJECTED"
+  | "COMPLETED"
+  | "EXPIRED"
   | "CANCELLED"
   | string;
 
-export type LessonExchangeProposalStatus = "PENDING" | "ACCEPTED" | "WITHDRAWN" | string;
+export type LessonExchangeProposalStatus =
+  | "ACTIVE"
+  | "ACCEPTED"
+  | "WITHDRAWN"
+  | "CLOSED"
+  | string;
 
 export interface LessonExchangePathParamsDto {
   requestId: number;
@@ -71,9 +78,9 @@ export interface LessonExchangeRequestDetailDto {
 export type LessonExchangeRequestListResponseDto = LessonExchangeRequestDetailDto[];
 
 export interface LessonExchangeProposalRequestDto {
-  lessonDate: string;
-  startPeriod: number;
-  endPeriod: number;
+  lessonDate?: string;
+  startPeriod?: number;
+  endPeriod?: number;
   content: string;
 }
 

--- a/api/post/post.api.test.ts
+++ b/api/post/post.api.test.ts
@@ -34,7 +34,7 @@ describe("post.api", () => {
   it("returns channel posts from the nested route", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
-    const response = await getChannelPosts({ channelId: 3 }, { postType: "NOTICE" });
+    const response = await getChannelPosts({ channelId: 3 }, { status: "PUBLISHED" });
 
     expect(response.content?.[0]).toMatchObject({ channelId: 3 });
   });
@@ -59,7 +59,6 @@ describe("post.api", () => {
     const createBody = {
       title: "New post",
       contentHtml: "<p>Body</p>",
-      postType: "NOTICE",
       isPinned: true,
     };
     const updateBody = { title: "Updated" };

--- a/api/post/post.api.ts
+++ b/api/post/post.api.ts
@@ -2,11 +2,15 @@ import authClient from "../client/authClient";
 import type {
   ChannelPathParamsDto,
   ChannelPostListQueryParamsDto,
+  AttachPostFileRequestDto,
   CreatePostRequestDto,
   PostListQueryParamsDto,
   PostDetailResponseDto,
   PostListResponseDto,
   PostPathParamsDto,
+  PinPostRequestDto,
+  PublishPostRequestDto,
+  SaveDraftRequestDto,
   UpdatePostRequestDto,
 } from "./post.dto";
 
@@ -62,5 +66,79 @@ export async function updatePost(pathParams: PostPathParamsDto, body: UpdatePost
 export async function deletePost(pathParams: PostPathParamsDto) {
   await authClient.delete(
     `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}`,
+  );
+}
+
+// 특정 채널에 초안 게시글을 생성하는 요청
+export async function createDraft(pathParams: ChannelPathParamsDto) {
+  const response = await authClient.post<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/drafts`,
+  );
+  return response.data;
+}
+
+// 현재 사용자의 특정 채널 초안 목록을 조회하는 요청
+export async function getMyDrafts(pathParams: ChannelPathParamsDto) {
+  const response = await authClient.get<PostListResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/me/drafts`,
+  );
+  return response.data;
+}
+
+// 특정 초안 게시글을 임시 저장하는 요청
+export async function saveDraft(pathParams: PostPathParamsDto, body: SaveDraftRequestDto) {
+  const response = await authClient.put<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/draft`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 초안 게시글을 발행하는 요청
+export async function publishPost(pathParams: PostPathParamsDto, body: PublishPostRequestDto) {
+  const response = await authClient.put<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/publish`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 게시글의 상단 고정 여부를 변경하는 요청
+export async function pinPost(pathParams: PostPathParamsDto, body: PinPostRequestDto) {
+  const response = await authClient.put<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/pin`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 게시글에 본문 이미지를 연결하는 요청
+export async function attachPostImage(
+  pathParams: PostPathParamsDto,
+  body: AttachPostFileRequestDto,
+) {
+  const response = await authClient.post<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/images`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 게시글에 첨부파일을 연결하는 요청
+export async function attachPostAttachment(
+  pathParams: PostPathParamsDto,
+  body: AttachPostFileRequestDto,
+) {
+  const response = await authClient.post<PostDetailResponseDto>(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/attachments`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 게시글에서 첨부파일 연결을 제거하는 요청
+export async function detachPostAttachment(pathParams: PostPathParamsDto & { fileId: string }) {
+  await authClient.delete(
+    `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/attachments/${pathParams.fileId}`,
   );
 }

--- a/api/post/post.dto.ts
+++ b/api/post/post.dto.ts
@@ -1,13 +1,12 @@
 import type { ChannelType } from "../channel/channel.dto";
 
 export type PostType = "NOTICE" | "GENERAL" | "EVENT" | string;
-export type PostStatus = "PUBLISHED" | "DRAFT" | string;
+export type PostStatus = "PUBLISHED" | "DRAFT" | "ARCHIVED" | string;
 
 export interface PostListQueryParamsDto {
   author?: string;
   title?: string;
   content?: string;
-  postType?: PostType;
   status?: PostStatus;
   channelId?: number;
   channelType?: ChannelType;
@@ -23,19 +22,50 @@ export type ChannelPostListQueryParamsDto = Omit<PostListQueryParamsDto, "channe
 export interface CreatePostRequestDto {
   title: string;
   contentHtml: string;
-  postType: PostType;
   status?: PostStatus;
   isPinned?: boolean;
   allowComment?: boolean;
+  thumbnailUrl?: string;
 }
 
 export interface UpdatePostRequestDto {
   title?: string;
   contentHtml?: string;
-  postType?: PostType;
   status?: PostStatus;
-  isPinned?: boolean;
   allowComment?: boolean;
+  thumbnailUrl?: string;
+}
+
+export interface PublishPostRequestDto {
+  title: string;
+  contentHtml: string;
+  allowComment?: boolean;
+  thumbnailUrl?: string;
+}
+
+export interface SaveDraftRequestDto {
+  title?: string;
+  contentHtml?: string;
+  allowComment?: boolean;
+  thumbnailUrl?: string;
+}
+
+export interface PinPostRequestDto {
+  isPinned: boolean;
+}
+
+export interface AttachPostFileRequestDto {
+  fileId: string;
+  sortOrder?: number;
+}
+
+export interface PostAttachmentInfoDto {
+  fileId?: string;
+  originalName?: string;
+  contentType?: string;
+  fileSize?: number;
+  url?: string;
+  sortOrder?: number;
 }
 
 export interface PostSummaryResponseDto {
@@ -44,12 +74,14 @@ export interface PostSummaryResponseDto {
   channelName?: string;
   channelType?: ChannelType;
   title?: string;
+  // Legacy mock/UI field. The backend now exposes post status and channelType instead.
   postType?: PostType;
   status?: PostStatus;
   authorId?: number;
   authorName?: string;
   isPinned?: boolean;
   viewCount?: number;
+  thumbnailUrl?: string | null;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -57,6 +89,8 @@ export interface PostSummaryResponseDto {
 export interface PostDetailResponseDto extends PostSummaryResponseDto {
   contentHtml?: string;
   allowComment?: boolean;
+  expiresAt?: string | null;
+  attachments?: PostAttachmentInfoDto[];
 }
 
 export interface PostListResponseDto {

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests representative request API functions across absence, purchase, lesson
- * exchange, and subject exchange flows.
+ * Tests representative request API functions across absence, purchase, and
+ * lesson exchange flows.
  */
 import "../../test/setup";
 
@@ -11,13 +11,12 @@ import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.hand
 import {
   ABSENCE_REQUEST_RESPONSE,
   LESSON_EXCHANGE_REQUEST_RESPONSE,
-  SUBJECT_EXCHANGE_REQUEST_RESPONSE,
 } from "../../mocks/handlers/request.handlers";
 import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
 import {
-  approveSubjectExchangeRequest,
+  approvePurchaseRequest,
   createLessonExchangeRequest,
   getAbsenceRequests,
 } from "./request.api";
@@ -55,7 +54,7 @@ describe("request.api", () => {
         return HttpResponse.json({
           ...LESSON_EXCHANGE_REQUEST_RESPONSE,
           id: 30,
-          lessonId: 22,
+          lessonDate: "2026-06-10",
           title: "Emergency swap",
           content: "Need a replacement",
         });
@@ -63,20 +62,22 @@ describe("request.api", () => {
     );
 
     const response = await createLessonExchangeRequest({
-      lessonId: 22,
+      lessonDate: "2026-06-10",
       title: "Emergency swap",
       content: "Need a replacement",
+      expiresAt: "2026-06-07T22:00:00",
     });
 
     expect(response.id).toBe(30);
     expect(observedBody).toEqual({
-      lessonId: 22,
+      lessonDate: "2026-06-10",
       title: "Emergency swap",
       content: "Need a replacement",
+      expiresAt: "2026-06-07T22:00:00",
     });
   });
 
-  it("approves a subject exchange request through the expected endpoint", async () => {
+  it("approves a purchase request through the admin endpoint", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     let observedPathname = "";
@@ -84,41 +85,37 @@ describe("request.api", () => {
 
     server.use(
       http.patch(
-        `${API_BASE_URL}/api/v1/subject-exchange-requests/4/approve`,
+        `${API_BASE_URL}/api/v1/admin/purchase-requests/4/approve`,
         async ({ request }) => {
           observedPathname = new URL(request.url).pathname;
           observedBody = await request.json();
           return HttpResponse.json({
-            ...SUBJECT_EXCHANGE_REQUEST_RESPONSE,
             id: 4,
             status: "APPROVED",
-            approvalByName: "User 77",
+            note: "승인합니다.",
           });
         },
       ),
     );
 
-    const response = await approveSubjectExchangeRequest(
-      { requestId: 4 },
-      { exchangeWithUserId: 77 },
-    );
+    const response = await approvePurchaseRequest({ requestId: 4 }, { note: "승인합니다." });
 
     expect(response.status).toBe("APPROVED");
-    expect(observedPathname).toBe("/api/v1/subject-exchange-requests/4/approve");
-    expect(observedBody).toEqual({ exchangeWithUserId: 77 });
+    expect(observedPathname).toBe("/api/v1/admin/purchase-requests/4/approve");
+    expect(observedBody).toEqual({ note: "승인합니다." });
   });
 
-  it("throws when a subject exchange approval fails", async () => {
+  it("throws when purchase approval fails", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     server.use(
-      http.patch(`${API_BASE_URL}/api/v1/subject-exchange-requests/999/approve`, () => {
+      http.patch(`${API_BASE_URL}/api/v1/admin/purchase-requests/999/approve`, () => {
         return HttpResponse.json({ message: "Request not found" }, { status: 404 });
       }),
     );
 
     await expect(
-      approveSubjectExchangeRequest({ requestId: 999 }, { exchangeWithUserId: 77 }),
+      approvePurchaseRequest({ requestId: 999 }, { note: "승인합니다." }),
     ).rejects.toMatchObject({
       response: { status: 404 },
     });

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -2,17 +2,18 @@ import authClient from "../client/authClient";
 import type {
   AbsenceRequestResponseDto,
   ApproveLessonExchangeRequestDto,
-  ApproveSubjectExchangeRequestDto,
   CreateAbsenceRequestDto,
   CreateLessonExchangeRequestDto,
   CreatePurchaseRequestDto,
-  CreateSubjectExchangeRequestDto,
   LessonExchangeRequestResponseDto,
   PurchaseRequestResponseDto,
+  PurchaseRequestSummaryResponseDto,
   RejectRequestDto,
+  ReportPurchaseRequestDto,
   RequestPathParamsDto,
+  RequestReconfirmationResponseDto,
+  ReviewPurchaseRequestDto,
   RequestStatusQueryParamsDto,
-  SubjectExchangeRequestResponseDto,
 } from "./request.dto";
 
 // 결석 요청 목록을 조회하는 요청
@@ -67,9 +68,12 @@ export async function deleteAbsenceRequest(pathParams: RequestPathParamsDto) {
 
 // 구매 요청 목록을 조회하는 요청
 export async function getPurchaseRequests(query?: RequestStatusQueryParamsDto) {
-  const response = await authClient.get<PurchaseRequestResponseDto[]>("/api/v1/purchase-requests", {
-    params: query,
-  });
+  const response = await authClient.get<PurchaseRequestSummaryResponseDto[]>(
+    "/api/v1/purchase-requests",
+    {
+      params: query,
+    },
+  );
   return response.data;
 }
 
@@ -91,9 +95,13 @@ export async function getPurchaseRequestDetail(pathParams: RequestPathParamsDto)
 }
 
 // 특정 구매 요청을 승인하는 요청
-export async function approvePurchaseRequest(pathParams: RequestPathParamsDto) {
+export async function approvePurchaseRequest(
+  pathParams: RequestPathParamsDto,
+  body: ReviewPurchaseRequestDto,
+) {
   const response = await authClient.patch<PurchaseRequestResponseDto>(
-    `/api/v1/purchase-requests/${pathParams.requestId}/approve`,
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/approve`,
+    body,
   );
   return response.data;
 }
@@ -104,8 +112,79 @@ export async function rejectPurchaseRequest(
   body: RejectRequestDto,
 ) {
   const response = await authClient.patch<PurchaseRequestResponseDto>(
-    `/api/v1/purchase-requests/${pathParams.requestId}/reject`,
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/reject`,
     body,
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 요청 목록을 조회하는 요청
+export async function getAllPurchaseRequests(query?: RequestStatusQueryParamsDto) {
+  const response = await authClient.get<PurchaseRequestSummaryResponseDto[]>(
+    "/api/v1/admin/purchase-requests",
+    {
+      params: query,
+    },
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 요청 상세를 조회하는 요청
+export async function getAdminPurchaseRequestDetail(pathParams: RequestPathParamsDto) {
+  const response = await authClient.get<PurchaseRequestResponseDto>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}`,
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 요청을 승인하는 요청
+export async function approveAdminPurchaseRequest(
+  pathParams: RequestPathParamsDto,
+  body: ReviewPurchaseRequestDto,
+) {
+  const response = await authClient.patch<PurchaseRequestResponseDto>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/approve`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 요청을 반려하는 요청
+export async function rejectAdminPurchaseRequest(
+  pathParams: RequestPathParamsDto,
+  body: RejectRequestDto,
+) {
+  const response = await authClient.patch<PurchaseRequestResponseDto>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/reject`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 완료 요청을 결재 확인하는 요청
+export async function confirmPurchase(pathParams: RequestPathParamsDto) {
+  const response = await authClient.patch<PurchaseRequestResponseDto>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/confirm`,
+  );
+  return response.data;
+}
+
+// 구매 완료 보고를 제출하는 요청
+export async function reportPurchase(
+  pathParams: RequestPathParamsDto,
+  body: ReportPurchaseRequestDto,
+) {
+  const response = await authClient.post<PurchaseRequestResponseDto>(
+    `/api/v1/purchase-requests/${pathParams.requestId}/report`,
+    body,
+  );
+  return response.data;
+}
+
+// 구매 요청 재확인을 요청하는 요청
+export async function requestReconfirmation(pathParams: RequestPathParamsDto) {
+  const response = await authClient.post<RequestReconfirmationResponseDto>(
+    `/api/v1/purchase-requests/${pathParams.requestId}/reconfirmation`,
   );
   return response.data;
 }
@@ -157,58 +236,6 @@ export async function rejectLessonExchangeRequest(
 ) {
   const response = await authClient.patch<LessonExchangeRequestResponseDto>(
     `/api/v1/lesson-exchange-requests/${pathParams.requestId}/reject`,
-    body,
-  );
-  return response.data;
-}
-
-// 과목 교환 요청 목록을 조회하는 요청
-export async function getSubjectExchangeRequests(query?: RequestStatusQueryParamsDto) {
-  const response = await authClient.get<SubjectExchangeRequestResponseDto[]>(
-    "/api/v1/subject-exchange-requests",
-    {
-      params: query,
-    },
-  );
-  return response.data;
-}
-
-// 과목 교환 요청을 생성하는 요청
-export async function createSubjectExchangeRequest(body: CreateSubjectExchangeRequestDto) {
-  const response = await authClient.post<SubjectExchangeRequestResponseDto>(
-    "/api/v1/subject-exchange-requests",
-    body,
-  );
-  return response.data;
-}
-
-// 특정 과목 교환 요청 상세를 조회하는 요청
-export async function getSubjectExchangeRequestDetail(pathParams: RequestPathParamsDto) {
-  const response = await authClient.get<SubjectExchangeRequestResponseDto>(
-    `/api/v1/subject-exchange-requests/${pathParams.requestId}`,
-  );
-  return response.data;
-}
-
-// 특정 과목 교환 요청을 승인하는 요청
-export async function approveSubjectExchangeRequest(
-  pathParams: RequestPathParamsDto,
-  body: ApproveSubjectExchangeRequestDto,
-) {
-  const response = await authClient.patch<SubjectExchangeRequestResponseDto>(
-    `/api/v1/subject-exchange-requests/${pathParams.requestId}/approve`,
-    body,
-  );
-  return response.data;
-}
-
-// 특정 과목 교환 요청을 반려하는 요청
-export async function rejectSubjectExchangeRequest(
-  pathParams: RequestPathParamsDto,
-  body: RejectRequestDto,
-) {
-  const response = await authClient.patch<SubjectExchangeRequestResponseDto>(
-    `/api/v1/subject-exchange-requests/${pathParams.requestId}/reject`,
     body,
   );
   return response.data;

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -8,6 +8,7 @@ import type {
   LessonExchangeRequestResponseDto,
   PurchaseRequestResponseDto,
   PurchaseRequestSummaryResponseDto,
+  PurchaseRequestStatusQueryParamsDto,
   RejectRequestDto,
   ReportPurchaseRequestDto,
   RequestPathParamsDto,
@@ -67,7 +68,7 @@ export async function deleteAbsenceRequest(pathParams: RequestPathParamsDto) {
 }
 
 // 구매 요청 목록을 조회하는 요청
-export async function getPurchaseRequests(query?: RequestStatusQueryParamsDto) {
+export async function getPurchaseRequests(query?: PurchaseRequestStatusQueryParamsDto) {
   const response = await authClient.get<PurchaseRequestSummaryResponseDto[]>(
     "/api/v1/purchase-requests",
     {
@@ -79,9 +80,23 @@ export async function getPurchaseRequests(query?: RequestStatusQueryParamsDto) {
 
 // 구매 요청을 생성하는 요청
 export async function createPurchaseRequest(body: CreatePurchaseRequestDto) {
+  const requestBody: CreatePurchaseRequestDto = {
+    title: body.title,
+    content: body.content,
+    classroomId: body.classroomId,
+    ...(typeof body.advancePaymentRequestedAmount === "number"
+      ? { advancePaymentRequestedAmount: body.advancePaymentRequestedAmount }
+      : {}),
+    items: body.items.map((item) => ({
+      name: item.name,
+      ...(item.reason ? { reason: item.reason } : {}),
+      ...(typeof item.expectedPrice === "number" ? { expectedPrice: item.expectedPrice } : {}),
+    })),
+  };
+
   const response = await authClient.post<PurchaseRequestResponseDto>(
     "/api/v1/purchase-requests",
-    body,
+    requestBody,
   );
   return response.data;
 }
@@ -106,6 +121,11 @@ export async function approvePurchaseRequest(
   return response.data;
 }
 
+// 특정 구매 요청을 삭제하는 요청
+export async function deletePurchaseRequest(pathParams: RequestPathParamsDto) {
+  await authClient.delete(`/api/v1/purchase-requests/${pathParams.requestId}`);
+}
+
 // 특정 구매 요청을 반려하는 요청
 export async function rejectPurchaseRequest(
   pathParams: RequestPathParamsDto,
@@ -119,7 +139,7 @@ export async function rejectPurchaseRequest(
 }
 
 // 관리자 기준 구매 요청 목록을 조회하는 요청
-export async function getAllPurchaseRequests(query?: RequestStatusQueryParamsDto) {
+export async function getAllPurchaseRequests(query?: PurchaseRequestStatusQueryParamsDto) {
   const response = await authClient.get<PurchaseRequestSummaryResponseDto[]>(
     "/api/v1/admin/purchase-requests",
     {
@@ -135,6 +155,11 @@ export async function getAdminPurchaseRequestDetail(pathParams: RequestPathParam
     `/api/v1/admin/purchase-requests/${pathParams.requestId}`,
   );
   return response.data;
+}
+
+// 관리자 기준 구매 요청을 삭제하는 요청
+export async function deleteAdminPurchaseRequest(pathParams: RequestPathParamsDto) {
+  await authClient.delete(`/api/v1/admin/purchase-requests/${pathParams.requestId}`);
 }
 
 // 관리자 기준 구매 요청을 승인하는 요청

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -10,6 +10,10 @@ export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
 }
 
+export interface PurchaseRequestStatusQueryParamsDto {
+  status?: PurchaseRequestStatus;
+}
+
 export interface RequestPathParamsDto {
   requestId: number;
 }

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -1,4 +1,10 @@
 export type RequestStatus = "PENDING" | "APPROVED" | "REJECTED";
+export type PurchaseRequestStatus =
+  | "PENDING"
+  | "APPROVED"
+  | "PURCHASED"
+  | "CONFIRMED"
+  | "REJECTED";
 
 export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
@@ -30,26 +36,74 @@ export interface AbsenceRequestResponseDto {
 export type AbsenceRequestListItemDto = AbsenceRequestResponseDto;
 
 export interface CreatePurchaseRequestDto {
-  subjectId: number;
   title: string;
   content: string;
+  classroomId: number;
+  advancePaymentRequestedAmount?: number;
+  items: PurchaseRequestItemDto[];
+}
+
+export interface PurchaseRequestItemDto {
+  name: string;
+  reason?: string;
+  expectedPrice?: number;
+}
+
+export interface PurchaseRequestItemReportDto {
+  itemId: number;
   price: number;
 }
 
-export interface PurchaseRequestResponseDto {
+export interface ReportPurchaseRequestDto {
+  items: PurchaseRequestItemReportDto[];
+  receiptFileIds?: string[];
+}
+
+export interface ReviewPurchaseRequestDto {
+  note: string;
+  advancePaymentApprovedAmount?: number;
+}
+
+export interface RequestReconfirmationResponseDto {
+  message?: string;
+}
+
+export interface PurchaseRequestItemResponseDto {
   id?: number;
-  subjectId?: number;
-  subjectName?: string;
-  requestedById?: number;
+  name?: string;
+  reason?: string;
+  expectedPrice?: number;
+  actualPrice?: number;
+}
+
+export interface PurchaseRequestReceiptResponseDto {
+  id?: number;
+  fileId?: string;
+  fileUrl?: string;
+}
+
+export interface PurchaseRequestSummaryResponseDto {
+  id?: number;
+  classroomName?: string;
   requestedByName?: string;
   title?: string;
+  totalPrice?: number;
+  advancePaymentRequestedAmount?: number;
+  advancePaymentApprovedAmount?: number;
+  status?: PurchaseRequestStatus;
+  createdAt?: string;
+}
+
+export interface PurchaseRequestResponseDto extends PurchaseRequestSummaryResponseDto {
+  classroomId?: number;
+  requestedById?: number;
   content?: string;
-  price?: number;
-  status?: RequestStatus;
   approvalAt?: string;
   approvalByName?: string;
+  purchasedAt?: string;
   note?: string;
-  createdAt?: string;
+  items?: PurchaseRequestItemResponseDto[];
+  receipts?: PurchaseRequestReceiptResponseDto[];
 }
 
 export type PurchaseRequestListItemDto = PurchaseRequestResponseDto;
@@ -77,34 +131,7 @@ export interface LessonExchangeRequestResponseDto {
 
 export type LessonExchangeRequestListItemDto = LessonExchangeRequestResponseDto;
 
-export interface CreateSubjectExchangeRequestDto {
-  subjectId: number;
-  title: string;
-  content: string;
-}
-
-export interface SubjectExchangeRequestResponseDto {
-  id?: number;
-  subjectId?: number;
-  subjectName?: string;
-  requestedById?: number;
-  requestedByName?: string;
-  title?: string;
-  content?: string;
-  status?: RequestStatus;
-  approvalAt?: string;
-  approvalByName?: string;
-  note?: string;
-  createdAt?: string;
-}
-
-export type SubjectExchangeRequestListItemDto = SubjectExchangeRequestResponseDto;
-
 export interface ApproveLessonExchangeRequestDto {
-  exchangeWithUserId: number;
-}
-
-export interface ApproveSubjectExchangeRequestDto {
   exchangeWithUserId: number;
 }
 

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests representative user API functions: getUsers, updateCurrentUser,
- * removeUserSubRole, and joinUserDepartment.
+ * and removeUserPermission.
  */
 import "../../test/setup";
 
@@ -14,8 +14,7 @@ import { setAccessToken } from "../client/tokenStorage";
 
 import {
   getUsers,
-  joinUserDepartment,
-  removeUserSubRole,
+  removeUserPermission,
   updateCurrentUser,
 } from "./user.api";
 
@@ -69,35 +68,38 @@ describe("user.api", () => {
     });
   });
 
-  it("sends DELETE body data when removing a user sub role", async () => {
+  it("sends DELETE body data when removing a user permission", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     let observedBody: unknown;
 
     server.use(
-      http.delete(`${API_BASE_URL}/api/v1/users/1/roles`, async ({ request }) => {
+      http.delete(`${API_BASE_URL}/api/v1/users/1/permissions`, async ({ request }) => {
         observedBody = await request.json();
         return HttpResponse.json([]);
       }),
     );
 
-    const response = await removeUserSubRole({ userId: 1 }, { subRole: "ASSISTANT" });
+    const response = await removeUserPermission(
+      { userId: 1 },
+      { permissionCode: "post:manage:*" },
+    );
 
     expect(response).toEqual([]);
-    expect(observedBody).toEqual({ subRole: "ASSISTANT" });
+    expect(observedBody).toEqual({ permissionCode: "post:manage:*" });
   });
 
-  it("throws when joining a department fails", async () => {
+  it("throws when removing a permission fails", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     server.use(
-      http.post(`${API_BASE_URL}/api/v1/users/1/departments`, () => {
+      http.delete(`${API_BASE_URL}/api/v1/users/1/permissions`, () => {
         return HttpResponse.json({ message: "Forbidden" }, { status: 403 });
       }),
     );
 
     await expect(
-      joinUserDepartment({ userId: 1 }, { departmentId: 10 }),
+      removeUserPermission({ userId: 1 }, { permissionCode: "post:manage:*" }),
     ).rejects.toMatchObject({
       response: { status: 403 },
     });

--- a/api/user/user.api.ts
+++ b/api/user/user.api.ts
@@ -1,14 +1,10 @@
 import authClient from "../client/authClient";
 import type {
-  AddSubRoleRequestDto,
   CreateUserRequestDto,
-  DepartmentListResponseDto,
-  JoinDepartmentRequestDto,
-  LeaveDepartmentPathParamsDto,
-  RemoveSubRoleRequestDto,
-  RoleResponseDto,
+  PermissionResponseDto,
   UpdateSelfRequestDto,
   UpdateUserRequestDto,
+  UserPermissionRequestDto,
   UserListQueryParamsDto,
   UserListResponseDto,
   UserPathParamsDto,
@@ -62,61 +58,35 @@ export async function updateCurrentUser(body: UpdateSelfRequestDto) {
 }
 
 // 특정 사용자의 역할 목록을 조회하는 요청
-export async function getUserRoles(pathParams: UserPathParamsDto) {
-  const response = await authClient.get<RoleResponseDto[]>(
-    `/api/v1/users/${pathParams.userId}/roles`,
+export async function getUserPermissions(pathParams: UserPathParamsDto) {
+  const response = await authClient.get<PermissionResponseDto[]>(
+    `/api/v1/users/${pathParams.userId}/permissions`,
   );
   return response.data;
 }
 
-// 특정 사용자에게 서브 역할을 추가하는 요청
-export async function addUserSubRole(pathParams: UserPathParamsDto, body: AddSubRoleRequestDto) {
-  const response = await authClient.post<RoleResponseDto[]>(
-    `/api/v1/users/${pathParams.userId}/roles`,
+// 특정 사용자에게 직접 권한을 추가하는 요청
+export async function addUserPermission(
+  pathParams: UserPathParamsDto,
+  body: UserPermissionRequestDto,
+) {
+  const response = await authClient.post<PermissionResponseDto[]>(
+    `/api/v1/users/${pathParams.userId}/permissions`,
     body,
   );
   return response.data;
 }
 
-// 특정 사용자에게서 서브 역할을 제거하는 요청
-export async function removeUserSubRole(
+// 특정 사용자에게서 직접 권한을 제거하는 요청
+export async function removeUserPermission(
   pathParams: UserPathParamsDto,
-  body: RemoveSubRoleRequestDto,
+  body: UserPermissionRequestDto,
 ) {
-  const response = await authClient.delete<RoleResponseDto[]>(
-    `/api/v1/users/${pathParams.userId}/roles`,
+  const response = await authClient.delete<PermissionResponseDto[]>(
+    `/api/v1/users/${pathParams.userId}/permissions`,
     {
       data: body,
     },
   );
   return response.data;
-}
-
-// 특정 사용자의 부서 목록을 조회하는 요청
-export async function getUserDepartments(pathParams: UserPathParamsDto) {
-  const response = await authClient.get<DepartmentListResponseDto>(
-    `/api/v1/users/${pathParams.userId}/departments`,
-  );
-  return response.data;
-}
-
-// 현재 로그인한 사용자의 부서 목록을 조회하는 요청
-export async function getMyDepartments() {
-  const response = await authClient.get<DepartmentListResponseDto>("/api/v1/users/me/departments");
-  return response.data;
-}
-
-// 특정 사용자를 부서에 소속시키는 요청
-export async function joinUserDepartment(
-  pathParams: UserPathParamsDto,
-  body: JoinDepartmentRequestDto,
-) {
-  await authClient.post(`/api/v1/users/${pathParams.userId}/departments`, body);
-}
-
-// 특정 사용자를 부서에서 제외하는 요청
-export async function leaveUserDepartment(pathParams: LeaveDepartmentPathParamsDto) {
-  await authClient.delete(
-    `/api/v1/users/${pathParams.userId}/departments/${pathParams.departmentId}`,
-  );
 }

--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -1,18 +1,21 @@
 export type UserRole = string;
 
-export interface RoleResponseDto {
+export interface PermissionResponseDto {
   name?: string;
-  level?: string | number;
-  code?: number;
+  code?: string;
 }
 
 export interface UserResponseDto {
   id?: number;
-  username?: string;
   name?: string;
+  nickname?: string;
   email?: string;
   phoneNumber?: string;
-  roles?: RoleResponseDto[];
+  role?: UserRole;
+  departmentId?: number | null;
+  permissions?: PermissionResponseDto[];
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export type UserListItemDto = UserResponseDto;
@@ -41,46 +44,39 @@ export interface UserListQueryParamsDto {
 }
 
 export interface CreateUserRequestDto {
-  username: string;
+  email: string;
+  nickname: string;
   password: string;
   name: string;
-  email?: string;
   phoneNumber?: string;
   role?: UserRole;
+  departmentId?: number | null;
 }
 
 export interface UpdateUserRequestDto {
   name?: string;
+  nickname?: string;
   phoneNumber?: string;
   email?: string;
   password?: string;
   role?: UserRole;
+  departmentId?: number | null;
 }
 
 export interface UpdateSelfRequestDto {
   name?: string;
+  nickname?: string;
   phoneNumber?: string;
   email?: string;
   password?: string;
 }
 
-export interface AddSubRoleRequestDto {
-  subRole?: string;
-}
-
-export interface RemoveSubRoleRequestDto {
-  subRole?: string;
-}
-
-export interface JoinDepartmentRequestDto {
-  departmentId: number;
+export interface UserPermissionRequestDto {
+  permissionCode: string;
 }
 
 export interface UserPathParamsDto {
   userId: number;
 }
 
-export interface LeaveDepartmentPathParamsDto {
-  userId: number;
-  departmentId: number;
-}
+export type RoleResponseDto = PermissionResponseDto;

--- a/app/staff/finance/[requestId]/page.tsx
+++ b/app/staff/finance/[requestId]/page.tsx
@@ -1,9 +1,5 @@
 import { notFound } from "next/navigation";
 import FinanceRequestDetailPage from "@/components/staff/FinanceRequestDetailPage";
-import {
-  financeRequests,
-  getFinanceRequestById,
-} from "@/mocks/staffFinance";
 
 type PageProps = {
   params: Promise<{
@@ -11,19 +7,13 @@ type PageProps = {
   }>;
 };
 
-export function generateStaticParams() {
-  return financeRequests.map((request) => ({
-    requestId: String(request.id),
-  }));
-}
-
 export default async function Page({ params }: PageProps) {
   const { requestId } = await params;
-  const request = getFinanceRequestById(Number(requestId));
+  const parsedRequestId = Number(requestId);
 
-  if (!request) {
+  if (!Number.isInteger(parsedRequestId) || parsedRequestId < 1) {
     notFound();
   }
 
-  return <FinanceRequestDetailPage request={request} />;
+  return <FinanceRequestDetailPage requestId={parsedRequestId} />;
 }

--- a/app/staff/finance/page.tsx
+++ b/app/staff/finance/page.tsx
@@ -1,9 +1,4 @@
-import { redirect } from "next/navigation";
 import FinanceRequestListPage from "@/components/staff/FinanceRequestListPage";
-import {
-  FINANCE_REQUESTS_PER_PAGE,
-  financeRequests,
-} from "@/mocks/staffFinance";
 
 type PageProps = {
   searchParams?: Promise<{
@@ -15,23 +10,6 @@ export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const rawPage = resolvedSearchParams?.page;
   const parsedPage = rawPage ? Number(rawPage) : 1;
-  const filteredRequests = financeRequests;
-  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / FINANCE_REQUESTS_PER_PAGE));
-  const isInvalidPage =
-    !Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages;
 
-  if (isInvalidPage) {
-    redirect("/staff/finance");
-  }
-
-  const startIndex = (parsedPage - 1) * FINANCE_REQUESTS_PER_PAGE;
-  const requests = filteredRequests.slice(startIndex, startIndex + FINANCE_REQUESTS_PER_PAGE);
-
-  return (
-    <FinanceRequestListPage
-      currentPage={parsedPage}
-      requests={requests}
-      totalPages={totalPages}
-    />
-  );
+  return <FinanceRequestListPage currentPage={parsedPage} />;
 }

--- a/components/auth/MyPage.tsx
+++ b/components/auth/MyPage.tsx
@@ -12,7 +12,7 @@ export default function MyPage() {
   const { status, user, signOut } = useAuthSession();
 
   const displayName = user?.name ?? "회원";
-  const identifier = user?.username ?? user?.email ?? "확인 가능한 계정 정보가 없습니다.";
+  const identifier = user?.nickname ?? user?.email ?? "확인 가능한 계정 정보가 없습니다.";
 
   async function handleLogout() {
     await signOut();
@@ -63,7 +63,7 @@ export default function MyPage() {
                   <ProfileValue>{displayName}</ProfileValue>
                 </ProfileItem>
                 <ProfileItem>
-                  <ProfileLabel>아이디</ProfileLabel>
+                  <ProfileLabel>닉네임</ProfileLabel>
                   <ProfileValue>{identifier}</ProfileValue>
                 </ProfileItem>
                 <ProfileItem>

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -16,17 +16,17 @@ import AuthShell from "@/components/auth/AuthShell";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 type RegisterFormState = {
-  username: string;
   password: string;
   name: string;
+  nickname: string;
   email: string;
   phoneNumber: string;
 };
 
 const initialState: RegisterFormState = {
-  username: "",
   password: "",
   name: "",
+  nickname: "",
   email: "",
   phoneNumber: "",
 };
@@ -38,7 +38,10 @@ export default function RegisterForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canSubmit =
-    form.username.trim().length > 0 && form.password.length >= 6 && form.name.trim().length > 0;
+    form.email.trim().length > 0 &&
+    form.password.length >= 8 &&
+    form.name.trim().length > 0 &&
+    form.nickname.trim().length > 0;
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -52,10 +55,10 @@ export default function RegisterForm() {
 
     try {
       await signup({
-        username: form.username.trim(),
         password: form.password,
+        nickname: form.nickname.trim(),
         name: form.name.trim(),
-        email: form.email.trim() || undefined,
+        email: form.email.trim(),
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
       setStatusMessage("회원가입이 완료되었습니다. 잠시 후 메인으로 이동합니다.");
@@ -72,16 +75,16 @@ export default function RegisterForm() {
       <Form onSubmit={handleSubmit} aria-label="회원가입 폼">
         <FieldGroup>
           <Field>
-            <Label htmlFor="register-username">아이디</Label>
+            <Label htmlFor="register-email">이메일</Label>
             <Input
-              id="register-username"
-              name="username"
-              type="text"
-              autoComplete="username"
-              placeholder="사용할 아이디"
-              value={form.username}
+              id="register-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="이메일"
+              value={form.email}
               onChange={(event) =>
-                setForm((current) => ({ ...current, username: event.target.value }))
+                setForm((current) => ({ ...current, email: event.target.value }))
               }
               required
             />
@@ -94,13 +97,13 @@ export default function RegisterForm() {
               name="password"
               type="password"
               autoComplete="new-password"
-              placeholder="6자 이상 입력"
+              placeholder="8자 이상 입력"
               value={form.password}
               onChange={(event) =>
                 setForm((current) => ({ ...current, password: event.target.value }))
               }
               required
-              minLength={6}
+              minLength={8}
             />
           </Field>
 
@@ -119,17 +122,18 @@ export default function RegisterForm() {
           </Field>
 
           <Field>
-            <Label htmlFor="register-email">이메일</Label>
+            <Label htmlFor="register-nickname">닉네임</Label>
             <Input
-              id="register-email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              placeholder="선택 입력"
-              value={form.email}
+              id="register-nickname"
+              name="nickname"
+              type="text"
+              autoComplete="nickname"
+              placeholder="닉네임"
+              value={form.nickname}
               onChange={(event) =>
-                setForm((current) => ({ ...current, email: event.target.value }))
+                setForm((current) => ({ ...current, nickname: event.target.value }))
               }
+              required
             />
           </Field>
 

--- a/components/board/BoardCreatePageClient.tsx
+++ b/components/board/BoardCreatePageClient.tsx
@@ -63,7 +63,6 @@ export default function BoardCreatePageClient() {
         {
           title: title.trim(),
           contentHtml: toContentHtml(content.trim()),
-          postType: "GENERAL",
           status: "PUBLISHED",
           allowComment: true,
         },

--- a/components/board/BoardListPageClient.tsx
+++ b/components/board/BoardListPageClient.tsx
@@ -26,7 +26,7 @@ type BoardListPageClientProps = {
 };
 
 function isNoticePost(post: PostSummaryResponseDto) {
-  return Boolean(post.isPinned) || post.postType === "NOTICE";
+  return Boolean(post.isPinned) || post.channelType === "NOTICE" || post.postType === "NOTICE";
 }
 
 function getPostTime(post: PostSummaryResponseDto) {

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -12,7 +12,7 @@ export default function NoticeCard() {
     queryKey: queryKeys.posts.noticeTop12(),
     queryFn: () =>
       getPosts({
-        postType: "NOTICE",
+        channelType: "NOTICE",
         page: 0,
         size: 12,
       }),

--- a/components/staff/FinanceRequestCreatePage.tsx
+++ b/components/staff/FinanceRequestCreatePage.tsx
@@ -1,9 +1,142 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
 import { IconFilePlus } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import { getClassrooms } from "@/api/classroom/classroom.api";
+import { createPurchaseRequest } from "@/api/request/request.api";
+import type { CreatePurchaseRequestDto } from "@/api/request/request.dto";
 import StaffSidebar from "@/components/staff/StaffSidebar";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
+type FinanceItemForm = {
+  id: number;
+  name: string;
+  reason: string;
+  expectedPrice: string;
+  receiptFileName: string;
+};
+
+const initialItem: FinanceItemForm = {
+  id: 1,
+  name: "",
+  reason: "",
+  expectedPrice: "",
+  receiptFileName: "",
+};
+
 export default function FinanceRequestCreatePage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user, status: authStatus } = useAuthSession();
+  const [title, setTitle] = useState("");
+  const [classroomId, setClassroomId] = useState("");
+  const [paymentDate, setPaymentDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [items, setItems] = useState<FinanceItemForm[]>([initialItem]);
+
+  const { data: classroomData } = useQuery({
+    queryKey: ["classrooms", "finance-request-create"],
+    queryFn: () => getClassrooms({ page: 0, size: 100 }),
+    retry: false,
+  });
+
+  const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
+
+  const mutation = useMutation({
+    mutationFn: (body: CreatePurchaseRequestDto) => createPurchaseRequest(body),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: queryKeys.requests.purchaseList() });
+      router.push("/staff/finance");
+    },
+  });
+
+  const normalizedItems = items
+    .map((item) => ({
+      name: item.name.trim(),
+      reason: item.reason.trim() || undefined,
+      expectedPrice: item.expectedPrice.trim().length > 0 ? Number(item.expectedPrice) : undefined,
+    }))
+    .filter((item) => item.name.length > 0);
+
+  const totalExpectedPrice = normalizedItems.reduce(
+    (sum, item) => sum + (typeof item.expectedPrice === "number" ? item.expectedPrice : 0),
+    0,
+  );
+
+  const canSubmit =
+    title.trim().length > 0 &&
+    classroomId.trim().length > 0 &&
+    Number.isInteger(Number(classroomId)) &&
+    paymentDate.trim().length > 0 &&
+    authStatus === "authenticated" &&
+    normalizedItems.length > 0 &&
+    !normalizedItems.some((item) => Number.isNaN(item.expectedPrice)) &&
+    totalExpectedPrice > 0 &&
+    !mutation.isPending;
+
+  const applicantName =
+    authStatus === "authenticated"
+      ? (user?.name ?? user?.nickname ?? user?.email ?? "이름 정보 없음")
+      : authStatus === "loading"
+        ? "사용자 확인 중"
+        : "로그인 필요";
+
+  function updateItem(itemId: number, patch: Partial<FinanceItemForm>) {
+    setItems((current) =>
+      current.map((item) => (item.id === itemId ? { ...item, ...patch } : item)),
+    );
+  }
+
+  function addItem() {
+    setItems((current) => [
+      ...current,
+      {
+        ...initialItem,
+        id: Math.max(...current.map((item) => item.id)) + 1,
+      },
+    ]);
+  }
+
+  function removeItem(itemId: number) {
+    setItems((current) => {
+      if (current.length <= 1) {
+        return [{ ...initialItem, id: current[0]?.id ?? 1 }];
+      }
+      return current.filter((item) => item.id !== itemId);
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit) {
+      return;
+    }
+
+    const itemContent = normalizedItems
+      .map((item, index) => {
+        const reason = item.reason ? ` - ${item.reason}` : "";
+        const price =
+          typeof item.expectedPrice === "number"
+            ? ` (${item.expectedPrice.toLocaleString()}원)`
+            : "";
+        return `${index + 1}. ${item.name}${reason}${price}`;
+      })
+      .join("\n");
+
+    mutation.mutate({
+      title: title.trim(),
+      content: `결제 일자: ${paymentDate}\n신청자: ${applicantName}\n\n${itemContent}`,
+      classroomId: Number(classroomId),
+      advancePaymentRequestedAmount: totalExpectedPrice,
+      items: normalizedItems,
+    });
+  }
+
   return (
     <Main>
       <Stage>
@@ -12,51 +145,131 @@ export default function FinanceRequestCreatePage() {
         <Content>
           <HeaderRow>
             <Title>결제 신청서 작성하기</Title>
-            <SubmitButton type="submit" form="finance-request-form">
-              결제 신청서 제출하기
+            <SubmitButton type="submit" form="finance-request-form" disabled={!canSubmit}>
+              {mutation.isPending ? "제출 중" : "결제 신청서 제출하기"}
             </SubmitButton>
           </HeaderRow>
 
-          <Form id="finance-request-form">
+          <Form id="finance-request-form" onSubmit={handleSubmit}>
             <Section>
               <Label htmlFor="title">제목</Label>
-              <Input id="title" name="title" placeholder="제목" />
+              <Input
+                id="title"
+                name="title"
+                placeholder="제목"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                required
+              />
             </Section>
 
             <Section>
               <SectionTitle>신청자 정보</SectionTitle>
               <InfoRow>
-                <FieldLabel htmlFor="className">반 이름</FieldLabel>
-                <InlineInput id="className" name="className" placeholder="개나리반" />
+                <FieldLabel htmlFor="classroomId">반 이름</FieldLabel>
+                <InlineSelect
+                  id="classroomId"
+                  name="classroomId"
+                  value={classroomId}
+                  onChange={(event) => setClassroomId(event.target.value)}
+                  required
+                >
+                  <option value="">반 선택</option>
+                  {classrooms.map((classroom) => (
+                    <option key={classroom.id} value={classroom.id}>
+                      {classroom.name}
+                    </option>
+                  ))}
+                </InlineSelect>
                 <FieldLabel htmlFor="paymentDate">결제 일자</FieldLabel>
-                <InlineInput id="paymentDate" name="paymentDate" placeholder="00.00.00" />
+                <InlineInput
+                  id="paymentDate"
+                  name="paymentDate"
+                  type="date"
+                  value={paymentDate}
+                  onChange={(event) => setPaymentDate(event.target.value)}
+                  required
+                />
                 <FieldLabel htmlFor="applicant">신청자</FieldLabel>
-                <InlineInput id="applicant" name="applicant" placeholder="홍길동" />
+                <InlineInput id="applicant" name="applicant" value={applicantName} readOnly />
               </InfoRow>
             </Section>
 
             <Section>
               <SectionTitle>상세 품목</SectionTitle>
-              <ItemBlock>
-                <ItemFieldRow>
-                  <ItemLabel htmlFor="itemName">품목</ItemLabel>
-                  <ItemInput id="itemName" name="itemName" placeholder="품목" />
-                </ItemFieldRow>
-                <ItemFieldRow>
-                  <ItemLabel htmlFor="paymentReason">결제 사유</ItemLabel>
-                  <ItemInput id="paymentReason" name="paymentReason" placeholder="품목" />
-                </ItemFieldRow>
-                <ItemLabel as="span">영수증</ItemLabel>
-                <UploadControl>
-                  <UploadInput id="receiptFile" name="receiptFile" type="file" />
-                  <UploadBox htmlFor="receiptFile">
-                    <IconFilePlus size={24} stroke={1.8} aria-hidden="true" />
-                    <span>파일 추가하기</span>
-                  </UploadBox>
-                </UploadControl>
-              </ItemBlock>
+              <ItemList>
+                {items.map((item, index) => (
+                  <ItemBlock key={item.id}>
+                    <ItemFieldRow>
+                      <ItemLabel htmlFor={`itemName-${item.id}`}>품목 {index + 1}</ItemLabel>
+                      <ItemInput
+                        id={`itemName-${item.id}`}
+                        name={`itemName-${item.id}`}
+                        placeholder="품목"
+                        value={item.name}
+                        onChange={(event) => updateItem(item.id, { name: event.target.value })}
+                        required={index === 0}
+                      />
+                    </ItemFieldRow>
+                    <ItemFieldRow>
+                      <ItemLabel htmlFor={`paymentReason-${item.id}`}>결제 사유</ItemLabel>
+                      <ItemInput
+                        id={`paymentReason-${item.id}`}
+                        name={`paymentReason-${item.id}`}
+                        placeholder="결제 사유"
+                        value={item.reason}
+                        onChange={(event) => updateItem(item.id, { reason: event.target.value })}
+                      />
+                    </ItemFieldRow>
+                    <ItemFieldRow>
+                      <ItemLabel htmlFor={`expectedPrice-${item.id}`}>예상 금액</ItemLabel>
+                      <ItemInput
+                        id={`expectedPrice-${item.id}`}
+                        name={`expectedPrice-${item.id}`}
+                        type="number"
+                        min="0"
+                        inputMode="numeric"
+                        placeholder="0"
+                        value={item.expectedPrice}
+                        onChange={(event) =>
+                          updateItem(item.id, { expectedPrice: event.target.value })
+                        }
+                      />
+                    </ItemFieldRow>
+                    <ItemLabel as="span">영수증</ItemLabel>
+                    <UploadControl>
+                      <UploadInput
+                        id={`receiptFile-${item.id}`}
+                        name={`receiptFile-${item.id}`}
+                        type="file"
+                        onChange={(event) =>
+                          updateItem(item.id, {
+                            receiptFileName: event.target.files?.[0]?.name ?? "",
+                          })
+                        }
+                      />
+                      <UploadBox htmlFor={`receiptFile-${item.id}`}>
+                        <IconFilePlus size={24} stroke={1.8} aria-hidden="true" />
+                        <span>{item.receiptFileName || "파일 추가하기"}</span>
+                      </UploadBox>
+                    </UploadControl>
+                    {items.length > 1 ? (
+                      <ItemActionRow>
+                        <DeleteItemButton type="button" onClick={() => removeItem(item.id)}>
+                          품목 삭제
+                        </DeleteItemButton>
+                      </ItemActionRow>
+                    ) : null}
+                  </ItemBlock>
+                ))}
+              </ItemList>
 
-              <AddItemButton type="button">품목 추가하기</AddItemButton>
+              <AddItemButton type="button" onClick={addItem}>
+                품목 추가하기
+              </AddItemButton>
+              {mutation.isError ? (
+                <StatusMessage role="alert">결제 신청서 제출에 실패했습니다.</StatusMessage>
+              ) : null}
             </Section>
           </Form>
         </Content>
@@ -150,6 +363,11 @@ const SubmitButton = styled.button`
   white-space: nowrap;
   cursor: pointer;
 
+  &:disabled {
+    background-color: #b7b7b7;
+    cursor: not-allowed;
+  }
+
   @media (min-width: 120rem) {
     min-height: 4rem;
     padding: ${spacing.space20} 1.875rem;
@@ -234,7 +452,7 @@ const Input = styled.input`
 
 const InfoRow = styled.div`
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   gap: ${spacing.space12};
 
@@ -268,11 +486,26 @@ const InlineInput = styled.input`
   }
 `;
 
+const InlineSelect = styled.select`
+  ${inputBase}
+  padding: 0.8125rem ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+  }
+`;
+
+const ItemList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const ItemBlock = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: ${spacing.space12};
-  padding-bottom: ${spacing.space20};
+  padding: ${spacing.space20} 0 ${spacing.space20};
   border-bottom: 1px solid #bcbcbc;
 
   @media (min-width: 120rem) {
@@ -345,6 +578,13 @@ const UploadBox = styled.label`
   line-height: ${typography.lineHeight130};
   cursor: pointer;
 
+  span {
+    max-width: 8rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   @media (min-width: 120rem) {
     min-width: 8.375rem;
     min-height: 6.25rem;
@@ -357,6 +597,14 @@ const UploadBox = styled.label`
       height: 2rem;
     }
   }
+`;
+
+const StatusMessage = styled.p`
+  margin: 0;
+  color: #da3a30;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
 `;
 
 const AddItemButton = styled.button`
@@ -373,6 +621,33 @@ const AddItemButton = styled.button`
   cursor: pointer;
 
   @media (min-width: 120rem) {
+    min-height: 3.125rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ItemActionRow = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: ${spacing.space12};
+  display: flex;
+  justify-content: flex-end;
+
+  @media (min-width: 120rem) {
+    bottom: ${spacing.space20};
+  }
+`;
+
+const DeleteItemButton = styled(AddItemButton)`
+  width: 9rem;
+  min-height: 2.125rem;
+  border-color: #e45a52;
+  background-color: #fde4e2;
+  color: #da3a30;
+
+  @media (min-width: 120rem) {
+    width: 12rem;
     min-height: 3.125rem;
     font-size: ${typography.fontSize20};
   }

--- a/components/staff/FinanceRequestDetailPage.tsx
+++ b/components/staff/FinanceRequestDetailPage.tsx
@@ -1,25 +1,70 @@
+"use client";
+
 import Link from "next/link";
 import { IconDownload } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import {
+  deletePurchaseRequest,
+  getPurchaseRequestDetail,
+} from "@/api/request/request.api";
+import type { PurchaseRequestStatus } from "@/api/request/request.dto";
 import StaffSidebar from "@/components/staff/StaffSidebar";
-import type { FinanceRequest } from "@/mocks/staffFinance";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type FinanceRequestDetailPageProps = {
-  request: FinanceRequest;
+  requestId: number;
 };
 
-const receiptFiles = ["자료.pdf", "자료.pdf", "자료.pdf", "자료.pdf"];
+const statusLabels: Record<PurchaseRequestStatus, string> = {
+  PENDING: "대기 중",
+  APPROVED: "승인 완료",
+  PURCHASED: "구매 완료",
+  CONFIRMED: "결재 확인",
+  REJECTED: "반려",
+};
 
-export default function FinanceRequestDetailPage({ request }: FinanceRequestDetailPageProps) {
-  const detailItems = [
-    {
-      id: request.id,
-      name: request.title,
-      reason: request.detail,
-      receipts: receiptFiles,
+function getStatusLabel(status?: PurchaseRequestStatus) {
+  return status ? (statusLabels[status] ?? status) : "-";
+}
+
+export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDetailPageProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data: request, isLoading, isError } = useQuery({
+    queryKey: queryKeys.requests.purchaseDetail(requestId),
+    queryFn: () => getPurchaseRequestDetail({ requestId }),
+    retry: false,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deletePurchaseRequest({ requestId }),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: queryKeys.requests.purchaseDetail(requestId) });
+      queryClient.removeQueries({ queryKey: queryKeys.requests.purchaseList() });
+      router.replace("/staff/finance");
     },
-  ];
+  });
+
+  const detailItems =
+    request?.items?.length
+      ? request.items.map((item, index) => ({
+          id: item.id ?? index,
+          name: item.name ?? "-",
+          reason: item.reason ?? request.content ?? "-",
+          price: item.actualPrice ?? item.expectedPrice,
+        }))
+      : [
+          {
+            id: request?.id ?? 0,
+            name: request?.title ?? "-",
+            reason: request?.content ?? "-",
+            price: request?.totalPrice,
+          },
+        ];
 
   return (
     <Main>
@@ -28,67 +73,95 @@ export default function FinanceRequestDetailPage({ request }: FinanceRequestDeta
 
         <Content>
           <Actions>
-            <ActionButton type="button" $variant="danger">
-              삭제
+            <ActionButton
+              type="button"
+              $variant="danger"
+              disabled={deleteMutation.isPending || isLoading || !request}
+              onClick={() => deleteMutation.mutate()}
+            >
+              {deleteMutation.isPending ? "삭제 중" : "삭제"}
             </ActionButton>
-            <ActionButton type="button">수정</ActionButton>
+            <ActionButton type="button" disabled title="백엔드 수정 API가 아직 없습니다.">
+              수정
+            </ActionButton>
             <ListButton href="/staff/finance">목록</ListButton>
           </Actions>
 
-          <ContentColumn>
-            <DateBar>{request.paymentDate}</DateBar>
+          {isLoading ? <StateMessage>결제 신청 정보를 불러오는 중입니다.</StateMessage> : null}
+          {isError ? (
+            <StateMessage role="alert">결제 신청 정보를 불러오지 못했습니다.</StateMessage>
+          ) : null}
+          {deleteMutation.isError ? (
+            <StateMessage role="alert">결제 신청 삭제에 실패했습니다.</StateMessage>
+          ) : null}
 
-            <Section>
-              <Label>제목</Label>
-              <Field>{request.title}</Field>
-            </Section>
+          {request ? (
+            <ContentColumn>
+              <DateBar>{formatUtcToKstShortDate(request.createdAt)}</DateBar>
 
-            <Section>
-              <SectionTitle>신청자 정보</SectionTitle>
-              <InfoRow>
-                <InlineLabel>반 이름</InlineLabel>
-                <InlineField>{request.className}</InlineField>
-                <InlineLabel>결제 일자</InlineLabel>
-                <InlineField>{request.paymentDate}</InlineField>
-                <InlineLabel>신청자</InlineLabel>
-                <InlineField>{request.author}</InlineField>
-              </InfoRow>
-            </Section>
+              <Section>
+                <Label>제목</Label>
+                <Field>{request.title ?? "-"}</Field>
+              </Section>
 
-            <Section>
-              <SectionTitle>상세 품목</SectionTitle>
-              <DetailItemList>
-                {detailItems.map((item, index) => (
-                  <DetailItemRow key={item.id}>
-                    <DetailLabel>품목 {index + 1}</DetailLabel>
-                    <DetailField>{item.name}</DetailField>
-                    <DetailLabel>결제 사유</DetailLabel>
-                    <ReasonField>{item.reason}</ReasonField>
-                    <DetailLabel>영수증</DetailLabel>
-                    <ReceiptList>
-                      {item.receipts.map((receipt, receiptIndex) => (
-                        <ReceiptLink
-                          key={`${item.id}-${receiptIndex}`}
-                          href="#"
-                          aria-label={`${receipt} 다운로드`}
-                        >
-                          <span>{receipt}</span>
-                          <ReceiptIcon aria-hidden="true">
-                            <IconDownload size={16} stroke={2.25} />
-                          </ReceiptIcon>
-                        </ReceiptLink>
-                      ))}
-                    </ReceiptList>
-                  </DetailItemRow>
-                ))}
-              </DetailItemList>
-            </Section>
+              <Section>
+                <SectionTitle>신청자 정보</SectionTitle>
+                <InfoRow>
+                  <InlineLabel>반 이름</InlineLabel>
+                  <InlineField>{request.classroomName ?? "-"}</InlineField>
+                  <InlineLabel>결제 일자</InlineLabel>
+                  <InlineField>{formatUtcToKstShortDate(request.createdAt)}</InlineField>
+                  <InlineLabel>신청자</InlineLabel>
+                  <InlineField>{request.requestedByName ?? "-"}</InlineField>
+                </InfoRow>
+              </Section>
 
-            <Section>
-              <SectionTitle>신청 현황</SectionTitle>
-              <StatusField>{request.status}</StatusField>
-            </Section>
-          </ContentColumn>
+              <Section>
+                <SectionTitle>상세 품목</SectionTitle>
+                <DetailItemList>
+                  {detailItems.map((item, index) => (
+                    <DetailItemRow key={`${item.id}-${index}`}>
+                      <DetailLabel>품목 {index + 1}</DetailLabel>
+                      <DetailField>{item.name}</DetailField>
+                      <DetailLabel>결제 사유</DetailLabel>
+                      <ReasonField>{item.reason}</ReasonField>
+                      <DetailLabel>금액</DetailLabel>
+                      <DetailField>
+                        {typeof item.price === "number" ? `${item.price.toLocaleString()}원` : "-"}
+                      </DetailField>
+                    </DetailItemRow>
+                  ))}
+                </DetailItemList>
+              </Section>
+
+              <Section>
+                <SectionTitle>영수증</SectionTitle>
+                <ReceiptList>
+                  {request.receipts?.length ? (
+                    request.receipts.map((receipt) => (
+                      <ReceiptLink
+                        key={receipt.id ?? receipt.fileId}
+                        href={receipt.fileUrl ?? "#"}
+                        aria-label={`${receipt.fileId ?? "영수증"} 다운로드`}
+                      >
+                        <span>{receipt.fileId ?? "영수증"}</span>
+                        <ReceiptIcon aria-hidden="true">
+                          <IconDownload size={16} stroke={2.25} />
+                        </ReceiptIcon>
+                      </ReceiptLink>
+                    ))
+                  ) : (
+                    <EmptyText>등록된 영수증이 없습니다.</EmptyText>
+                  )}
+                </ReceiptList>
+              </Section>
+
+              <Section>
+                <SectionTitle>신청 현황</SectionTitle>
+                <StatusField>{getStatusLabel(request.status)}</StatusField>
+              </Section>
+            </ContentColumn>
+          ) : null}
         </Content>
       </Stage>
     </Main>
@@ -196,6 +269,12 @@ const BaseAction = styled.button<{ $variant?: "default" | "danger" }>`
   line-height: ${typography.lineHeight130};
   text-decoration: none;
   cursor: pointer;
+
+  &:disabled {
+    background-color: #d4d4d4;
+    color: #7b7b7b;
+    cursor: not-allowed;
+  }
 
   @media (min-width: 120rem) {
     min-width: 5.9375rem;
@@ -376,6 +455,21 @@ const ReceiptList = styled.div`
   @media (min-width: 120rem) {
     padding: ${spacing.space20};
   }
+`;
+
+const StateMessage = styled.p`
+  margin: 0 0 ${spacing.space20};
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
+`;
+
+const EmptyText = styled.span`
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
 `;
 
 const ReceiptLink = styled(Link)`

--- a/components/staff/FinanceRequestListPage.tsx
+++ b/components/staff/FinanceRequestListPage.tsx
@@ -1,30 +1,64 @@
+"use client";
+
 import styled from "styled-components";
+import { useQuery } from "@tanstack/react-query";
+import { getPurchaseRequests } from "@/api/request/request.api";
+import type { PurchaseRequestStatus } from "@/api/request/request.dto";
 import ListPanel from "@/components/staff/ListPanel";
 import StaffSidebar from "@/components/staff/StaffSidebar";
-import { FINANCE_REQUESTS_PER_PAGE, type FinanceRequest } from "@/mocks/staffFinance";
+import { FINANCE_REQUESTS_PER_PAGE } from "@/mocks/staffFinance";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type FinanceRequestListPageProps = {
   currentPage: number;
-  requests: FinanceRequest[];
-  totalPages: number;
 };
 
-export default function FinanceRequestListPage({
-  currentPage,
-  requests,
-  totalPages,
-}: FinanceRequestListPageProps) {
-  const rows = requests.map((request, index) => ({
-    id: request.id,
-    no: String((currentPage - 1) * FINANCE_REQUESTS_PER_PAGE + index + 1).padStart(2, "0"),
-    className: request.className,
-    title: request.title,
-    author: request.author,
-    date: request.paymentDate,
-    status: request.status,
+const statusLabels: Record<PurchaseRequestStatus, string> = {
+  PENDING: "대기 중",
+  APPROVED: "승인 완료",
+  PURCHASED: "구매 완료",
+  CONFIRMED: "결재 확인",
+  REJECTED: "반려",
+};
+
+function getStatusLabel(status?: PurchaseRequestStatus) {
+  return status ? (statusLabels[status] ?? status) : "-";
+}
+
+export default function FinanceRequestListPage({ currentPage }: FinanceRequestListPageProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.requests.purchaseList(),
+    queryFn: () => getPurchaseRequests(),
+    retry: false,
+  });
+
+  const requests = data ?? [];
+  const totalPages = Math.max(1, Math.ceil(requests.length / FINANCE_REQUESTS_PER_PAGE));
+  const safeCurrentPage =
+    Number.isInteger(currentPage) && currentPage >= 1 && currentPage <= totalPages
+      ? currentPage
+      : 1;
+  const startIndex = (safeCurrentPage - 1) * FINANCE_REQUESTS_PER_PAGE;
+  const visibleRequests = requests.slice(startIndex, startIndex + FINANCE_REQUESTS_PER_PAGE);
+
+  const rows = visibleRequests.map((request, index) => ({
+    id: request.id ?? index,
+    no: String((safeCurrentPage - 1) * FINANCE_REQUESTS_PER_PAGE + index + 1).padStart(2, "0"),
+    className: request.classroomName ?? "-",
+    title: request.title ?? "제목 없음",
+    author: request.requestedByName ?? "-",
+    date: formatUtcToKstShortDate(request.createdAt),
+    status: getStatusLabel(request.status),
     detailHref: `/staff/finance/${request.id}`,
   }));
+
+  const emptyMessage = isLoading
+    ? "결제 신청 내역을 불러오는 중입니다."
+    : isError
+      ? "결제 신청 내역을 불러오지 못했습니다."
+      : "결제 신청 내역이 없습니다.";
 
   return (
     <Main>
@@ -38,10 +72,10 @@ export default function FinanceRequestListPage({
             writeHref="/staff/finance/new"
             listPath="/staff/finance"
             rows={rows}
-            currentPage={currentPage}
+            currentPage={safeCurrentPage}
             totalPages={totalPages}
             showMineOnlyToggle={false}
-            emptyMessage="결제 신청 내역이 없습니다."
+            emptyMessage={emptyMessage}
             headerTone="finance"
           />
         </Content>

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -14,5 +14,7 @@ export const queryKeys = {
     lessonExchangeDetail: (requestId: number) => ["lesson-exchange-request", requestId] as const,
     absenceList: () => ["absence-requests"] as const,
     absenceDetail: (requestId: number) => ["absence-request", requestId] as const,
+    purchaseList: () => ["purchase-requests"] as const,
+    purchaseDetail: (requestId: number) => ["purchase-request", requestId] as const,
   },
 };

--- a/mocks/handlers/auth.handlers.ts
+++ b/mocks/handlers/auth.handlers.ts
@@ -26,8 +26,8 @@ export const DEFAULT_LOGIN_REQUEST: LoginRequestDto = {
 };
 
 export const DEFAULT_SIGNUP_REQUEST: SignupRequestDto = {
-  username: "new-user",
   password: "signup-password",
+  nickname: "new-user",
   name: "New User",
   email: "new-user@example.com",
   phoneNumber: "010-0000-0000",
@@ -57,7 +57,7 @@ export const authHandlers = [
   http.post(`${API_BASE_URL}/api/v1/auth/signup`, async ({ request }) => {
     const body = (await request.json()) as SignupRequestDto;
 
-    if (!body.username || !body.password || !body.name) {
+    if (!body.email || !body.nickname || !body.password || !body.name) {
       return HttpResponse.json({ message: "Invalid signup payload" }, { status: 400 });
     }
 

--- a/mocks/handlers/channel.handlers.ts
+++ b/mocks/handlers/channel.handlers.ts
@@ -9,13 +9,12 @@ import { API_BASE_URL, REFRESHED_ACCESS_TOKEN, VALID_ACCESS_TOKEN } from "./auth
 export const CHANNEL_RESPONSE = {
   id: 1,
   name: "Notice",
-  slug: "notice",
   description: "General notices",
-  channelType: "ALL",
-  classroomId: null,
-  departmentId: null,
-  customRefId: null,
-  writerPolicy: "ADMIN_MANAGER_ONLY",
+  channelType: "NOTICE",
+  bindingType: "STANDALONE",
+  refId: null,
+  accessLevel: "READ_ONLY",
+  allowGuestRead: false,
   isDefault: true,
   isActive: true,
   lastPostedAt: "2026-04-10T19:30:00",
@@ -46,7 +45,7 @@ export const channelHandlers: RequestHandler[] = [
 
     const body = (await request.json()) as CreateChannelRequestDto;
 
-    if (!body.name || !body.slug || !body.channelType) {
+    if (!body.name || !body.accessLevel) {
       return HttpResponse.json({ message: "Invalid channel payload" }, { status: 400 });
     }
 
@@ -54,13 +53,9 @@ export const channelHandlers: RequestHandler[] = [
       ...CHANNEL_RESPONSE,
       id: 2,
       name: body.name,
-      slug: body.slug,
       description: body.description,
-      channelType: body.channelType,
-      classroomId: body.classroomId ?? null,
-      departmentId: body.departmentId ?? null,
-      customRefId: body.customRefId ?? null,
-      writerPolicy: body.writerPolicy,
+      accessLevel: body.accessLevel,
+      allowGuestRead: body.allowGuestRead,
       isDefault: body.isDefault,
       isActive: body.isActive,
     });
@@ -94,27 +89,5 @@ export const channelHandlers: RequestHandler[] = [
     }
 
     return new HttpResponse(null, { status: 204 });
-  }),
-  http.patch(`${API_BASE_URL}/api/v1/channels/:id/show`, ({ request, params }) => {
-    if (!hasValidAuthorization(request)) {
-      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    return HttpResponse.json({
-      ...CHANNEL_RESPONSE,
-      id: Number(params.id),
-      isActive: true,
-    });
-  }),
-  http.patch(`${API_BASE_URL}/api/v1/channels/:id/hide`, ({ request, params }) => {
-    if (!hasValidAuthorization(request)) {
-      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
-    return HttpResponse.json({
-      ...CHANNEL_RESPONSE,
-      id: Number(params.id),
-      isActive: false,
-    });
   }),
 ];

--- a/mocks/handlers/classroom.handlers.ts
+++ b/mocks/handlers/classroom.handlers.ts
@@ -61,7 +61,7 @@ export const classroomHandlers: RequestHandler[] = [
       id: Number(params.id),
     });
   }),
-  http.put(`${API_BASE_URL}/api/v1/classrooms/:id`, async ({ request, params }) => {
+  http.patch(`${API_BASE_URL}/api/v1/classrooms/:id`, async ({ request, params }) => {
     if (!hasValidAuthorization(request)) {
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }

--- a/mocks/handlers/post.handlers.ts
+++ b/mocks/handlers/post.handlers.ts
@@ -8,7 +8,7 @@ export const POST_SUMMARY_RESPONSE = {
   id: 1,
   channelId: 1,
   channelName: "Notice",
-  channelType: "ALL",
+  channelType: "NOTICE",
   title: "April notice",
   postType: "NOTICE",
   status: "PUBLISHED",
@@ -96,7 +96,7 @@ export const postHandlers: RequestHandler[] = [
 
     const body = (await request.json()) as CreatePostRequestDto;
 
-    if (!body.title || !body.contentHtml || !body.postType) {
+    if (!body.title || !body.contentHtml) {
       return HttpResponse.json({ message: "Invalid post payload" }, { status: 400 });
     }
 

--- a/mocks/handlers/request.handlers.ts
+++ b/mocks/handlers/request.handlers.ts
@@ -136,6 +136,9 @@ export const requestHandlers: RequestHandler[] = [
       HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, id: Number(params.requestId) })
     );
   }),
+  http.delete(`${API_BASE_URL}/api/v1/purchase-requests/:requestId`, ({ request }) => {
+    return unauthorizedWhenNeeded(request) ?? new HttpResponse(null, { status: 204 });
+  }),
   http.post(`${API_BASE_URL}/api/v1/purchase-requests/:requestId/report`, async ({ request, params }) => {
     const unauthorizedResponse = unauthorizedWhenNeeded(request);
     if (unauthorizedResponse) return unauthorizedResponse;
@@ -159,6 +162,9 @@ export const requestHandlers: RequestHandler[] = [
       unauthorizedWhenNeeded(request) ??
       HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, id: Number(params.requestId) })
     );
+  }),
+  http.delete(`${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId`, ({ request }) => {
+    return unauthorizedWhenNeeded(request) ?? new HttpResponse(null, { status: 204 });
   }),
   http.patch(
     `${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId/approve`,

--- a/mocks/handlers/request.handlers.ts
+++ b/mocks/handlers/request.handlers.ts
@@ -14,14 +14,18 @@ export const ABSENCE_REQUEST_RESPONSE = {
 
 export const PURCHASE_REQUEST_RESPONSE = {
   id: 2,
-  subjectId: 21,
-  subjectName: "English",
+  classroomId: 21,
+  classroomName: "한글반",
   requestedById: 5,
   requestedByName: "Teacher One",
   title: "Workbook",
   content: "Need new workbook copies",
-  price: 30000,
+  totalPrice: 30000,
+  advancePaymentRequestedAmount: 30000,
+  advancePaymentApprovedAmount: 30000,
   status: "PENDING",
+  items: [{ id: 1, name: "Workbook", expectedPrice: 30000 }],
+  receipts: [],
 };
 
 export const LESSON_EXCHANGE_REQUEST_RESPONSE = {
@@ -119,10 +123,10 @@ export const requestHandlers: RequestHandler[] = [
     if (unauthorizedResponse) return unauthorizedResponse;
 
     const body = (await request.json()) as {
-      subjectId?: number;
+      classroomId?: number;
       title?: string;
       content?: string;
-      price?: number;
+      items?: unknown[];
     };
     return HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, ...body, id: 20 });
   }),
@@ -132,18 +136,47 @@ export const requestHandlers: RequestHandler[] = [
       HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, id: Number(params.requestId) })
     );
   }),
-  http.patch(`${API_BASE_URL}/api/v1/purchase-requests/:requestId/approve`, ({ request, params }) => {
+  http.post(`${API_BASE_URL}/api/v1/purchase-requests/:requestId/report`, async ({ request, params }) => {
+    const unauthorizedResponse = unauthorizedWhenNeeded(request);
+    if (unauthorizedResponse) return unauthorizedResponse;
+
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({
+      ...PURCHASE_REQUEST_RESPONSE,
+      id: Number(params.requestId),
+      ...body,
+      status: "PURCHASED",
+    });
+  }),
+  http.post(`${API_BASE_URL}/api/v1/purchase-requests/:requestId/reconfirmation`, ({ request }) => {
+    return unauthorizedWhenNeeded(request) ?? HttpResponse.json({ message: "재확인을 요청했습니다." });
+  }),
+  http.get(`${API_BASE_URL}/api/v1/admin/purchase-requests`, ({ request }) => {
+    return unauthorizedWhenNeeded(request) ?? HttpResponse.json([PURCHASE_REQUEST_RESPONSE]);
+  }),
+  http.get(`${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId`, ({ request, params }) => {
     return (
       unauthorizedWhenNeeded(request) ??
-      HttpResponse.json({
-        ...PURCHASE_REQUEST_RESPONSE,
-        id: Number(params.requestId),
-        status: "APPROVED",
-      })
+      HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, id: Number(params.requestId) })
     );
   }),
   http.patch(
-    `${API_BASE_URL}/api/v1/purchase-requests/:requestId/reject`,
+    `${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId/approve`,
+    async ({ request, params }) => {
+      const unauthorizedResponse = unauthorizedWhenNeeded(request);
+      if (unauthorizedResponse) return unauthorizedResponse;
+
+      const body = (await request.json()) as { note?: string };
+      return HttpResponse.json({
+        ...PURCHASE_REQUEST_RESPONSE,
+        id: Number(params.requestId),
+        status: "APPROVED",
+        note: body.note ?? "",
+      });
+    },
+  ),
+  http.patch(
+    `${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId/reject`,
     async ({ request, params }) => {
       const unauthorizedResponse = unauthorizedWhenNeeded(request);
       if (unauthorizedResponse) return unauthorizedResponse;
@@ -157,6 +190,16 @@ export const requestHandlers: RequestHandler[] = [
       });
     },
   ),
+  http.patch(`${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId/confirm`, ({ request, params }) => {
+    return (
+      unauthorizedWhenNeeded(request) ??
+      HttpResponse.json({
+        ...PURCHASE_REQUEST_RESPONSE,
+        id: Number(params.requestId),
+        status: "CONFIRMED",
+      })
+    );
+  }),
   http.get(`${API_BASE_URL}/api/v1/lesson-exchange-requests`, ({ request }) => {
     return unauthorizedWhenNeeded(request) ?? HttpResponse.json([LESSON_EXCHANGE_REQUEST_RESPONSE]);
   }),

--- a/mocks/handlers/user.handlers.ts
+++ b/mocks/handlers/user.handlers.ts
@@ -6,11 +6,13 @@ export const USER_LIST_RESPONSE = {
   content: [
     {
       id: 1,
-      username: "teacher-1",
       name: "Teacher One",
+      nickname: "teacher-1",
       email: "teacher1@example.com",
       phoneNumber: "010-2222-3333",
-      roles: [{ name: "TEACHER", level: 1, code: 101 }],
+      role: "VOLUNTEER",
+      departmentId: 1,
+      permissions: [{ name: "게시판 관리", code: "post:manage:*" }],
     },
   ],
   page: 0,
@@ -45,8 +47,12 @@ export const userHandlers: RequestHandler[] = [
     const unauthorizedResponse = unauthorizedWhenNeeded(request);
     if (unauthorizedResponse) return unauthorizedResponse;
 
-    const body = (await request.json()) as { username?: string; name?: string; email?: string };
-    if (!body.username || !body.name) {
+    const body = (await request.json()) as {
+      email?: string;
+      nickname?: string;
+      name?: string;
+    };
+    if (!body.email || !body.nickname || !body.name) {
       return HttpResponse.json({ message: "Invalid user payload" }, { status: 400 });
     }
 
@@ -78,51 +84,28 @@ export const userHandlers: RequestHandler[] = [
   http.delete(`${API_BASE_URL}/api/v1/users/:userId`, ({ request }) => {
     return unauthorizedWhenNeeded(request) ?? new HttpResponse(null, { status: 204 });
   }),
-  http.get(`${API_BASE_URL}/api/v1/users/:userId/roles`, ({ request }) => {
-    return unauthorizedWhenNeeded(request) ?? HttpResponse.json(USER_DETAIL_RESPONSE.roles);
+  http.get(`${API_BASE_URL}/api/v1/users/:userId/permissions`, ({ request }) => {
+    return unauthorizedWhenNeeded(request) ?? HttpResponse.json(USER_DETAIL_RESPONSE.permissions);
   }),
-  http.post(`${API_BASE_URL}/api/v1/users/:userId/roles`, async ({ request }) => {
+  http.post(`${API_BASE_URL}/api/v1/users/:userId/permissions`, async ({ request }) => {
     const unauthorizedResponse = unauthorizedWhenNeeded(request);
     if (unauthorizedResponse) return unauthorizedResponse;
 
-    const body = (await request.json()) as { subRole?: string };
+    const body = (await request.json()) as { permissionCode?: string };
     return HttpResponse.json([
-      ...(USER_DETAIL_RESPONSE.roles ?? []),
-      { name: body.subRole ?? "ASSISTANT", level: 2, code: 202 },
+      ...(USER_DETAIL_RESPONSE.permissions ?? []),
+      { name: "추가 권한", code: body.permissionCode ?? "post:write:*" },
     ]);
   }),
-  http.delete(`${API_BASE_URL}/api/v1/users/:userId/roles`, async ({ request }) => {
+  http.delete(`${API_BASE_URL}/api/v1/users/:userId/permissions`, async ({ request }) => {
     const unauthorizedResponse = unauthorizedWhenNeeded(request);
     if (unauthorizedResponse) return unauthorizedResponse;
 
-    const body = (await request.json()) as { subRole?: string };
+    const body = (await request.json()) as { permissionCode?: string };
     return HttpResponse.json(
-      (USER_DETAIL_RESPONSE.roles ?? []).filter((role) => role.name !== body.subRole),
+      (USER_DETAIL_RESPONSE.permissions ?? []).filter(
+        (permission) => permission.code !== body.permissionCode,
+      ),
     );
   }),
-  http.get(`${API_BASE_URL}/api/v1/users/:userId/departments`, ({ request }) => {
-    return (
-      unauthorizedWhenNeeded(request) ??
-      HttpResponse.json({
-        departments: [{ id: 1, name: "Education", description: "Education team" }],
-      })
-    );
-  }),
-  http.get(`${API_BASE_URL}/api/v1/users/me/departments`, ({ request }) => {
-    return (
-      unauthorizedWhenNeeded(request) ??
-      HttpResponse.json({
-        departments: [{ id: 1, name: "Education", description: "Education team" }],
-      })
-    );
-  }),
-  http.post(`${API_BASE_URL}/api/v1/users/:userId/departments`, ({ request }) => {
-    return unauthorizedWhenNeeded(request) ?? new HttpResponse(null, { status: 204 });
-  }),
-  http.delete(
-    `${API_BASE_URL}/api/v1/users/:userId/departments/:departmentId`,
-    ({ request }) => {
-      return unauthorizedWhenNeeded(request) ?? new HttpResponse(null, { status: 204 });
-    },
-  ),
 ];


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 결제 신청 API 연동
   \- 결제 신청 목록 조회 API를 연결하였습니다.
   \- 결제 신청 상세 조회 API를 연결하였습니다.
   \- 결제 신청 생성 API를 연결하였습니다.
   \- 결제 신청 삭제 API를 연결하였습니다.
   \- 백엔드 명세에 수정 API가 없어 수정 버튼은 비활성 상태로 처리하였습니다.

   <img width="1917" height="701" alt="화면 캡처 2026-05-08 173511" src="https://github.com/user-attachments/assets/014b94c1-283c-4180-9c8d-521229e17ffa" />

   배포된 사이트에서 관리자 계정으로 로그인하면, 목록 데이터가 정상적으로 조회되는 것을 확인할 수 있습니다.

   <img width="1897" height="865" alt="화면 캡처 2026-05-08 173615" src="https://github.com/user-attachments/assets/a12a7c16-58e0-40a0-9e6d-c87498435fe2" />

   신청서 작성

   <img width="1918" height="867" alt="스크린샷 2026-05-08 173631" src="https://github.com/user-attachments/assets/9fe8f66a-d3eb-4f3f-b8e5-b916cc7ddcd5" />

   새로운 신청 항목 생성

2. 결제 신청서 작성 화면 개선
   \- 결제 일자를 date input으로 수정 가능하게 연결하였습니다.
   \- 신청자는 현재 로그인한 사용자 정보 기반으로 자동 표시합니다.
   \- 품목 추가 및 품목 삭제 동작을 추가하였습니다.

   <img width="1897" height="865" alt="스크린샷 2026-05-08 174050" src="https://github.com/user-attachments/assets/03891bdb-ce7d-4f49-951e-49fe67749b5b" />

4. Mock 및 Query Key 정리
   \- 구매 요청 관련 query key를 추가했습니다.
   \- MSW handler에 구매 요청 삭제 흐름을 반영했습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #50 

## 💬 기타 사항

개선해야 할 사항은 다음과 같습니다.

1. 현재 요청서 생성 시, 반만 선택 가능하게 되어 있습니다. 해당 부분은 추후 수정할 예정입니다.
2. 관리자가 승인하기 전에는 영수증 관련 목록을 별도로 노출할 필요가 없을 것 같습니다. 승인 후에는 요청서 전체 글을 다시 수정하는 방식보다는, 작성자 본인만 기존 요청서 본문에서 바로 영수증을 추가할 수 있도록 하는 방식이 적절해 보입니다.

## 📂 참고 자료

> N/A
