### PR TITLE
[FEAT] 관리자 페이지 구축

### DIFF
--- a/api/auth/auth.api.test.ts
+++ b/api/auth/auth.api.test.ts
@@ -19,7 +19,16 @@ import {
 } from "../../mocks/handlers/auth.handlers";
 
 import { getAccessToken, getRefreshToken, setTokens } from "../client/tokenStorage";
-import { login, logout, logoutAllDevices, refreshToken, signup } from "./auth.api";
+import {
+  connectLocalAccount,
+  googleLogin,
+  googleSignup,
+  login,
+  logout,
+  logoutAllDevices,
+  refreshToken,
+  signup,
+} from "./auth.api";
 
 describe("auth.api", () => {
   it("returns the login token DTO and stores the received tokens", async () => {
@@ -130,5 +139,58 @@ describe("auth.api", () => {
     expect(response).toEqual({ message: "Logged out from all devices" });
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+  });
+
+  it("returns and stores tokens for Google auth flows", async () => {
+    let observedSignupBody: unknown;
+    let observedLoginBody: unknown;
+    let observedConnectBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth/google/signup`, async ({ request }) => {
+        observedSignupBody = await request.json();
+        return HttpResponse.json({
+          accessToken: VALID_ACCESS_TOKEN,
+          refreshToken: VALID_REFRESH_TOKEN,
+          tokenType: "Bearer",
+        });
+      }),
+      http.post(`${API_BASE_URL}/api/v1/auth/google/login`, async ({ request }) => {
+        observedLoginBody = await request.json();
+        return HttpResponse.json({
+          accessToken: REFRESHED_ACCESS_TOKEN,
+          refreshToken: REFRESHED_REFRESH_TOKEN,
+          tokenType: "Bearer",
+        });
+      }),
+      http.post(`${API_BASE_URL}/api/v1/auth/google/connect`, async ({ request }) => {
+        observedConnectBody = await request.json();
+        return HttpResponse.json({
+          accessToken: VALID_ACCESS_TOKEN,
+          refreshToken: VALID_REFRESH_TOKEN,
+          tokenType: "Bearer",
+        });
+      }),
+    );
+
+    await googleSignup({
+      tempToken: "temp-token",
+      nickname: "nickname",
+      name: "User",
+      phoneNumber: "010-0000-0000",
+    });
+    await googleLogin({ tempToken: "temp-token" });
+    await connectLocalAccount({ tempToken: "temp-token" });
+
+    expect(observedSignupBody).toEqual({
+      tempToken: "temp-token",
+      nickname: "nickname",
+      name: "User",
+      phoneNumber: "010-0000-0000",
+    });
+    expect(observedLoginBody).toEqual({ tempToken: "temp-token" });
+    expect(observedConnectBody).toEqual({ tempToken: "temp-token" });
+    expect(getAccessToken()).toBe(VALID_ACCESS_TOKEN);
+    expect(getRefreshToken()).toBe(VALID_REFRESH_TOKEN);
   });
 });

--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -3,6 +3,9 @@ import publicClient from "../client/publicClient";
 import { clearTokens, setTokens } from "../client/tokenStorage";
 import type {
   AuthMessageResponseDto,
+  GoogleCallbackQueryParamsDto,
+  GoogleLoginRequestDto,
+  GoogleSignupRequestDto,
   LoginRequestDto,
   LogoutRequestDto,
   RefreshTokenRequestDto,
@@ -41,5 +44,33 @@ export async function logout(body: LogoutRequestDto) {
 export async function logoutAllDevices() {
   const response = await authClient.post<AuthMessageResponseDto>("/api/v1/auth/logout-all");
   clearTokens();
+  return response.data;
+}
+
+export async function redirectToGoogle() {
+  await publicClient.get("/api/v1/auth/google");
+}
+
+export async function handleGoogleCallback(query: GoogleCallbackQueryParamsDto) {
+  await publicClient.get("/api/v1/auth/google/callback", {
+    params: query,
+  });
+}
+
+export async function googleSignup(body: GoogleSignupRequestDto) {
+  const response = await publicClient.post<TokenResponseDto>("/api/v1/auth/google/signup", body);
+  setTokens(response.data.accessToken, response.data.refreshToken);
+  return response.data;
+}
+
+export async function googleLogin(body: GoogleLoginRequestDto) {
+  const response = await publicClient.post<TokenResponseDto>("/api/v1/auth/google/login", body);
+  setTokens(response.data.accessToken, response.data.refreshToken);
+  return response.data;
+}
+
+export async function connectLocalAccount(body: GoogleLoginRequestDto) {
+  const response = await authClient.post<TokenResponseDto>("/api/v1/auth/google/connect", body);
+  setTokens(response.data.accessToken, response.data.refreshToken);
   return response.data;
 }

--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -31,3 +31,18 @@ export interface TokenResponseDto {
 export interface AuthMessageResponseDto {
   message?: string;
 }
+
+export interface GoogleCallbackQueryParamsDto {
+  code: string;
+}
+
+export interface GoogleSignupRequestDto {
+  tempToken: string;
+  nickname: string;
+  name: string;
+  phoneNumber?: string;
+}
+
+export interface GoogleLoginRequestDto {
+  tempToken: string;
+}

--- a/api/post/post.api.test.ts
+++ b/api/post/post.api.test.ts
@@ -8,7 +8,15 @@ import { POST_DETAIL_RESPONSE, POST_LIST_RESPONSE } from "../../mocks/handlers/p
 import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
-import { createPost, getChannelPosts, getPost, getPosts, updatePost } from "./post.api";
+import {
+  attachPostAttachment,
+  attachPostImage,
+  createPost,
+  getChannelPosts,
+  getPost,
+  getPosts,
+  updatePost,
+} from "./post.api";
 
 describe("post.api", () => {
   it("returns integrated posts with query params", async () => {
@@ -76,5 +84,36 @@ describe("post.api", () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     await expect(getPost({ channelId: 1, postId: 1 })).resolves.toEqual(POST_DETAIL_RESPONSE);
+  });
+
+  it("uploads post images and attachments as multipart form data", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    const uploadedFile = { fileId: "file-1", originalName: "notice.png" };
+    let observedImageContentType = "";
+    let observedAttachmentContentType = "";
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/channels/1/posts/2/images`, ({ request }) => {
+        observedImageContentType = request.headers.get("content-type") ?? "";
+        return HttpResponse.json(uploadedFile);
+      }),
+      http.post(`${API_BASE_URL}/api/v1/channels/1/posts/2/attachments`, ({ request }) => {
+        observedAttachmentContentType = request.headers.get("content-type") ?? "";
+        return HttpResponse.json(uploadedFile);
+      }),
+    );
+
+    const file = new Blob(["file-content"], { type: "image/png" });
+
+    await expect(attachPostImage({ channelId: 1, postId: 2 }, file, "notice.png")).resolves.toEqual(
+      uploadedFile,
+    );
+    await expect(
+      attachPostAttachment({ channelId: 1, postId: 2 }, file, "notice.png"),
+    ).resolves.toEqual(uploadedFile);
+
+    expect(observedImageContentType).toContain("multipart/form-data");
+    expect(observedAttachmentContentType).toContain("multipart/form-data");
   });
 });

--- a/api/post/post.api.ts
+++ b/api/post/post.api.ts
@@ -1,9 +1,9 @@
 import authClient from "../client/authClient";
+import type { FileUploadResponseDto } from "../file/file.dto";
 import type {
+  CreatePostRequestDto,
   ChannelPathParamsDto,
   ChannelPostListQueryParamsDto,
-  AttachPostFileRequestDto,
-  CreatePostRequestDto,
   PostListQueryParamsDto,
   PostDetailResponseDto,
   PostListResponseDto,
@@ -13,6 +13,18 @@ import type {
   SaveDraftRequestDto,
   UpdatePostRequestDto,
 } from "./post.dto";
+
+function createMultipartFormData(file: Blob, filename?: string) {
+  const formData = new FormData();
+
+  if (filename) {
+    formData.append("file", file, filename);
+  } else {
+    formData.append("file", file);
+  }
+
+  return formData;
+}
 
 // 전체 게시글 목록을 통합 조회하는 요청
 export async function getPosts(query?: PostListQueryParamsDto) {
@@ -115,11 +127,17 @@ export async function pinPost(pathParams: PostPathParamsDto, body: PinPostReques
 // 특정 게시글에 본문 이미지를 연결하는 요청
 export async function attachPostImage(
   pathParams: PostPathParamsDto,
-  body: AttachPostFileRequestDto,
+  file: Blob,
+  filename?: string,
 ) {
-  const response = await authClient.post<PostDetailResponseDto>(
+  const response = await authClient.post<FileUploadResponseDto>(
     `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/images`,
-    body,
+    createMultipartFormData(file, filename),
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
   );
   return response.data;
 }
@@ -127,11 +145,17 @@ export async function attachPostImage(
 // 특정 게시글에 첨부파일을 연결하는 요청
 export async function attachPostAttachment(
   pathParams: PostPathParamsDto,
-  body: AttachPostFileRequestDto,
+  file: Blob,
+  filename?: string,
 ) {
-  const response = await authClient.post<PostDetailResponseDto>(
+  const response = await authClient.post<FileUploadResponseDto>(
     `/api/v1/channels/${pathParams.channelId}/posts/${pathParams.postId}/attachments`,
-    body,
+    createMultipartFormData(file, filename),
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
   );
   return response.data;
 }

--- a/api/post/post.dto.ts
+++ b/api/post/post.dto.ts
@@ -64,6 +64,8 @@ export interface PostAttachmentInfoDto {
   originalName?: string;
   contentType?: string;
   fileSize?: number;
+  ext?: string;
+  downloadUrl?: string;
   url?: string;
   sortOrder?: number;
 }

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -32,7 +32,13 @@ describe("request.api", () => {
       http.get(`${API_BASE_URL}/api/v1/absence-requests`, ({ request }) => {
         observedAuthorizationHeader = request.headers.get("authorization");
         observedQueryString = new URL(request.url).search;
-        return HttpResponse.json([ABSENCE_REQUEST_RESPONSE]);
+        return HttpResponse.json({
+          content: [ABSENCE_REQUEST_RESPONSE],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
       }),
     );
 

--- a/api/subject/subject.api.test.ts
+++ b/api/subject/subject.api.test.ts
@@ -12,7 +12,13 @@ import { SUBJECT_LIST_RESPONSE } from "../../mocks/handlers/subject.handlers";
 import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
-import { createSubject, getSubjects, updateSubject } from "./subject.api";
+import {
+  assignSubjectTeacher,
+  createSubject,
+  getSubjects,
+  updateSubject,
+  updateSubjectSchedule,
+} from "./subject.api";
 
 describe("subject.api", () => {
   it("returns subjects with auth header and classroom query", async () => {
@@ -58,7 +64,6 @@ describe("subject.api", () => {
       name: "English Writing",
       startAt: "2026-04-01",
       endAt: "2026-06-30",
-      times: 10,
       dayOfWeek: "MONDAY",
       startTime: "16:00",
       endTime: "17:00",
@@ -73,13 +78,40 @@ describe("subject.api", () => {
       name: "English Writing",
       startAt: "2026-04-01",
       endAt: "2026-06-30",
-      times: 10,
       dayOfWeek: "MONDAY",
       startTime: "16:00",
       endTime: "17:00",
       period: 2,
       description: "Writing practice",
     });
+  });
+
+  it("updates subject teacher and schedule through dedicated Swagger routes", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedTeacherBody: unknown;
+    let observedScheduleBody: unknown;
+
+    server.use(
+      http.patch(`${API_BASE_URL}/api/v1/subjects/1/teacher`, async ({ request }) => {
+        observedTeacherBody = await request.json();
+        return HttpResponse.json({ ...SUBJECT_LIST_RESPONSE[0], teacherId: 5 });
+      }),
+      http.patch(`${API_BASE_URL}/api/v1/subjects/1/schedule`, async ({ request }) => {
+        observedScheduleBody = await request.json();
+        return HttpResponse.json({ ...SUBJECT_LIST_RESPONSE[0], period: 2 });
+      }),
+    );
+
+    await expect(assignSubjectTeacher({ subjectId: 1 }, { teacherId: 5 })).resolves.toMatchObject({
+      teacherId: 5,
+    });
+    await expect(
+      updateSubjectSchedule({ subjectId: 1 }, { dayOfWeek: "TUESDAY", period: 2 }),
+    ).resolves.toMatchObject({ period: 2 });
+
+    expect(observedTeacherBody).toEqual({ teacherId: 5 });
+    expect(observedScheduleBody).toEqual({ dayOfWeek: "TUESDAY", period: 2 });
   });
 
   it("throws when updating a missing subject fails", async () => {

--- a/api/subject/subject.api.ts
+++ b/api/subject/subject.api.ts
@@ -1,9 +1,11 @@
 import authClient from "../client/authClient";
 import type {
+  AssignSubjectTeacherRequestDto,
   CreateSubjectRequestDto,
   SubjectDetailResponseDto,
   SubjectListQueryParamsDto,
   SubjectPathParamsDto,
+  UpdateSubjectScheduleRequestDto,
   UpdateSubjectRequestDto,
 } from "./subject.dto";
 
@@ -36,6 +38,30 @@ export async function updateSubject(
 ) {
   const response = await authClient.patch<SubjectDetailResponseDto>(
     `/api/v1/subjects/${pathParams.subjectId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 과목 담당 교사를 배정하거나 해제하는 요청
+export async function assignSubjectTeacher(
+  pathParams: SubjectPathParamsDto,
+  body: AssignSubjectTeacherRequestDto,
+) {
+  const response = await authClient.patch<SubjectDetailResponseDto>(
+    `/api/v1/subjects/${pathParams.subjectId}/teacher`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 과목 일정을 수정하는 요청
+export async function updateSubjectSchedule(
+  pathParams: SubjectPathParamsDto,
+  body: UpdateSubjectScheduleRequestDto,
+) {
+  const response = await authClient.patch<SubjectDetailResponseDto>(
+    `/api/v1/subjects/${pathParams.subjectId}/schedule`,
     body,
   );
   return response.data;

--- a/api/subject/subject.dto.ts
+++ b/api/subject/subject.dto.ts
@@ -13,11 +13,10 @@ export interface SubjectListQueryParamsDto {
 
 export interface CreateSubjectRequestDto {
   classroomId: number;
-  teacherId: number;
+  teacherId?: number | null;
   name: string;
   startAt: string;
   endAt: string;
-  times: number;
   dayOfWeek: SubjectDayOfWeek;
   startTime: string;
   endTime: string;
@@ -26,23 +25,29 @@ export interface CreateSubjectRequestDto {
 }
 
 export interface UpdateSubjectRequestDto {
-  classroomId?: number;
-  teacherId?: number;
   name?: string;
+  description?: string;
+}
+
+export interface AssignSubjectTeacherRequestDto {
+  teacherId?: number | null;
+}
+
+export interface UpdateSubjectScheduleRequestDto {
   startAt?: string;
   endAt?: string;
-  times?: number;
   dayOfWeek?: SubjectDayOfWeek;
   startTime?: string;
   endTime?: string;
   period?: number;
-  description?: string;
 }
 
 export interface SubjectDetailResponseDto {
   id?: number;
   classroomId?: number;
-  teacherId?: number;
+  classroomName?: string;
+  teacherId?: number | null;
+  teacherName?: string | null;
   name?: string;
   startAt?: string;
   endAt?: string;
@@ -51,6 +56,7 @@ export interface SubjectDetailResponseDto {
   startTime?: string;
   endTime?: string;
   period?: number;
+  teacherAssignedAt?: string | null;
   description?: string;
   isActive?: boolean;
 }

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -13,6 +13,7 @@ import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
 import {
+  getAssignablePermissions,
   getUsers,
   removeUserPermission,
   updateCurrentUser,
@@ -103,5 +104,28 @@ describe("user.api", () => {
     ).rejects.toMatchObject({
       response: { status: 403 },
     });
+  });
+
+  it("returns assignable permission definitions", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/permission-registry`, () => {
+        return HttpResponse.json([
+          {
+            permissionCode: "post:manage:*",
+            resourceCode: "post",
+            actionCode: "manage",
+            globalAllowed: true,
+            targetAllowed: false,
+            label: "게시글 관리",
+          },
+        ]);
+      }),
+    );
+
+    await expect(getAssignablePermissions()).resolves.toEqual([
+      expect.objectContaining({ permissionCode: "post:manage:*" }),
+    ]);
   });
 });

--- a/api/user/user.api.ts
+++ b/api/user/user.api.ts
@@ -1,6 +1,7 @@
 import authClient from "../client/authClient";
 import type {
   CreateUserRequestDto,
+  PermissionDefinitionDto,
   PermissionResponseDto,
   UpdateSelfRequestDto,
   UpdateUserRequestDto,
@@ -87,6 +88,14 @@ export async function removeUserPermission(
     {
       data: body,
     },
+  );
+  return response.data;
+}
+
+// 사용자에게 부여할 수 있는 권한 선택지를 조회하는 요청
+export async function getAssignablePermissions() {
+  const response = await authClient.get<PermissionDefinitionDto[]>(
+    "/api/v1/permission-registry",
   );
   return response.data;
 }

--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -1,8 +1,32 @@
 export type UserRole = string;
 
 export interface PermissionResponseDto {
+  id?: number;
+  permissionCode?: string;
+  resourceCode?: string;
+  resourceLabel?: string;
+  actionCode?: string;
+  actionLabel?: string;
+  scope?: string;
+  targetId?: number | null;
+  targetName?: string | null;
+  label?: string;
+  description?: string;
   name?: string;
   code?: string;
+}
+
+export interface PermissionDefinitionDto {
+  permissionCode?: string;
+  resourceCode?: string;
+  resourceLabel?: string;
+  actionCode?: string;
+  actionLabel?: string;
+  scope?: string;
+  globalAllowed?: boolean;
+  targetAllowed?: boolean;
+  label?: string;
+  description?: string;
 }
 
 export interface UserResponseDto {

--- a/app/(admin)/admin/login/page.tsx
+++ b/app/(admin)/admin/login/page.tsx
@@ -1,0 +1,5 @@
+import AdminLoginPage from "@/components/admin/AdminLoginPage";
+
+export default function Page() {
+  return <AdminLoginPage />;
+}

--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -1,0 +1,5 @@
+import AdminDashboardPage from "@/components/admin/AdminDashboardPage";
+
+export default function Page() {
+  return <AdminDashboardPage />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import QueryProvider from "@/components/providers/QueryProvider";
 import Header from "@/components/layout/Header";
 import StyledComponentsRegistry from "@/lib/styled-components-registry";
+import "react-toastify/dist/ReactToastify.css";
+import "@toast-ui/editor/dist/toastui-editor.css";
 import "./globals.css";
 
 export const metadata: Metadata = {

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -1,31 +1,329 @@
-"use client";
+﻿"use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ToastContainer, toast } from "react-toastify";
 import styled from "styled-components";
-import { getClassrooms } from "@/api/classroom/classroom.api";
-import { getDepartments } from "@/api/department/department.api";
-import { getPurchaseRequests } from "@/api/request/request.api";
-import { getUsers } from "@/api/user/user.api";
+import { AdminMainDashboardSection } from "@/components/admin/AdminMainDashboardSection";
+import { StatePanel } from "@/components/admin/AdminDashboardSectionParts";
+import { AdminChannelsSection } from "@/components/admin/channels/AdminChannelsSection";
+import { AdminClassroomsSection } from "@/components/admin/classes/AdminClassroomsSection";
+import { AdminDepartmentsSection } from "@/components/admin/departments/AdminDepartmentsSection";
+import { AdminPostsSection } from "@/components/admin/posts/AdminPostsSection";
+import { AdminPurchasesSection } from "@/components/admin/purchase-requests/AdminPurchasesSection";
+import { AdminUsersSection } from "@/components/admin/users/AdminUsersSection";
+import type {
+  AdminMenu,
+  ChannelFormState,
+  ClassroomFormState,
+  DepartmentFormState,
+  PermissionFormState,
+  PostCreateState,
+  PostEditState,
+  PurchaseCreateState,
+  UserFormState,
+} from "@/components/admin/AdminDashboardTypes";
+import {
+  createChannel,
+  deleteChannel,
+  getChannel,
+  getChannels,
+  updateChannel,
+} from "@/api/channel/channel.api";
+import {
+  createClassroom,
+  deleteClassroom,
+  getClassroomDetail,
+  getClassrooms,
+  updateClassroom,
+} from "@/api/classroom/classroom.api";
+import {
+  createDepartment,
+  deleteDepartment,
+  getDepartmentDetail,
+  getDepartments,
+  updateDepartment,
+} from "@/api/department/department.api";
+import {
+  createPost,
+  deletePost,
+  getPost,
+  getPosts,
+  pinPost,
+  updatePost,
+} from "@/api/post/post.api";
+import type { PostStatus } from "@/api/post/post.dto";
+import {
+  approveAdminPurchaseRequest,
+  confirmPurchase,
+  createPurchaseRequest,
+  deleteAdminPurchaseRequest,
+  getAdminPurchaseRequestDetail,
+  getAllPurchaseRequests,
+  rejectAdminPurchaseRequest,
+} from "@/api/request/request.api";
+import type { PurchaseRequestStatus } from "@/api/request/request.dto";
+import {
+  addUserPermission,
+  createUser,
+  deleteUser,
+  getAssignablePermissions,
+  getUserDetail,
+  getUserPermissions,
+  getUsers,
+  removeUserPermission,
+  updateUser,
+} from "@/api/user/user.api";
+import type { PermissionDefinitionDto } from "@/api/user/user.dto";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-const dashboardQueryKeys = {
-  users: () => ["admin", "users"] as const,
-  departments: () => ["admin", "departments"] as const,
-  classrooms: () => ["admin", "classrooms"] as const,
-  pendingPurchases: () => ["admin", ...queryKeys.requests.purchaseList(), "pending"] as const,
+const navigationItems: { key: AdminMenu; label: string }[] = [
+  { key: "dashboard", label: "대시보드" },
+  { key: "users", label: "사용자" },
+  { key: "departments", label: "부서" },
+  { key: "classrooms", label: "분반" },
+  { key: "channels", label: "채널" },
+  { key: "posts", label: "게시글" },
+  { key: "purchases", label: "구매 요청" },
+];
+
+const fallbackPermissions: PermissionDefinitionDto[] = [
+  {
+    permissionCode: "user:manage:*",
+    resourceCode: "user",
+    actionCode: "manage",
+    scope: "GLOBAL_ONLY",
+    globalAllowed: true,
+    targetAllowed: false,
+    label: "전체 사용자 관리",
+  },
+  {
+    permissionCode: "department:read:*",
+    resourceCode: "department",
+    actionCode: "read",
+    scope: "BOTH",
+    globalAllowed: true,
+    targetAllowed: true,
+    label: "부서 조회",
+  },
+  {
+    permissionCode: "department:manage:*",
+    resourceCode: "department",
+    actionCode: "manage",
+    scope: "BOTH",
+    globalAllowed: true,
+    targetAllowed: true,
+    label: "부서 관리",
+  },
+  {
+    permissionCode: "purchase-request:review:*",
+    resourceCode: "purchase-request",
+    actionCode: "review",
+    scope: "GLOBAL_ONLY",
+    globalAllowed: true,
+    targetAllowed: false,
+    label: "구매 요청 검토",
+  },
+  {
+    permissionCode: "channel:manage:*",
+    resourceCode: "channel",
+    actionCode: "manage",
+    scope: "BOTH",
+    globalAllowed: true,
+    targetAllowed: true,
+    label: "채널 관리",
+  },
+  {
+    permissionCode: "subject:write:*",
+    resourceCode: "subject",
+    actionCode: "write",
+    scope: "BOTH",
+    globalAllowed: true,
+    targetAllowed: true,
+    label: "과목 작성",
+  },
+];
+
+const emptyUserForm: UserFormState = {
+  email: "",
+  nickname: "",
+  password: "",
+  name: "",
+  phoneNumber: "",
+  role: "VOLUNTEER",
+  departmentId: "",
 };
 
-const navigationItems = ["대시보드", "사용자", "채널", "게시글", "부서", "분반", "구매 요청"];
+const emptyChannelForm: ChannelFormState = {
+  name: "",
+  description: "",
+  accessLevel: "READ_WRITE",
+  allowGuestRead: false,
+  isDefault: false,
+  isActive: true,
+};
+
+const emptyDepartmentForm: DepartmentFormState = {
+  name: "",
+  description: "",
+};
+
+const emptyClassroomForm: ClassroomFormState = {
+  name: "",
+  type: "WEEKDAY",
+  description: "",
+};
+
+const emptyPostEdit: PostEditState = {
+  title: "",
+  status: "PUBLISHED",
+  allowComment: true,
+  thumbnailUrl: "",
+  contentHtml: "",
+};
+
+const emptyPostCreate: PostCreateState = {
+  channelScope: "",
+  channelTargetId: "",
+  channelId: "",
+  title: "",
+  status: "PUBLISHED",
+  allowComment: true,
+  isPinned: false,
+  thumbnailUrl: "",
+  contentHtml: "",
+};
+
+const emptyPurchaseCreate: PurchaseCreateState = {
+  title: "",
+  content: "",
+  classroomId: "",
+  advancePaymentRequestedAmount: "",
+  itemName: "",
+  itemReason: "",
+  itemExpectedPrice: "",
+};
+
+const emptyPermissionForm: PermissionFormState = {
+  resourceType: "user",
+  actionType: "manage",
+  scope: "GLOBAL",
+  target: "",
+};
+
+function toNumber(value: string) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  return fallback;
+}
+
+function getTotalFromPage(contentLength: number, totalElements?: number) {
+  return typeof totalElements === "number" ? totalElements : contentLength;
+}
+
+function buildPermissionCode(form: PermissionFormState) {
+  const target = form.scope === "GLOBAL" ? "*" : form.target.trim();
+  return `${form.resourceType}:${form.actionType}:${target}`;
+}
+
+function mapCreateUserFormToPayload(form: UserFormState) {
+  return {
+    email: form.email.trim(),
+    nickname: form.nickname.trim(),
+    password: form.password,
+    name: form.name.trim(),
+    phoneNumber: form.phoneNumber.trim() || undefined,
+    role: form.role,
+    departmentId: form.departmentId ? (toNumber(form.departmentId) ?? null) : null,
+  };
+}
+
+function mapUpdateUserFormToPayload(form: UserFormState) {
+  return {
+    email: form.email.trim(),
+    nickname: form.nickname.trim(),
+    ...(form.password ? { password: form.password } : {}),
+    name: form.name.trim(),
+    phoneNumber: form.phoneNumber.trim() || undefined,
+    role: form.role,
+    departmentId: form.departmentId ? (toNumber(form.departmentId) ?? null) : null,
+  };
+}
+
+function mapChannelFormToPayload(form: ChannelFormState) {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim() || undefined,
+    accessLevel: form.accessLevel,
+    allowGuestRead: form.allowGuestRead,
+    isDefault: form.isDefault,
+    isActive: form.isActive,
+  };
+}
+
+function mapPostToEditState(post?: {
+  title?: string;
+  status?: PostStatus;
+  allowComment?: boolean;
+  thumbnailUrl?: string | null;
+  contentHtml?: string;
+}) {
+  if (!post) {
+    return emptyPostEdit;
+  }
+
+  return {
+    title: post.title ?? "",
+    status: post.status ?? "PUBLISHED",
+    allowComment: post.allowComment ?? true,
+    thumbnailUrl: post.thumbnailUrl ?? "",
+    contentHtml: post.contentHtml ?? "",
+  };
+}
 
 export default function AdminDashboardPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { status, user, signOut } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
+  const [activeMenu, setActiveMenu] = useState<AdminMenu>("dashboard");
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const [selectedChannelId, setSelectedChannelId] = useState<number | null>(null);
+  const [selectedPost, setSelectedPost] = useState<{ channelId: number; postId: number } | null>(
+    null,
+  );
+  const [selectedDepartmentId, setSelectedDepartmentId] = useState<number | null>(null);
+  const [selectedClassroomId, setSelectedClassroomId] = useState<number | null>(null);
+  const [selectedPurchaseId, setSelectedPurchaseId] = useState<number | null>(null);
+  const [userSearch, setUserSearch] = useState("");
+  const [channelSearch, setChannelSearch] = useState("");
+  const [postTitleSearch, setPostTitleSearch] = useState("");
+  const [classroomSearch, setClassroomSearch] = useState("");
+  const [purchaseStatus, setPurchaseStatus] = useState<PurchaseRequestStatus | "">("");
+  const [userForm, setUserForm] = useState<UserFormState>(emptyUserForm);
+  const [channelForm, setChannelForm] = useState<ChannelFormState>(emptyChannelForm);
+  const [departmentForm, setDepartmentForm] = useState<DepartmentFormState>(emptyDepartmentForm);
+  const [classroomForm, setClassroomForm] = useState<ClassroomFormState>(emptyClassroomForm);
+  const [postEdit, setPostEdit] = useState<PostEditState>(emptyPostEdit);
+  const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
+  const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
+  const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
+  const [reviewNote, setReviewNote] = useState("");
+  const [approvedAmount, setApprovedAmount] = useState("");
 
   useEffect(() => {
     if (status === "unauthenticated" || (status === "authenticated" && user?.role !== "ADMIN")) {
@@ -34,50 +332,536 @@ export default function AdminDashboardPage() {
   }, [router, status, user?.role]);
 
   const usersQuery = useQuery({
-    queryKey: dashboardQueryKeys.users(),
-    queryFn: () => getUsers({ page: 0, size: 1 }),
+    queryKey: queryKeys.admin.users(0, 50),
+    queryFn: () => getUsers({ page: 0, size: 50 }),
     enabled: isAdmin,
   });
   const departmentsQuery = useQuery({
-    queryKey: dashboardQueryKeys.departments(),
+    queryKey: queryKeys.admin.departments(),
     queryFn: getDepartments,
     enabled: isAdmin,
   });
   const classroomsQuery = useQuery({
-    queryKey: dashboardQueryKeys.classrooms(),
-    queryFn: () => getClassrooms({ page: 0, size: 1 }),
+    queryKey: queryKeys.admin.classrooms(),
+    queryFn: () => getClassrooms({ page: 0, size: 50, name: classroomSearch || undefined }),
     enabled: isAdmin,
+    placeholderData: (previousData) => previousData,
   });
   const pendingPurchasesQuery = useQuery({
-    queryKey: dashboardQueryKeys.pendingPurchases(),
-    queryFn: () => getPurchaseRequests({ status: "PENDING" }),
+    queryKey: queryKeys.admin.purchaseRequests("PENDING"),
+    queryFn: () => getAllPurchaseRequests({ status: "PENDING" }),
     enabled: isAdmin,
   });
+  const channelsQuery = useQuery({
+    queryKey: queryKeys.admin.channels(),
+    queryFn: () => getChannels({ name: channelSearch || undefined }),
+    enabled: isAdmin,
+  });
+  const postsQuery = useQuery({
+    queryKey: queryKeys.admin.posts(0, 50),
+    queryFn: () => getPosts({ page: 0, size: 50, title: postTitleSearch || undefined }),
+    enabled: isAdmin,
+  });
+  const purchasesQuery = useQuery({
+    queryKey: queryKeys.admin.purchaseRequests(purchaseStatus || undefined),
+    queryFn: () => getAllPurchaseRequests(purchaseStatus ? { status: purchaseStatus } : undefined),
+    enabled: isAdmin,
+  });
+  const permissionRegistryQuery = useQuery({
+    queryKey: queryKeys.admin.permissionRegistry(),
+    queryFn: getAssignablePermissions,
+    enabled: isAdmin,
+  });
+  const userDetailQuery = useQuery({
+    queryKey: selectedUserId
+      ? queryKeys.admin.userDetail(selectedUserId)
+      : ["admin", "users", "detail", "none"],
+    queryFn: () => getUserDetail({ userId: selectedUserId ?? 0 }),
+    enabled: isAdmin && selectedUserId !== null,
+  });
+  const userPermissionsQuery = useQuery({
+    queryKey: selectedUserId
+      ? queryKeys.admin.userPermissions(selectedUserId)
+      : ["admin", "users", "permissions", "none"],
+    queryFn: () => getUserPermissions({ userId: selectedUserId ?? 0 }),
+    enabled: isAdmin && selectedUserId !== null,
+  });
+  const channelDetailQuery = useQuery({
+    queryKey: selectedChannelId
+      ? queryKeys.admin.channelDetail(selectedChannelId)
+      : ["admin", "channels", "detail", "none"],
+    queryFn: () => getChannel({ id: selectedChannelId ?? 0 }),
+    enabled: isAdmin && selectedChannelId !== null,
+  });
+  const postDetailQuery = useQuery({
+    queryKey: selectedPost
+      ? queryKeys.admin.postDetail(selectedPost.channelId, selectedPost.postId)
+      : ["admin", "posts", "detail", "none"],
+    queryFn: async () => {
+      const post = await getPost(selectedPost ?? { channelId: 0, postId: 0 });
+      setPostEdit(mapPostToEditState(post));
+      return post;
+    },
+    enabled: isAdmin && selectedPost !== null,
+  });
+  const departmentDetailQuery = useQuery({
+    queryKey: selectedDepartmentId
+      ? queryKeys.admin.departmentDetail(selectedDepartmentId)
+      : ["admin", "departments", "detail", "none"],
+    queryFn: () => getDepartmentDetail({ id: selectedDepartmentId ?? 0 }),
+    enabled: isAdmin && selectedDepartmentId !== null,
+  });
+  const classroomDetailQuery = useQuery({
+    queryKey: selectedClassroomId
+      ? queryKeys.admin.classroomDetail(selectedClassroomId)
+      : ["admin", "classrooms", "detail", "none"],
+    queryFn: () => getClassroomDetail({ id: selectedClassroomId ?? 0 }),
+    enabled: isAdmin && selectedClassroomId !== null,
+  });
+  const purchaseDetailQuery = useQuery({
+    queryKey: selectedPurchaseId
+      ? queryKeys.admin.purchaseRequestDetail(selectedPurchaseId)
+      : ["admin", "purchase-requests", "detail", "none"],
+    queryFn: () => getAdminPurchaseRequestDetail({ requestId: selectedPurchaseId ?? 0 }),
+    enabled: isAdmin && selectedPurchaseId !== null,
+  });
 
-  const isLoading =
-    status === "loading" ||
-    usersQuery.isLoading ||
-    departmentsQuery.isLoading ||
-    classroomsQuery.isLoading ||
-    pendingPurchasesQuery.isLoading;
+  const users = useMemo(() => usersQuery.data?.content ?? [], [usersQuery.data?.content]);
+  const filteredUsers = useMemo(() => {
+    const keyword = userSearch.trim().toLowerCase();
+    if (!keyword) {
+      return users;
+    }
+    return users.filter((item) =>
+      [item.name, item.nickname, item.email, item.role].some((value) =>
+        value?.toLowerCase().includes(keyword),
+      ),
+    );
+  }, [userSearch, users]);
+  const departments = departmentsQuery.data?.departments ?? [];
+  const classrooms = classroomsQuery.data?.content ?? [];
+  const channels = channelsQuery.data ?? [];
+  const posts = postsQuery.data?.content ?? [];
+  const purchases = purchasesQuery.data ?? [];
+  const registry = permissionRegistryQuery.data?.length
+    ? permissionRegistryQuery.data
+    : fallbackPermissions;
+  const permissionOptions = useMemo(() => {
+    return registry.filter((option) => option.resourceCode && option.actionCode);
+  }, [registry]);
+  const availableActions = permissionOptions
+    .filter((option) => option.resourceCode === permissionForm.resourceType)
+    .map((option) => option.actionCode)
+    .filter(
+      (value, index, array): value is string => Boolean(value) && array.indexOf(value) === index,
+    );
+  const selectedPermissionDefinition = permissionOptions.find(
+    (option) =>
+      option.resourceCode === permissionForm.resourceType &&
+      option.actionCode === permissionForm.actionType,
+  );
+  const canUseGlobalPermission =
+    selectedPermissionDefinition?.globalAllowed ??
+    selectedPermissionDefinition?.scope !== "TARGET_ONLY";
+  const canUseTargetPermission =
+    selectedPermissionDefinition?.targetAllowed ??
+    selectedPermissionDefinition?.scope !== "GLOBAL_ONLY";
+  const generatedPermissionCode = buildPermissionCode(permissionForm);
 
-  const hasError =
-    usersQuery.isError ||
-    departmentsQuery.isError ||
-    classroomsQuery.isError ||
-    pendingPurchasesQuery.isError;
+  const stats = [
+    { label: "사용자", value: getTotalFromPage(users.length, usersQuery.data?.totalElements) },
+    { label: "부서", value: departments.length },
+    {
+      label: "분반",
+      value: getTotalFromPage(classrooms.length, classroomsQuery.data?.totalElements),
+    },
+    { label: "대기 중 구매 요청", value: pendingPurchasesQuery.data?.length ?? 0 },
+  ];
+
+  function notifySuccess(message: string) {
+    toast.success(message);
+  }
+
+  function notifyError(message: string) {
+    toast.error(message);
+  }
+
+  function selectUser(item: (typeof users)[number]) {
+    if (!item.id) {
+      return;
+    }
+    setSelectedUserId(item.id);
+    setUserForm({
+      email: item.email ?? "",
+      nickname: item.nickname ?? "",
+      password: "",
+      name: item.name ?? "",
+      phoneNumber: item.phoneNumber ?? "",
+      role: item.role ?? "VOLUNTEER",
+      departmentId: item.departmentId ? String(item.departmentId) : "",
+    });
+  }
+
+  function selectChannel(item: (typeof channels)[number]) {
+    if (!item.id) {
+      return;
+    }
+    setSelectedChannelId(item.id);
+    setChannelForm({
+      name: item.name ?? "",
+      description: item.description ?? "",
+      accessLevel: item.accessLevel ?? "READ_WRITE",
+      allowGuestRead: item.allowGuestRead ?? false,
+      isDefault: item.isDefault ?? false,
+      isActive: item.isActive ?? true,
+    });
+  }
+
+  function selectPost(item: (typeof posts)[number]) {
+    if (!item.id || !item.channelId) {
+      return;
+    }
+    setSelectedPost({ channelId: item.channelId, postId: item.id });
+    setPostEdit(mapPostToEditState(item));
+  }
+
+  function selectDepartment(item: (typeof departments)[number]) {
+    if (!item.id) {
+      return;
+    }
+    setSelectedDepartmentId(item.id);
+    setDepartmentForm({
+      name: item.name ?? "",
+      description: item.description ?? "",
+    });
+  }
+
+  function selectClassroom(item: (typeof classrooms)[number]) {
+    if (!item.id) {
+      return;
+    }
+    setSelectedClassroomId(item.id);
+    setClassroomForm({
+      name: item.name ?? "",
+      type: item.type ?? "WEEKDAY",
+      description: item.description ?? "",
+    });
+  }
+
+  const invalidateDashboard = () => {
+    queryClient.invalidateQueries({ queryKey: ["admin"] });
+  };
+
+  const createUserMutation = useMutation({
+    mutationFn: () => createUser(mapCreateUserFormToPayload(userForm)),
+    onSuccess: () => {
+      notifySuccess("사용자를 생성했습니다.");
+      setUserForm(emptyUserForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "사용자 생성에 실패했습니다.")),
+  });
+  const updateUserMutation = useMutation({
+    mutationFn: () =>
+      updateUser({ userId: selectedUserId ?? 0 }, mapUpdateUserFormToPayload(userForm)),
+    onSuccess: () => {
+      notifySuccess("사용자를 수정했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+      if (selectedUserId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.userDetail(selectedUserId) });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "사용자 수정에 실패했습니다.")),
+  });
+  const deleteUserMutation = useMutation({
+    mutationFn: () => deleteUser({ userId: selectedUserId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("사용자를 삭제했습니다.");
+      setSelectedUserId(null);
+      setUserForm(emptyUserForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "사용자 삭제에 실패했습니다.")),
+  });
+  const addPermissionMutation = useMutation({
+    mutationFn: () =>
+      addUserPermission(
+        { userId: selectedUserId ?? 0 },
+        { permissionCode: generatedPermissionCode },
+      ),
+    onSuccess: () => {
+      notifySuccess("사용자 권한을 추가했습니다.");
+      if (selectedUserId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.userPermissions(selectedUserId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "권한 추가에 실패했습니다.")),
+  });
+  const removePermissionMutation = useMutation({
+    mutationFn: (permissionCode: string) =>
+      removeUserPermission({ userId: selectedUserId ?? 0 }, { permissionCode }),
+    onSuccess: () => {
+      notifySuccess("사용자 권한을 제거했습니다.");
+      if (selectedUserId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.userPermissions(selectedUserId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "권한 제거에 실패했습니다.")),
+  });
+
+  const createChannelMutation = useMutation({
+    mutationFn: () => createChannel(mapChannelFormToPayload(channelForm)),
+    onSuccess: () => {
+      notifySuccess("채널을 생성했습니다.");
+      setChannelForm(emptyChannelForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "채널 생성에 실패했습니다.")),
+  });
+  const updateChannelMutation = useMutation({
+    mutationFn: () =>
+      updateChannel({ id: selectedChannelId ?? 0 }, mapChannelFormToPayload(channelForm)),
+    onSuccess: () => {
+      notifySuccess("채널을 수정했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
+      if (selectedChannelId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.channelDetail(selectedChannelId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "채널 수정에 실패했습니다.")),
+  });
+  const deleteChannelMutation = useMutation({
+    mutationFn: () => deleteChannel({ id: selectedChannelId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("채널을 삭제했습니다.");
+      setSelectedChannelId(null);
+      setChannelForm(emptyChannelForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "채널 삭제에 실패했습니다.")),
+  });
+
+  const createPostMutation = useMutation({
+    mutationFn: () =>
+      createPost(
+        { channelId: toNumber(postCreate.channelId) ?? 0 },
+        {
+          title: postCreate.title.trim(),
+          contentHtml: postCreate.contentHtml,
+          status: postCreate.status,
+          allowComment: postCreate.allowComment,
+          isPinned: postCreate.isPinned,
+          thumbnailUrl: postCreate.thumbnailUrl || undefined,
+        },
+      ),
+    onSuccess: () => {
+      notifySuccess("게시글을 작성했습니다.");
+      setPostCreate(emptyPostCreate);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "게시글 작성에 실패했습니다.")),
+  });
+
+  const updatePostMutation = useMutation({
+    mutationFn: () =>
+      updatePost(selectedPost ?? { channelId: 0, postId: 0 }, {
+        title: postEdit.title,
+        status: postEdit.status,
+        allowComment: postEdit.allowComment,
+        thumbnailUrl: postEdit.thumbnailUrl || undefined,
+        contentHtml: postEdit.contentHtml,
+      }),
+    onSuccess: () => {
+      notifySuccess("게시글을 수정했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      if (selectedPost) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.postDetail(selectedPost.channelId, selectedPost.postId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "게시글 수정에 실패했습니다.")),
+  });
+  const deletePostMutation = useMutation({
+    mutationFn: () => deletePost(selectedPost ?? { channelId: 0, postId: 0 }),
+    onSuccess: () => {
+      notifySuccess("게시글을 삭제했습니다.");
+      setSelectedPost(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "게시글 삭제에 실패했습니다.")),
+  });
+  const pinPostMutation = useMutation({
+    mutationFn: (isPinned: boolean) =>
+      pinPost(selectedPost ?? { channelId: 0, postId: 0 }, { isPinned }),
+    onSuccess: () => {
+      notifySuccess("게시글 고정 상태를 변경했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      if (selectedPost) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.postDetail(selectedPost.channelId, selectedPost.postId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "게시글 고정 변경에 실패했습니다.")),
+  });
+
+  const createDepartmentMutation = useMutation({
+    mutationFn: () => createDepartment(departmentForm),
+    onSuccess: () => {
+      notifySuccess("부서를 생성했습니다.");
+      setDepartmentForm(emptyDepartmentForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "부서 생성에 실패했습니다.")),
+  });
+  const updateDepartmentMutation = useMutation({
+    mutationFn: () => updateDepartment({ id: selectedDepartmentId ?? 0 }, departmentForm),
+    onSuccess: () => {
+      notifySuccess("부서를 수정했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
+      if (selectedDepartmentId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.departmentDetail(selectedDepartmentId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "부서 수정에 실패했습니다.")),
+  });
+  const deleteDepartmentMutation = useMutation({
+    mutationFn: () => deleteDepartment({ id: selectedDepartmentId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("부서를 삭제했습니다.");
+      setSelectedDepartmentId(null);
+      setDepartmentForm(emptyDepartmentForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
+    },
+    onError: (error) =>
+      notifyError(
+        getErrorMessage(
+          error,
+          "부서 삭제에 실패했습니다. 할당된 역할이나 멤버가 있으면 삭제할 수 없습니다.",
+        ),
+      ),
+  });
+
+  const createClassroomMutation = useMutation({
+    mutationFn: () => createClassroom(classroomForm),
+    onSuccess: () => {
+      notifySuccess("분반을 생성했습니다.");
+      setClassroomForm(emptyClassroomForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "분반 생성에 실패했습니다.")),
+  });
+  const updateClassroomMutation = useMutation({
+    mutationFn: () => updateClassroom({ id: selectedClassroomId ?? 0 }, classroomForm),
+    onSuccess: () => {
+      notifySuccess("분반을 수정했습니다.");
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
+      if (selectedClassroomId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.classroomDetail(selectedClassroomId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "분반 수정에 실패했습니다.")),
+  });
+  const deleteClassroomMutation = useMutation({
+    mutationFn: () => deleteClassroom({ id: selectedClassroomId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("분반을 삭제했습니다.");
+      setSelectedClassroomId(null);
+      setClassroomForm(emptyClassroomForm);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "분반 삭제에 실패했습니다.")),
+  });
+
+  const createPurchaseMutation = useMutation({
+    mutationFn: () =>
+      createPurchaseRequest({
+        title: purchaseCreate.title.trim(),
+        content: purchaseCreate.content.trim(),
+        classroomId: toNumber(purchaseCreate.classroomId) ?? 0,
+        ...(purchaseCreate.advancePaymentRequestedAmount
+          ? {
+              advancePaymentRequestedAmount: toNumber(purchaseCreate.advancePaymentRequestedAmount),
+            }
+          : {}),
+        items: [
+          {
+            name: purchaseCreate.itemName.trim(),
+            reason: purchaseCreate.itemReason.trim() || undefined,
+            ...(purchaseCreate.itemExpectedPrice
+              ? { expectedPrice: toNumber(purchaseCreate.itemExpectedPrice) }
+              : {}),
+          },
+        ],
+      }),
+    onSuccess: () => {
+      notifySuccess("구매 요청을 작성했습니다.");
+      setPurchaseCreate(emptyPurchaseCreate);
+      invalidateDashboard();
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "구매 요청 작성에 실패했습니다.")),
+  });
+
+  const approvePurchaseMutation = useMutation({
+    mutationFn: () =>
+      approveAdminPurchaseRequest(
+        { requestId: selectedPurchaseId ?? 0 },
+        {
+          note: reviewNote || "승인합니다.",
+          ...(approvedAmount ? { advancePaymentApprovedAmount: toNumber(approvedAmount) } : {}),
+        },
+      ),
+    onSuccess: () => {
+      notifySuccess("구매 요청을 승인했습니다.");
+      invalidateDashboard();
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "구매 요청 승인에 실패했습니다.")),
+  });
+  const rejectPurchaseMutation = useMutation({
+    mutationFn: () =>
+      rejectAdminPurchaseRequest(
+        { requestId: selectedPurchaseId ?? 0 },
+        { note: reviewNote || "반려합니다." },
+      ),
+    onSuccess: () => {
+      notifySuccess("구매 요청을 반려했습니다.");
+      invalidateDashboard();
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "구매 요청 반려에 실패했습니다.")),
+  });
+  const confirmPurchaseMutation = useMutation({
+    mutationFn: () => confirmPurchase({ requestId: selectedPurchaseId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("구매 요청을 결재 확인했습니다.");
+      invalidateDashboard();
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "결재 확인에 실패했습니다.")),
+  });
+  const deletePurchaseMutation = useMutation({
+    mutationFn: () => deleteAdminPurchaseRequest({ requestId: selectedPurchaseId ?? 0 }),
+    onSuccess: () => {
+      notifySuccess("구매 요청을 삭제했습니다.");
+      setSelectedPurchaseId(null);
+      invalidateDashboard();
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "구매 요청 삭제에 실패했습니다.")),
+  });
 
   async function handleLogout() {
     await signOut();
     router.replace("/admin/login");
   }
-
-  const stats = [
-    { label: "사용자", value: usersQuery.data?.totalElements ?? 0 },
-    { label: "부서", value: departmentsQuery.data?.departments?.length ?? 0 },
-    { label: "분반", value: classroomsQuery.data?.totalElements ?? 0 },
-    { label: "대기 중 구매 요청", value: pendingPurchasesQuery.data?.length ?? 0 },
-  ];
 
   if (!isAdmin) {
     return (
@@ -91,11 +875,27 @@ export default function AdminDashboardPage() {
     );
   }
 
+  const currentTitle = navigationItems.find((item) => item.key === activeMenu)?.label ?? "대시보드";
+  const currentDescription = {
+    dashboard:
+      "전체 사용자, 부서, 분반, 승인 대기 구매 요청을 요약하고 주요 관리 화면으로 이동합니다.",
+    users:
+      "사용자 목록 조회, 역할 확인, 사용자 생성/수정/삭제, 직접 권한 조회와 권한 부여를 제공합니다.",
+    channels:
+      "채널 목록 조회, 유형과 연결 대상 확인, 채널 생성/수정/삭제 및 활성 상태 관리를 제공합니다.",
+    posts:
+      "공지/부서/반별 채널 게시글 작성, 이미지 첨부, 게시글 조회/수정/삭제/고정 관리를 제공합니다.",
+    departments:
+      "부서 목록과 상세 정보를 조회하고 부서 생성/수정/삭제, 소속 사용자와 권한 정보를 확인합니다.",
+    classrooms: "분반 목록과 상세 정보를 조회하고 분반 생성/수정/삭제 및 이름 검색을 제공합니다.",
+    purchases: "구매 요청 작성, 목록/상세 조회, 승인/반려/결재 확인/삭제 처리를 제공합니다.",
+  }[activeMenu];
+
   return (
     <ConsoleShell>
       <TopLine aria-hidden="true" />
       <Sidebar>
-        <Brand>
+        <Brand href="/" aria-label="홈으로 이동">
           <BrandLogo src="/logo.svg" alt="" aria-hidden="true" />
           <BrandText>
             <BrandTitle>관리자 콘솔</BrandTitle>
@@ -104,9 +904,14 @@ export default function AdminDashboardPage() {
         </Brand>
 
         <SidebarNav aria-label="관리자 메뉴">
-          {navigationItems.map((item, index) => (
-            <SidebarItem key={item} $active={index === 0}>
-              {item}
+          {navigationItems.map((item) => (
+            <SidebarItem
+              key={item.key}
+              type="button"
+              $active={activeMenu === item.key}
+              onClick={() => setActiveMenu(item.key)}
+            >
+              {item.label}
             </SidebarItem>
           ))}
         </SidebarNav>
@@ -120,78 +925,146 @@ export default function AdminDashboardPage() {
         <AdminContent>
           <AccountText>{user?.email}</AccountText>
           <PageHeader>
-            <Title>대시보드</Title>
-            <Description>운영자가 처리해야 할 핵심 데이터를 모아봅니다.</Description>
+            <Title>{currentTitle}</Title>
+            <Description>{currentDescription}</Description>
           </PageHeader>
-
-          {hasError ? (
-            <InlineStatus role="alert">일부 관리자 데이터를 불러오지 못했습니다.</InlineStatus>
+          {activeMenu === "dashboard" ? (
+            <AdminMainDashboardSection
+              stats={stats}
+              usersQuery={usersQuery}
+              departmentsQuery={departmentsQuery}
+              classroomsQuery={classroomsQuery}
+              pendingPurchasesQuery={pendingPurchasesQuery}
+              setActiveMenu={setActiveMenu}
+              setPurchaseStatus={setPurchaseStatus}
+            />
           ) : null}
-
-          {isLoading ? (
-            <StatePanel>
-              <LoadingSpinner label="관리자 데이터 불러오는 중" />
-            </StatePanel>
-          ) : (
-            <>
-              <StatsGrid>
-                {stats.map((stat) => (
-                  <StatCard key={stat.label}>
-                    <StatLabel>{stat.label}</StatLabel>
-                    <StatValue>{stat.value}</StatValue>
-                  </StatCard>
-                ))}
-              </StatsGrid>
-
-              <DashboardGrid>
-                <SectionCard>
-                  <SectionTitle>사용자 및 권한 관리</SectionTitle>
-                  <ActionGrid>
-                    <ActionCard>
-                      <ActionTitle>사용자 관리</ActionTitle>
-                      <ActionDescription>전체 사용자 및 권한 조회/수정</ActionDescription>
-                    </ActionCard>
-                    <ActionCard>
-                      <ActionTitle>부서 관리</ActionTitle>
-                      <ActionDescription>기관 산하 부서 조직 구성</ActionDescription>
-                    </ActionCard>
-                  </ActionGrid>
-                </SectionCard>
-
-                <SectionCard>
-                  <SectionTitle>게시판 및 교육 운영</SectionTitle>
-                  <ActionGrid>
-                    <ActionCard>
-                      <ActionTitle>채널 관리</ActionTitle>
-                      <ActionDescription>소통 채널 및 게시판 설정</ActionDescription>
-                    </ActionCard>
-                    <ActionCard>
-                      <ActionTitle>게시글 관리</ActionTitle>
-                      <ActionDescription>모든 채널의 게시물 모니터링</ActionDescription>
-                    </ActionCard>
-                    <ActionCard>
-                      <ActionTitle>분반 관리</ActionTitle>
-                      <ActionDescription>분반 및 교육 과정 운영</ActionDescription>
-                    </ActionCard>
-                  </ActionGrid>
-                </SectionCard>
-              </DashboardGrid>
-
-              <SectionCard>
-                <SectionTitle>결재 및 행정 지원</SectionTitle>
-                <SupportGrid>
-                  <ActionCard>
-                    <ActionTitle>전체 구매 요청</ActionTitle>
-                    <ActionDescription>물품 구매 요청 이력 확인</ActionDescription>
-                  </ActionCard>
-                  <ActionCard>
-                    <ActionTitle $accent>승인 대기 중</ActionTitle>
-                    <ActionDescription>검토가 필요한 신규 구매 요청</ActionDescription>
-                  </ActionCard>
-                </SupportGrid>
-              </SectionCard>
-            </>
-          )}
+          {activeMenu === "users" ? (
+            <AdminUsersSection
+              filteredUsers={filteredUsers}
+              selectedUserId={selectedUserId}
+              userSearch={userSearch}
+              userForm={userForm}
+              permissionForm={permissionForm}
+              permissionOptions={permissionOptions}
+              availableActions={availableActions}
+              canUseGlobalPermission={canUseGlobalPermission}
+              canUseTargetPermission={canUseTargetPermission}
+              generatedPermissionCode={generatedPermissionCode}
+              usersQuery={usersQuery}
+              userDetailQuery={userDetailQuery}
+              userPermissionsQuery={userPermissionsQuery}
+              createUserMutation={createUserMutation}
+              updateUserMutation={updateUserMutation}
+              deleteUserMutation={deleteUserMutation}
+              addPermissionMutation={addPermissionMutation}
+              removePermissionMutation={removePermissionMutation}
+              setSelectedUserId={setSelectedUserId}
+              setUserSearch={setUserSearch}
+              setUserForm={setUserForm}
+              setPermissionForm={setPermissionForm}
+              selectUser={selectUser}
+              emptyUserForm={emptyUserForm}
+            />
+          ) : null}
+          {activeMenu === "channels" ? (
+            <AdminChannelsSection
+              channels={channels}
+              selectedChannelId={selectedChannelId}
+              channelSearch={channelSearch}
+              channelForm={channelForm}
+              channelsQuery={channelsQuery}
+              channelDetailQuery={channelDetailQuery}
+              createChannelMutation={createChannelMutation}
+              updateChannelMutation={updateChannelMutation}
+              deleteChannelMutation={deleteChannelMutation}
+              setSelectedChannelId={setSelectedChannelId}
+              setChannelSearch={setChannelSearch}
+              setChannelForm={setChannelForm}
+              selectChannel={selectChannel}
+              emptyChannelForm={emptyChannelForm}
+            />
+          ) : null}
+          {activeMenu === "posts" ? (
+            <AdminPostsSection
+              channels={channels}
+              classrooms={classrooms}
+              departments={departments}
+              posts={posts}
+              selectedPost={selectedPost}
+              postTitleSearch={postTitleSearch}
+              postCreate={postCreate}
+              postEdit={postEdit}
+              postsQuery={postsQuery}
+              postDetailQuery={postDetailQuery}
+              createPostMutation={createPostMutation}
+              updatePostMutation={updatePostMutation}
+              pinPostMutation={pinPostMutation}
+              deletePostMutation={deletePostMutation}
+              setPostTitleSearch={setPostTitleSearch}
+              setPostCreate={setPostCreate}
+              setPostEdit={setPostEdit}
+              selectPost={selectPost}
+            />
+          ) : null}
+          {activeMenu === "departments" ? (
+            <AdminDepartmentsSection
+              departments={departments}
+              selectedDepartmentId={selectedDepartmentId}
+              departmentForm={departmentForm}
+              departmentsQuery={departmentsQuery}
+              departmentDetailQuery={departmentDetailQuery}
+              createDepartmentMutation={createDepartmentMutation}
+              updateDepartmentMutation={updateDepartmentMutation}
+              deleteDepartmentMutation={deleteDepartmentMutation}
+              setSelectedDepartmentId={setSelectedDepartmentId}
+              setDepartmentForm={setDepartmentForm}
+              selectDepartment={selectDepartment}
+              emptyDepartmentForm={emptyDepartmentForm}
+            />
+          ) : null}
+          {activeMenu === "classrooms" ? (
+            <AdminClassroomsSection
+              classrooms={classrooms}
+              selectedClassroomId={selectedClassroomId}
+              classroomSearch={classroomSearch}
+              classroomForm={classroomForm}
+              classroomsQuery={classroomsQuery}
+              classroomDetailQuery={classroomDetailQuery}
+              createClassroomMutation={createClassroomMutation}
+              updateClassroomMutation={updateClassroomMutation}
+              deleteClassroomMutation={deleteClassroomMutation}
+              setSelectedClassroomId={setSelectedClassroomId}
+              setClassroomSearch={setClassroomSearch}
+              setClassroomForm={setClassroomForm}
+              selectClassroom={selectClassroom}
+              emptyClassroomForm={emptyClassroomForm}
+            />
+          ) : null}
+          {activeMenu === "purchases" ? (
+            <AdminPurchasesSection
+              classrooms={classrooms}
+              purchases={purchases}
+              selectedPurchaseId={selectedPurchaseId}
+              purchaseStatus={purchaseStatus}
+              purchaseCreate={purchaseCreate}
+              reviewNote={reviewNote}
+              approvedAmount={approvedAmount}
+              purchasesQuery={purchasesQuery}
+              purchaseDetailQuery={purchaseDetailQuery}
+              createPurchaseMutation={createPurchaseMutation}
+              approvePurchaseMutation={approvePurchaseMutation}
+              rejectPurchaseMutation={rejectPurchaseMutation}
+              confirmPurchaseMutation={confirmPurchaseMutation}
+              deletePurchaseMutation={deletePurchaseMutation}
+              setPurchaseStatus={setPurchaseStatus}
+              setPurchaseCreate={setPurchaseCreate}
+              setSelectedPurchaseId={setSelectedPurchaseId}
+              setReviewNote={setReviewNote}
+              setApprovedAmount={setApprovedAmount}
+            />
+          ) : null}
+          <ToastContainer position="top-right" autoClose={2400} newestOnTop pauseOnHover />
         </AdminContent>
       </Main>
     </ConsoleShell>
@@ -238,11 +1111,25 @@ const Sidebar = styled.aside`
   }
 `;
 
-const Brand = styled.div`
+const Brand = styled(Link)`
   display: flex;
   align-items: center;
   gap: ${spacing.space8};
   margin-bottom: ${spacing.space24};
+  border-radius: 0.375rem;
+  text-decoration: none;
+  transition:
+    transform 0.18s ease,
+    opacity 0.18s ease;
+
+  &:hover {
+    opacity: 0.86;
+    transform: translateX(0.125rem);
+  }
+
+  &:active {
+    transform: translateX(0.125rem) scale(0.98);
+  }
 
   @media (min-width: 120rem) {
     gap: ${spacing.space12};
@@ -291,19 +1178,53 @@ const SidebarNav = styled.nav`
   gap: ${spacing.space8};
 `;
 
-const SidebarItem = styled.div<{ $active: boolean }>`
+const SidebarItem = styled.button<{ $active: boolean }>`
+  position: relative;
   min-height: 2.375rem;
+  border: 0;
   padding: 0.625rem 0.75rem;
   border-radius: 0.375rem;
   background-color: ${({ $active }) => ($active ? colors.pointSoft : "transparent")};
   color: ${({ $active }) => ($active ? "#1d9a35" : "#1f2b28")};
+  font-family: inherit;
   font-size: ${typography.fontSize13};
   font-weight: 800;
   line-height: ${typography.lineHeight130};
+  text-align: left;
+  cursor: pointer;
+  transform: translateX(${({ $active }) => ($active ? "0.25rem" : "0")});
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover {
+    background-color: ${({ $active }) => ($active ? colors.pointSoft : "#f1f5f2")};
+    transform: translateX(0.25rem);
+  }
+
+  &:active {
+    transform: translateX(0.25rem) scale(0.98);
+  }
+
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 0.25rem;
+    width: 0.1875rem;
+    height: 1.125rem;
+    border-radius: ${radii.radius999};
+    background-color: ${colors.point};
+    content: "";
+    opacity: ${({ $active }) => ($active ? 1 : 0)};
+    transform: translateY(-50%);
+    transition: opacity 0.18s ease;
+  }
 
   @media (min-width: 120rem) {
     min-height: 3.625rem;
-    padding: 1rem 1rem;
+    padding: 1rem;
     border-radius: 0.5rem;
     font-size: ${typography.fontSize18};
   }
@@ -395,162 +1316,4 @@ const Description = styled.p`
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize18};
   }
-`;
-
-const StatsGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: ${spacing.space12};
-
-  @media (min-width: 120rem) {
-    gap: ${spacing.space16};
-  }
-
-  @media (max-width: ${layout.breakpointTablet}) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-`;
-
-const StatCard = styled.section`
-  min-height: 5.125rem;
-  padding: 1rem 0.875rem;
-  background-color: ${colors.white};
-  border: 1px solid #e6e9e7;
-  border-radius: ${radii.radius12};
-
-  @media (min-width: 120rem) {
-    min-height: 8.25rem;
-    padding: 1.5rem;
-  }
-`;
-
-const StatLabel = styled.p`
-  margin: 0 0 ${spacing.space8};
-  color: #64706c;
-  font-size: ${typography.fontSize14};
-  font-weight: 800;
-  line-height: ${typography.lineHeight130};
-
-  @media (min-width: 120rem) {
-    margin-bottom: ${spacing.space16};
-    font-size: ${typography.fontSize18};
-  }
-`;
-
-const StatValue = styled.p`
-  margin: 0;
-  color: #050505;
-  font-size: ${typography.fontSize24};
-  font-weight: 900;
-  line-height: ${typography.lineHeight100};
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize32};
-  }
-`;
-
-const DashboardGrid = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: ${spacing.space16};
-
-  @media (max-width: ${layout.breakpointTablet}) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const SectionCard = styled.section`
-  padding: 1.25rem 1rem;
-  background-color: ${colors.white};
-  border: 1px solid #e6e9e7;
-  border-radius: ${radii.radius12};
-
-  @media (min-width: 120rem) {
-    padding: 2rem 1.75rem;
-  }
-`;
-
-const SectionTitle = styled.h2`
-  margin: 0 0 ${spacing.space16};
-  color: #050505;
-  font-size: ${typography.fontSize18};
-  font-weight: 900;
-  line-height: ${typography.lineHeight130};
-
-  @media (min-width: 120rem) {
-    margin-bottom: ${spacing.space24};
-    font-size: ${typography.fontSize24};
-  }
-`;
-
-const ActionGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: ${spacing.space12};
-
-  @media (max-width: ${layout.breakpointMobile}) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const SupportGrid = styled(ActionGrid)`
-  max-width: 41rem;
-
-  @media (min-width: 120rem) {
-    max-width: 61.5rem;
-  }
-`;
-
-const ActionCard = styled.div`
-  min-height: 4.25rem;
-  padding: 1rem;
-  border: 1px solid #e1e5e3;
-  border-radius: 0.5rem;
-  background-color: ${colors.white};
-
-  @media (min-width: 120rem) {
-    min-height: 6.875rem;
-    padding: 1.5rem;
-  }
-`;
-
-const ActionTitle = styled.p<{ $accent?: boolean }>`
-  margin: 0 0 ${spacing.space4};
-  color: ${({ $accent }) => ($accent ? "#b27600" : "#64706c")};
-  font-size: ${typography.fontSize14};
-  font-weight: 900;
-  line-height: ${typography.lineHeight130};
-
-  @media (min-width: 120rem) {
-    margin-bottom: ${spacing.space8};
-    font-size: ${typography.fontSize18};
-  }
-`;
-
-const ActionDescription = styled.p`
-  margin: 0;
-  color: #64706c;
-  font-size: ${typography.fontSize13};
-  line-height: ${typography.lineHeight130};
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize16};
-  }
-`;
-
-const StatePanel = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 12rem;
-  background-color: ${colors.white};
-  border: 1px solid #e6e9e7;
-  border-radius: ${radii.radius12};
-`;
-
-const InlineStatus = styled.p`
-  margin: 0;
-  color: ${colors.notice};
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight130};
 `;

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -1,0 +1,556 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getClassrooms } from "@/api/classroom/classroom.api";
+import { getDepartments } from "@/api/department/department.api";
+import { getPurchaseRequests } from "@/api/request/request.api";
+import { getUsers } from "@/api/user/user.api";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+const dashboardQueryKeys = {
+  users: () => ["admin", "users"] as const,
+  departments: () => ["admin", "departments"] as const,
+  classrooms: () => ["admin", "classrooms"] as const,
+  pendingPurchases: () => ["admin", ...queryKeys.requests.purchaseList(), "pending"] as const,
+};
+
+const navigationItems = ["대시보드", "사용자", "채널", "게시글", "부서", "분반", "구매 요청"];
+
+export default function AdminDashboardPage() {
+  const router = useRouter();
+  const { status, user, signOut } = useAuthSession();
+  const isAdmin = status === "authenticated" && user?.role === "ADMIN";
+
+  useEffect(() => {
+    if (status === "unauthenticated" || (status === "authenticated" && user?.role !== "ADMIN")) {
+      router.replace("/admin/login");
+    }
+  }, [router, status, user?.role]);
+
+  const usersQuery = useQuery({
+    queryKey: dashboardQueryKeys.users(),
+    queryFn: () => getUsers({ page: 0, size: 1 }),
+    enabled: isAdmin,
+  });
+  const departmentsQuery = useQuery({
+    queryKey: dashboardQueryKeys.departments(),
+    queryFn: getDepartments,
+    enabled: isAdmin,
+  });
+  const classroomsQuery = useQuery({
+    queryKey: dashboardQueryKeys.classrooms(),
+    queryFn: () => getClassrooms({ page: 0, size: 1 }),
+    enabled: isAdmin,
+  });
+  const pendingPurchasesQuery = useQuery({
+    queryKey: dashboardQueryKeys.pendingPurchases(),
+    queryFn: () => getPurchaseRequests({ status: "PENDING" }),
+    enabled: isAdmin,
+  });
+
+  const isLoading =
+    status === "loading" ||
+    usersQuery.isLoading ||
+    departmentsQuery.isLoading ||
+    classroomsQuery.isLoading ||
+    pendingPurchasesQuery.isLoading;
+
+  const hasError =
+    usersQuery.isError ||
+    departmentsQuery.isError ||
+    classroomsQuery.isError ||
+    pendingPurchasesQuery.isError;
+
+  async function handleLogout() {
+    await signOut();
+    router.replace("/admin/login");
+  }
+
+  const stats = [
+    { label: "사용자", value: usersQuery.data?.totalElements ?? 0 },
+    { label: "부서", value: departmentsQuery.data?.departments?.length ?? 0 },
+    { label: "분반", value: classroomsQuery.data?.totalElements ?? 0 },
+    { label: "대기 중 구매 요청", value: pendingPurchasesQuery.data?.length ?? 0 },
+  ];
+
+  if (!isAdmin) {
+    return (
+      <Main>
+        <AdminContent>
+          <StatePanel>
+            <LoadingSpinner label="관리자 권한 확인 중" />
+          </StatePanel>
+        </AdminContent>
+      </Main>
+    );
+  }
+
+  return (
+    <ConsoleShell>
+      <TopLine aria-hidden="true" />
+      <Sidebar>
+        <Brand>
+          <BrandLogo src="/logo.svg" alt="" aria-hidden="true" />
+          <BrandText>
+            <BrandTitle>관리자 콘솔</BrandTitle>
+            <BrandDescription>금정열린배움터 운영</BrandDescription>
+          </BrandText>
+        </Brand>
+
+        <SidebarNav aria-label="관리자 메뉴">
+          {navigationItems.map((item, index) => (
+            <SidebarItem key={item} $active={index === 0}>
+              {item}
+            </SidebarItem>
+          ))}
+        </SidebarNav>
+
+        <LogoutButton type="button" onClick={handleLogout}>
+          로그아웃
+        </LogoutButton>
+      </Sidebar>
+
+      <Main>
+        <AdminContent>
+          <AccountText>{user?.email}</AccountText>
+          <PageHeader>
+            <Title>대시보드</Title>
+            <Description>운영자가 처리해야 할 핵심 데이터를 모아봅니다.</Description>
+          </PageHeader>
+
+          {hasError ? (
+            <InlineStatus role="alert">일부 관리자 데이터를 불러오지 못했습니다.</InlineStatus>
+          ) : null}
+
+          {isLoading ? (
+            <StatePanel>
+              <LoadingSpinner label="관리자 데이터 불러오는 중" />
+            </StatePanel>
+          ) : (
+            <>
+              <StatsGrid>
+                {stats.map((stat) => (
+                  <StatCard key={stat.label}>
+                    <StatLabel>{stat.label}</StatLabel>
+                    <StatValue>{stat.value}</StatValue>
+                  </StatCard>
+                ))}
+              </StatsGrid>
+
+              <DashboardGrid>
+                <SectionCard>
+                  <SectionTitle>사용자 및 권한 관리</SectionTitle>
+                  <ActionGrid>
+                    <ActionCard>
+                      <ActionTitle>사용자 관리</ActionTitle>
+                      <ActionDescription>전체 사용자 및 권한 조회/수정</ActionDescription>
+                    </ActionCard>
+                    <ActionCard>
+                      <ActionTitle>부서 관리</ActionTitle>
+                      <ActionDescription>기관 산하 부서 조직 구성</ActionDescription>
+                    </ActionCard>
+                  </ActionGrid>
+                </SectionCard>
+
+                <SectionCard>
+                  <SectionTitle>게시판 및 교육 운영</SectionTitle>
+                  <ActionGrid>
+                    <ActionCard>
+                      <ActionTitle>채널 관리</ActionTitle>
+                      <ActionDescription>소통 채널 및 게시판 설정</ActionDescription>
+                    </ActionCard>
+                    <ActionCard>
+                      <ActionTitle>게시글 관리</ActionTitle>
+                      <ActionDescription>모든 채널의 게시물 모니터링</ActionDescription>
+                    </ActionCard>
+                    <ActionCard>
+                      <ActionTitle>분반 관리</ActionTitle>
+                      <ActionDescription>분반 및 교육 과정 운영</ActionDescription>
+                    </ActionCard>
+                  </ActionGrid>
+                </SectionCard>
+              </DashboardGrid>
+
+              <SectionCard>
+                <SectionTitle>결재 및 행정 지원</SectionTitle>
+                <SupportGrid>
+                  <ActionCard>
+                    <ActionTitle>전체 구매 요청</ActionTitle>
+                    <ActionDescription>물품 구매 요청 이력 확인</ActionDescription>
+                  </ActionCard>
+                  <ActionCard>
+                    <ActionTitle $accent>승인 대기 중</ActionTitle>
+                    <ActionDescription>검토가 필요한 신규 구매 요청</ActionDescription>
+                  </ActionCard>
+                </SupportGrid>
+              </SectionCard>
+            </>
+          )}
+        </AdminContent>
+      </Main>
+    </ConsoleShell>
+  );
+}
+
+const ConsoleShell = styled.div`
+  display: flex;
+  min-height: 100vh;
+  background-color: #f4f6f5;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const TopLine = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 5;
+  width: 100%;
+  height: 0.125rem;
+  background-color: #17466b;
+`;
+
+const Sidebar = styled.aside`
+  display: flex;
+  flex-direction: column;
+  width: 14rem;
+  min-height: 100vh;
+  padding: 1.5rem 0.875rem 2.25rem;
+  background-color: ${colors.white};
+  border-right: 1px solid ${colors.border};
+
+  @media (min-width: 120rem) {
+    width: 17.4375rem;
+    padding: 2.25rem 1.5rem 3rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    width: 100%;
+    min-height: auto;
+  }
+`;
+
+const Brand = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  margin-bottom: ${spacing.space24};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12};
+    margin-bottom: ${spacing.space40};
+  }
+`;
+
+const BrandLogo = styled.img`
+  width: 1.75rem;
+  height: auto;
+
+  @media (min-width: 120rem) {
+    width: 2.625rem;
+  }
+`;
+
+const BrandText = styled.div`
+  min-width: 0;
+`;
+
+const BrandTitle = styled.p`
+  margin: 0;
+  color: #050505;
+  font-size: ${typography.fontSize16};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const BrandDescription = styled.p`
+  margin: ${spacing.space4} 0 0;
+  color: #64706c;
+  font-size: 0.6875rem;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize14};
+  }
+`;
+
+const SidebarNav = styled.nav`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const SidebarItem = styled.div<{ $active: boolean }>`
+  min-height: 2.375rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.375rem;
+  background-color: ${({ $active }) => ($active ? colors.pointSoft : "transparent")};
+  color: ${({ $active }) => ($active ? "#1d9a35" : "#1f2b28")};
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 3.625rem;
+    padding: 1rem 1rem;
+    border-radius: 0.5rem;
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const LogoutButton = styled.button`
+  min-height: 2.375rem;
+  margin-top: ${spacing.space20};
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 3.625rem;
+    margin-top: ${spacing.space32};
+    border-radius: 0.5rem;
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const Main = styled.main`
+  flex: 1;
+  min-width: 0;
+  min-height: 100vh;
+  background-color: #f4f6f5;
+`;
+
+const AdminContent = styled.div`
+  position: relative;
+  display: grid;
+  gap: ${spacing.space16};
+  width: 100%;
+  max-width: ${layout.adminMaxWidth};
+  margin: 0 auto;
+  padding: 3.25rem ${spacing.space20} ${spacing.space32};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space24};
+    max-width: ${layout.adminMaxWidthLarge};
+    padding: 5.625rem ${spacing.space24} 4.125rem;
+  }
+`;
+
+const AccountText = styled.p`
+  position: absolute;
+  top: 1.5rem;
+  right: ${spacing.space20};
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    top: 2.375rem;
+    right: ${spacing.space24};
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const PageHeader = styled.header`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #050505;
+  font-size: ${typography.fontSize24};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+const Description = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const StatsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+const StatCard = styled.section`
+  min-height: 5.125rem;
+  padding: 1rem 0.875rem;
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+
+  @media (min-width: 120rem) {
+    min-height: 8.25rem;
+    padding: 1.5rem;
+  }
+`;
+
+const StatLabel = styled.p`
+  margin: 0 0 ${spacing.space8};
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-bottom: ${spacing.space16};
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const StatValue = styled.p`
+  margin: 0;
+  color: #050505;
+  font-size: ${typography.fontSize24};
+  font-weight: 900;
+  line-height: ${typography.lineHeight100};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+const DashboardGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${spacing.space16};
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const SectionCard = styled.section`
+  padding: 1.25rem 1rem;
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 ${spacing.space16};
+  color: #050505;
+  font-size: ${typography.fontSize18};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-bottom: ${spacing.space24};
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const ActionGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const SupportGrid = styled(ActionGrid)`
+  max-width: 41rem;
+
+  @media (min-width: 120rem) {
+    max-width: 61.5rem;
+  }
+`;
+
+const ActionCard = styled.div`
+  min-height: 4.25rem;
+  padding: 1rem;
+  border: 1px solid #e1e5e3;
+  border-radius: 0.5rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: 6.875rem;
+    padding: 1.5rem;
+  }
+`;
+
+const ActionTitle = styled.p<{ $accent?: boolean }>`
+  margin: 0 0 ${spacing.space4};
+  color: ${({ $accent }) => ($accent ? "#b27600" : "#64706c")};
+  font-size: ${typography.fontSize14};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-bottom: ${spacing.space8};
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const ActionDescription = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const StatePanel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+`;
+
+const InlineStatus = styled.p`
+  margin: 0;
+  color: ${colors.notice};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/admin/AdminDashboardSectionParts.tsx
+++ b/components/admin/AdminDashboardSectionParts.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import type { ReactNode } from "react";
+import styled from "styled-components";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+type DataStateProps = {
+  isLoading: boolean;
+  isError: boolean;
+  isEmpty: boolean;
+  loadingLabel: string;
+  errorLabel: string;
+  emptyLabel: string;
+  children: ReactNode;
+};
+
+export function DataState({
+  isLoading,
+  isError,
+  isEmpty,
+  loadingLabel,
+  errorLabel,
+  emptyLabel,
+  children,
+}: DataStateProps) {
+  if (isLoading) {
+    return (
+      <DataStateBox>
+        <StatePanel>
+          <LoadingSpinner label={loadingLabel} />
+        </StatePanel>
+      </DataStateBox>
+    );
+  }
+
+  if (isError) {
+    return (
+      <DataStateBox>
+        <StatePanel role="alert">{errorLabel}</StatePanel>
+      </DataStateBox>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <DataStateBox>
+        <StatePanel>{emptyLabel}</StatePanel>
+      </DataStateBox>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+export const TwoColumnGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(20rem, 0.8fr);
+  gap: ${spacing.space16};
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const StatsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+export const StatCard = styled.section`
+  min-height: 5.125rem;
+  padding: 1rem 0.875rem;
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+
+  @media (min-width: 120rem) {
+    min-height: 8.25rem;
+    padding: 1.5rem;
+  }
+`;
+
+export const StatLabel = styled.p`
+  margin: 0 0 ${spacing.space8};
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const StatValue = styled.p`
+  margin: 0;
+  color: #050505;
+  font-size: ${typography.fontSize24};
+  font-weight: 900;
+  line-height: ${typography.lineHeight100};
+`;
+
+export const DashboardGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${spacing.space16};
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const SectionCard = styled.section`
+  min-width: 0;
+  padding: 1.25rem 1rem;
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+`;
+
+export const SectionHeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+`;
+
+export const SectionTitle = styled.h2`
+  margin: 0 0 ${spacing.space16};
+  color: #050505;
+  font-size: ${typography.fontSize18};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+
+  ${SectionHeaderRow} & {
+    margin-bottom: 0;
+  }
+`;
+
+export const SectionDescription = styled.p`
+  margin: -${spacing.space8} 0 ${spacing.space16};
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+
+  ${SectionHeaderRow} + & {
+    margin-top: ${spacing.space8};
+  }
+`;
+
+export const ActionGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const SupportGrid = styled(ActionGrid)`
+  max-width: 41rem;
+`;
+
+export const ActionCardButton = styled.button`
+  min-height: 4.25rem;
+  border: 1px solid #e1e5e3;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background-color: ${colors.white};
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    border-color: ${colors.point};
+  }
+`;
+
+export const ActionTitle = styled.p<{ $accent?: boolean }>`
+  margin: 0 0 ${spacing.space4};
+  color: ${({ $accent }) => ($accent ? "#b27600" : "#64706c")};
+  font-size: ${typography.fontSize14};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const ActionDescription = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;
+
+export const StatePanel = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 8rem;
+  padding: ${spacing.space20};
+  background-color: ${colors.white};
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+`;
+
+export const DataStateBox = styled.div`
+  display: flex;
+  width: 100%;
+  min-height: 16rem;
+  margin-bottom: ${spacing.space12};
+`;
+
+export const StableListArea = styled.div`
+  min-height: 16rem;
+`;
+
+export const InlineStatus = styled.p`
+  margin: 0;
+  color: ${colors.notice};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+export const ControlRow = styled.div`
+  display: flex;
+  gap: ${spacing.space8};
+  margin: ${spacing.space12} 0;
+`;
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: ${typography.fontSize13};
+
+  th,
+  td {
+    border-bottom: 1px solid #e6e9e7;
+    padding: ${spacing.space8};
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    color: #64706c;
+    font-weight: 800;
+  }
+
+  tbody tr {
+    cursor: pointer;
+  }
+
+  tbody tr:hover {
+    background-color: ${colors.pointSoft};
+  }
+`;
+
+export const FormGrid = styled.form`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+export const Label = styled.label`
+  display: grid;
+  gap: ${spacing.space4};
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+`;
+
+export const EditorLabel = styled(Label)`
+  .toastui-editor-defaultUI {
+    border-color: ${colors.border};
+    border-radius: 0.375rem;
+    overflow: hidden;
+  }
+`;
+
+export const EditorField = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  .toastui-editor-defaultUI {
+    border-color: ${colors.border};
+    border-radius: 0.375rem;
+    overflow: hidden;
+  }
+
+  .toastui-editor-mode-switch {
+    display: none;
+  }
+
+  .toastui-editor-md-tab-container {
+    display: none;
+  }
+
+  .toastui-editor-contents {
+    color: #111827;
+    font-size: ${typography.fontSize14};
+    font-weight: 400;
+  }
+
+  .toastui-editor-contents strong,
+  .toastui-editor-contents b {
+    font-weight: 800;
+  }
+
+  .toastui-editor-ww-container strong,
+  .toastui-editor-ww-container b {
+    font-weight: 800;
+  }
+`;
+
+export const EditorFieldTitle = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const CheckLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+`;
+
+export const TextInput = styled.input`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 ${spacing.space12};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+`;
+
+export const TextArea = styled.textarea`
+  width: 100%;
+  min-height: 8rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: ${spacing.space12};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  resize: vertical;
+`;
+
+export const Select = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 ${spacing.space12};
+  background-color: ${colors.white};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+`;
+
+export const ButtonRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${spacing.space8};
+`;
+
+export const PrimaryButton = styled.button`
+  min-height: 2.375rem;
+  border: 0;
+  border-radius: 0.375rem;
+  padding: 0 ${spacing.space16};
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-family: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: #74bd48;
+    color: ${colors.white};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+`;
+
+export const SmallButton = styled.button`
+  min-height: 2.25rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 ${spacing.space16};
+  background-color: ${colors.white};
+  color: #1f2b28;
+  font-family: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    border-color: #88cd5a;
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+`;
+
+export const DangerButton = styled(SmallButton)`
+  border-color: #eb665c;
+  color: ${colors.notice};
+
+  &:not(:disabled):hover {
+    border-color: #da3a30;
+    background-color: #fff1f0;
+    color: #da3a30;
+  }
+`;
+
+export const Divider = styled.hr`
+  width: 100%;
+  margin: ${spacing.space20} 0;
+  border: 0;
+  border-top: 1px solid #e6e9e7;
+`;
+
+export const List = styled.ul`
+  display: grid;
+  gap: ${spacing.space8};
+  margin: ${spacing.space12} 0;
+  padding: 0;
+  list-style: none;
+`;
+
+export const ListItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+  padding: ${spacing.space8};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+`;
+
+export const MetaGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space8};
+  margin-bottom: ${spacing.space12};
+`;
+
+export const MetaItem = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -1,0 +1,73 @@
+import type { ChannelAccessLevel } from "@/api/channel/channel.dto";
+import type { ClassroomType } from "@/api/classroom/classroom.dto";
+import type { PostStatus } from "@/api/post/post.dto";
+import type { UserRole } from "@/api/user/user.dto";
+
+export type AdminMenu = "dashboard" | "users" | "channels" | "posts" | "departments" | "classrooms" | "purchases";
+
+export type UserFormState = {
+  email: string;
+  nickname: string;
+  password: string;
+  name: string;
+  phoneNumber: string;
+  role: UserRole;
+  departmentId: string;
+};
+
+export type ChannelFormState = {
+  name: string;
+  description: string;
+  accessLevel: ChannelAccessLevel;
+  allowGuestRead: boolean;
+  isDefault: boolean;
+  isActive: boolean;
+};
+
+export type DepartmentFormState = {
+  name: string;
+  description: string;
+};
+
+export type ClassroomFormState = {
+  name: string;
+  type: ClassroomType;
+  description: string;
+};
+
+export type PostEditState = {
+  title: string;
+  status: PostStatus;
+  allowComment: boolean;
+  thumbnailUrl: string;
+  contentHtml: string;
+};
+
+export type PostCreateState = {
+  channelScope: "" | "NOTICE" | "CLASSROOM" | "DEPARTMENT" | "CUSTOM";
+  channelTargetId: string;
+  channelId: string;
+  title: string;
+  status: PostStatus;
+  allowComment: boolean;
+  isPinned: boolean;
+  thumbnailUrl: string;
+  contentHtml: string;
+};
+
+export type PurchaseCreateState = {
+  title: string;
+  content: string;
+  classroomId: string;
+  advancePaymentRequestedAmount: string;
+  itemName: string;
+  itemReason: string;
+  itemExpectedPrice: string;
+};
+
+export type PermissionFormState = {
+  resourceType: string;
+  actionType: string;
+  scope: "GLOBAL" | "TARGET";
+  target: string;
+};

--- a/components/admin/AdminLoginPage.tsx
+++ b/components/admin/AdminLoginPage.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+import { login } from "@/api/auth/auth.api";
+import { clearTokens } from "@/api/client/tokenStorage";
+import { getCurrentUser } from "@/api/user/user.api";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+type AdminLoginForm = {
+  email: string;
+  password: string;
+};
+
+const initialForm: AdminLoginForm = {
+  email: "",
+  password: "",
+};
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [form, setForm] = useState(initialForm);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusMessage("");
+
+    try {
+      await login({
+        email: form.email.trim(),
+        password: form.password,
+      });
+
+      const user = await getCurrentUser();
+
+      if (user.role !== "ADMIN") {
+        clearTokens();
+        setStatusMessage("관리자 계정으로만 접근할 수 있습니다.");
+        return;
+      }
+
+      router.replace("/admin");
+    } catch {
+      clearTokens();
+      setStatusMessage("입력하신 관리자 계정 정보를 다시 확인해주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Main>
+      <AdminContent>
+        <LoginPanel aria-labelledby="admin-login-title">
+          <PanelHeader>
+            <Logo src="/logo.svg" alt="" aria-hidden="true" />
+            <HeadingGroup>
+              <Title id="admin-login-title">관리자 로그인</Title>
+              <Description>사용자, 부서, 분반, 구매 요청 관리</Description>
+            </HeadingGroup>
+          </PanelHeader>
+
+          <Form onSubmit={handleSubmit}>
+            <Field>
+              <Label htmlFor="admin-login-email">이메일</Label>
+              <Input
+                id="admin-login-email"
+                name="email"
+                type="text"
+                autoComplete="username"
+                value={form.email}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, email: event.target.value }))
+                }
+                required
+              />
+            </Field>
+
+            <Field>
+              <Label htmlFor="admin-login-password">비밀번호</Label>
+              <Input
+                id="admin-login-password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                value={form.password}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, password: event.target.value }))
+                }
+                required
+              />
+            </Field>
+
+            <Status role="status" aria-live="polite" $visible={Boolean(statusMessage)}>
+              {statusMessage}
+            </Status>
+
+            <SubmitButton type="submit" disabled={!canSubmit || isSubmitting}>
+              {isSubmitting ? "로그인 중" : "로그인"}
+            </SubmitButton>
+          </Form>
+        </LoginPanel>
+      </AdminContent>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: 100vh;
+  background-color: #f5f7f6;
+`;
+
+const AdminContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: ${layout.adminMaxWidth};
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: ${spacing.space28} ${spacing.space20} ${spacing.space32};
+
+  @media (min-width: 120rem) {
+    max-width: ${layout.adminMaxWidthLarge};
+    padding-top: ${spacing.space46};
+    padding-bottom: ${spacing.space47};
+  }
+`;
+
+const LoginPanel = styled.section`
+  width: 100%;
+  max-width: 20.5rem;
+  padding: 1.5625rem 1.4375rem 1.5rem;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius12};
+
+  @media (min-width: 120rem) {
+    max-width: 30.75rem;
+    padding: 2.375rem 2.1875rem 2.25rem;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  margin-bottom: 1.375rem;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    margin-bottom: ${spacing.space32};
+  }
+`;
+
+const Logo = styled.img`
+  width: 1.75rem;
+  height: auto;
+
+  @media (min-width: 120rem) {
+    width: 2.625rem;
+  }
+`;
+
+const HeadingGroup = styled.div`
+  min-width: 0;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #050505;
+  font-size: ${typography.fontSize16};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const Description = styled.p`
+  margin: ${spacing.space4} 0 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-top: ${spacing.space8};
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const Form = styled.form`
+  display: grid;
+  gap: ${spacing.space16};
+`;
+
+const Field = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const Label = styled.label`
+  color: #050505;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const Input = styled.input`
+  width: 100%;
+  min-height: 2.5rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 ${spacing.space12};
+  color: #050505;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 3.75rem;
+    border-radius: 0.5rem;
+    padding: 0 ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+
+  &:focus {
+    border-color: ${colors.point};
+    outline: 2px solid ${colors.pointSoft};
+  }
+`;
+
+const Status = styled.p<{ $visible: boolean }>`
+  min-height: 1.125rem;
+  margin: 0;
+  color: ${colors.notice};
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+
+  @media (min-width: 120rem) {
+    min-height: 1.5rem;
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const SubmitButton = styled.button`
+  min-height: 2.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-family: inherit;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 3.75rem;
+    border-radius: 0.5rem;
+    font-size: ${typography.fontSize18};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+`;

--- a/components/admin/AdminMainDashboardSection.tsx
+++ b/components/admin/AdminMainDashboardSection.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type { PurchaseRequestStatus } from "@/api/request/request.dto";
+import type { AdminMenu } from "@/components/admin/AdminDashboardTypes";
+import {
+  ActionCardButton,
+  ActionDescription,
+  ActionGrid,
+  ActionTitle,
+  DataState,
+  DashboardGrid,
+  SectionCard,
+  SectionTitle,
+  StatCard,
+  StatLabel,
+  StatsGrid,
+  StatValue,
+  SupportGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState = {
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type StatItem = {
+  label: string;
+  value: number;
+};
+
+type AdminMainDashboardSectionProps = {
+  stats: StatItem[];
+  usersQuery: QueryState;
+  departmentsQuery: QueryState;
+  classroomsQuery: QueryState;
+  pendingPurchasesQuery: QueryState;
+  setActiveMenu: Dispatch<SetStateAction<AdminMenu>>;
+  setPurchaseStatus: Dispatch<SetStateAction<PurchaseRequestStatus | "">>;
+};
+
+export function AdminMainDashboardSection({
+  stats,
+  usersQuery,
+  departmentsQuery,
+  classroomsQuery,
+  pendingPurchasesQuery,
+  setActiveMenu,
+  setPurchaseStatus,
+}: AdminMainDashboardSectionProps) {
+  return (
+    <>
+      <DataState
+        isLoading={usersQuery.isLoading || departmentsQuery.isLoading || classroomsQuery.isLoading || pendingPurchasesQuery.isLoading}
+        isError={usersQuery.isError || departmentsQuery.isError || classroomsQuery.isError || pendingPurchasesQuery.isError}
+        isEmpty={false}
+        loadingLabel="관리자 데이터 불러오는 중"
+        errorLabel="대시보드 데이터를 불러오지 못했습니다."
+        emptyLabel=""
+      >
+        <StatsGrid>
+          {stats.map((stat) => (
+            <StatCard key={stat.label}>
+              <StatLabel>{stat.label}</StatLabel>
+              <StatValue>{stat.value}</StatValue>
+            </StatCard>
+          ))}
+        </StatsGrid>
+      </DataState>
+
+      <DashboardGrid>
+        <SectionCard>
+          <SectionTitle>사용자 및 권한 관리</SectionTitle>
+          <ActionGrid>
+            <ActionCardButton type="button" onClick={() => setActiveMenu("users")}>
+              <ActionTitle>사용자 관리</ActionTitle>
+              <ActionDescription>전체 사용자 및 권한 조회/수정</ActionDescription>
+            </ActionCardButton>
+            <ActionCardButton type="button" onClick={() => setActiveMenu("departments")}>
+              <ActionTitle>부서 관리</ActionTitle>
+              <ActionDescription>기관 산하 부서 조직 구성</ActionDescription>
+            </ActionCardButton>
+          </ActionGrid>
+        </SectionCard>
+
+        <SectionCard>
+          <SectionTitle>게시판 및 교육 운영</SectionTitle>
+          <ActionGrid>
+            <ActionCardButton type="button" onClick={() => setActiveMenu("channels")}>
+              <ActionTitle>채널 관리</ActionTitle>
+              <ActionDescription>소통 채널 및 게시판 설정</ActionDescription>
+            </ActionCardButton>
+            <ActionCardButton type="button" onClick={() => setActiveMenu("posts")}>
+              <ActionTitle>게시글 관리</ActionTitle>
+              <ActionDescription>모든 채널의 게시물 모니터링</ActionDescription>
+            </ActionCardButton>
+            <ActionCardButton type="button" onClick={() => setActiveMenu("classrooms")}>
+              <ActionTitle>분반 관리</ActionTitle>
+              <ActionDescription>분반 및 교육 과정 운영</ActionDescription>
+            </ActionCardButton>
+          </ActionGrid>
+        </SectionCard>
+      </DashboardGrid>
+
+      <SectionCard>
+        <SectionTitle>결재 및 행정 지원</SectionTitle>
+        <SupportGrid>
+          <ActionCardButton type="button" onClick={() => setActiveMenu("purchases")}>
+            <ActionTitle>전체 구매 요청</ActionTitle>
+            <ActionDescription>물품 구매 요청 이력 확인</ActionDescription>
+          </ActionCardButton>
+          <ActionCardButton
+            type="button"
+            onClick={() => {
+              setPurchaseStatus("PENDING");
+              setActiveMenu("purchases");
+            }}
+          >
+            <ActionTitle $accent>승인 대기 중</ActionTitle>
+            <ActionDescription>검토가 필요한 신규 구매 요청</ActionDescription>
+          </ActionCardButton>
+        </SupportGrid>
+      </SectionCard>
+    </>
+  );
+}

--- a/components/admin/channels/AdminChannelsSection.tsx
+++ b/components/admin/channels/AdminChannelsSection.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type { ChannelListItemDto } from "@/api/channel/channel.dto";
+import type { ChannelFormState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  CheckLabel,
+  ControlRow,
+  DangerButton,
+  DataState,
+  FormGrid,
+  Label,
+  MetaGrid,
+  MetaItem,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionHeaderRow,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState<TData> = {
+  data?: TData;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type AdminChannelsSectionProps = {
+  channels: ChannelListItemDto[];
+  selectedChannelId: number | null;
+  channelSearch: string;
+  channelForm: ChannelFormState;
+  channelsQuery: QueryState<unknown>;
+  channelDetailQuery: QueryState<ChannelListItemDto>;
+  createChannelMutation: VoidMutationAction;
+  updateChannelMutation: VoidMutationAction;
+  deleteChannelMutation: VoidMutationAction;
+  setSelectedChannelId: Dispatch<SetStateAction<number | null>>;
+  setChannelSearch: Dispatch<SetStateAction<string>>;
+  setChannelForm: Dispatch<SetStateAction<ChannelFormState>>;
+  selectChannel: (item: ChannelListItemDto) => void;
+  emptyChannelForm: ChannelFormState;
+};
+
+export function AdminChannelsSection({
+  channels,
+  selectedChannelId,
+  channelSearch,
+  channelForm,
+  channelsQuery,
+  channelDetailQuery,
+  createChannelMutation,
+  updateChannelMutation,
+  deleteChannelMutation,
+  setSelectedChannelId,
+  setChannelSearch,
+  setChannelForm,
+  selectChannel,
+  emptyChannelForm,
+}: AdminChannelsSectionProps) {
+  return (
+    <TwoColumnGrid>
+      <SectionCard>
+        <SectionHeaderRow>
+          <SectionTitle>채널 목록</SectionTitle>
+          <SmallButton
+            type="button"
+            onClick={() => {
+              setSelectedChannelId(null);
+              setChannelForm(emptyChannelForm);
+            }}
+          >
+            신규 개설
+          </SmallButton>
+        </SectionHeaderRow>
+        <ControlRow>
+          <TextInput
+            value={channelSearch}
+            onChange={(event) => setChannelSearch(event.target.value)}
+            placeholder="채널명 검색"
+          />
+        </ControlRow>
+        <DataState
+          isLoading={channelsQuery.isLoading}
+          isError={channelsQuery.isError}
+          isEmpty={channels.length === 0}
+          loadingLabel="채널 목록 불러오는 중"
+          errorLabel="채널 목록을 불러오지 못했습니다."
+          emptyLabel="채널이 없습니다."
+        >
+          <Table>
+            <thead>
+              <tr>
+                <th>이름</th>
+                <th>유형</th>
+                <th>연결</th>
+                <th>상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {channels.map((item) => (
+                <tr key={item.id} onClick={() => selectChannel(item)}>
+                  <td>{item.name}</td>
+                  <td>{item.channelType}</td>
+                  <td>{item.refId ?? "-"}</td>
+                  <td>{item.isActive ? "활성" : "비활성"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </DataState>
+      </SectionCard>
+      <SectionCard>
+        <SectionTitle>{selectedChannelId ? "채널 상세/수정" : "채널 생성"}</SectionTitle>
+        <MetaGrid>
+          <MetaItem>유형: {channelDetailQuery.data?.channelType ?? "-"}</MetaItem>
+          <MetaItem>바인딩: {channelDetailQuery.data?.bindingType ?? "-"}</MetaItem>
+          <MetaItem>연결 대상: {channelDetailQuery.data?.refId ?? "-"}</MetaItem>
+        </MetaGrid>
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (selectedChannelId) {
+              updateChannelMutation.mutate();
+            } else {
+              createChannelMutation.mutate();
+            }
+          }}
+        >
+          <Label>
+            이름
+            <TextInput
+              value={channelForm.name}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            설명
+            <TextInput
+              value={channelForm.description}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, description: event.target.value }))
+              }
+            />
+          </Label>
+          <Label>
+            접근 수준
+            <Select
+              value={channelForm.accessLevel}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, accessLevel: event.target.value }))
+              }
+            >
+              <option value="CLOSED">CLOSED</option>
+              <option value="READ_ONLY">READ_ONLY</option>
+              <option value="READ_COMMENT">READ_COMMENT</option>
+              <option value="READ_WRITE">READ_WRITE</option>
+            </Select>
+          </Label>
+          <CheckLabel>
+            <input
+              type="checkbox"
+              checked={channelForm.allowGuestRead}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, allowGuestRead: event.target.checked }))
+              }
+            />{" "}
+            게스트 읽기
+          </CheckLabel>
+          <CheckLabel>
+            <input
+              type="checkbox"
+              checked={channelForm.isDefault}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, isDefault: event.target.checked }))
+              }
+            />{" "}
+            기본 채널
+          </CheckLabel>
+          <CheckLabel>
+            <input
+              type="checkbox"
+              checked={channelForm.isActive}
+              onChange={(event) =>
+                setChannelForm((current) => ({ ...current, isActive: event.target.checked }))
+              }
+            />{" "}
+            활성
+          </CheckLabel>
+          <ButtonRow>
+            <PrimaryButton
+              disabled={createChannelMutation.isPending || updateChannelMutation.isPending}
+            >
+              {selectedChannelId ? "수정" : "생성"}
+            </PrimaryButton>
+            {selectedChannelId ? (
+              <DangerButton
+                type="button"
+                disabled={deleteChannelMutation.isPending}
+                onClick={() => deleteChannelMutation.mutate()}
+              >
+                삭제
+              </DangerButton>
+            ) : null}
+          </ButtonRow>
+        </FormGrid>
+      </SectionCard>
+    </TwoColumnGrid>
+  );
+}

--- a/components/admin/classes/AdminClassroomsSection.tsx
+++ b/components/admin/classes/AdminClassroomsSection.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
+import type { ClassroomFormState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  ControlRow,
+  DangerButton,
+  DataState,
+  FormGrid,
+  InlineStatus,
+  Label,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionHeaderRow,
+  SectionTitle,
+  Select,
+  SmallButton,
+  StableListArea,
+  Table,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState = {
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type AdminClassroomsSectionProps = {
+  classrooms: ClassroomListItemDto[];
+  selectedClassroomId: number | null;
+  classroomSearch: string;
+  classroomForm: ClassroomFormState;
+  classroomsQuery: QueryState;
+  classroomDetailQuery: QueryState;
+  createClassroomMutation: VoidMutationAction;
+  updateClassroomMutation: VoidMutationAction;
+  deleteClassroomMutation: VoidMutationAction;
+  setSelectedClassroomId: Dispatch<SetStateAction<number | null>>;
+  setClassroomSearch: Dispatch<SetStateAction<string>>;
+  setClassroomForm: Dispatch<SetStateAction<ClassroomFormState>>;
+  selectClassroom: (item: ClassroomListItemDto) => void;
+  emptyClassroomForm: ClassroomFormState;
+};
+
+export function AdminClassroomsSection({
+  classrooms,
+  selectedClassroomId,
+  classroomSearch,
+  classroomForm,
+  classroomsQuery,
+  classroomDetailQuery,
+  createClassroomMutation,
+  updateClassroomMutation,
+  deleteClassroomMutation,
+  setSelectedClassroomId,
+  setClassroomSearch,
+  setClassroomForm,
+  selectClassroom,
+  emptyClassroomForm,
+}: AdminClassroomsSectionProps) {
+  return (
+    <TwoColumnGrid>
+      <SectionCard>
+        <SectionHeaderRow>
+          <SectionTitle>분반 목록</SectionTitle>
+          <SmallButton
+            type="button"
+            onClick={() => {
+              setSelectedClassroomId(null);
+              setClassroomForm(emptyClassroomForm);
+            }}
+          >
+            신규 개설
+          </SmallButton>
+        </SectionHeaderRow>
+        <ControlRow>
+          <TextInput
+            value={classroomSearch}
+            onChange={(event) => setClassroomSearch(event.target.value)}
+            placeholder="분반명 검색"
+          />
+        </ControlRow>
+        <StableListArea>
+          <DataState
+            isLoading={classroomsQuery.isLoading}
+            isError={classroomsQuery.isError}
+            isEmpty={classrooms.length === 0}
+            loadingLabel="분반 목록 불러오는 중"
+            errorLabel="분반 목록을 불러오지 못했습니다."
+            emptyLabel="분반이 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>이름</th>
+                  <th>유형</th>
+                  <th>설명</th>
+                </tr>
+              </thead>
+              <tbody>
+                {classrooms.map((item) => (
+                  <tr key={item.id} onClick={() => selectClassroom(item)}>
+                    <td>{item.id}</td>
+                    <td>{item.name}</td>
+                    <td>{item.type}</td>
+                    <td>{item.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </StableListArea>
+      </SectionCard>
+      <SectionCard>
+        <SectionTitle>{selectedClassroomId ? "분반 상세/수정" : "분반 생성"}</SectionTitle>
+        <SectionDescription>
+          분반 이름, 유형, 설명을 생성하거나 수정하고 삭제할 수 있습니다.
+        </SectionDescription>
+        {classroomDetailQuery.isLoading ? (
+          <InlineStatus>분반 상세를 불러오는 중입니다.</InlineStatus>
+        ) : null}
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (selectedClassroomId) {
+              updateClassroomMutation.mutate();
+            } else {
+              createClassroomMutation.mutate();
+            }
+          }}
+        >
+          <Label>
+            이름
+            <TextInput
+              value={classroomForm.name}
+              onChange={(event) =>
+                setClassroomForm((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            유형
+            <Select
+              value={classroomForm.type}
+              onChange={(event) =>
+                setClassroomForm((current) => ({ ...current, type: event.target.value }))
+              }
+            >
+              <option value="WEEKDAY">WEEKDAY</option>
+              <option value="WEEKEND">WEEKEND</option>
+            </Select>
+          </Label>
+          <Label>
+            설명
+            <TextInput
+              value={classroomForm.description}
+              onChange={(event) =>
+                setClassroomForm((current) => ({ ...current, description: event.target.value }))
+              }
+            />
+          </Label>
+          <ButtonRow>
+            <PrimaryButton
+              disabled={createClassroomMutation.isPending || updateClassroomMutation.isPending}
+            >
+              {selectedClassroomId ? "수정" : "생성"}
+            </PrimaryButton>
+            {selectedClassroomId ? (
+              <DangerButton
+                type="button"
+                disabled={deleteClassroomMutation.isPending}
+                onClick={() => deleteClassroomMutation.mutate()}
+              >
+                삭제
+              </DangerButton>
+            ) : null}
+          </ButtonRow>
+        </FormGrid>
+      </SectionCard>
+    </TwoColumnGrid>
+  );
+}

--- a/components/admin/departments/AdminDepartmentsSection.tsx
+++ b/components/admin/departments/AdminDepartmentsSection.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  DepartmentDetailResponseDto,
+  DepartmentListItemDto,
+} from "@/api/department/department.dto";
+import type { DepartmentFormState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  DangerButton,
+  DataState,
+  Divider,
+  FormGrid,
+  Label,
+  List,
+  ListItem,
+  MetaGrid,
+  MetaItem,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionHeaderRow,
+  SectionTitle,
+  SmallButton,
+  Table,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState<TData> = {
+  data?: TData;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type AdminDepartmentsSectionProps = {
+  departments: DepartmentListItemDto[];
+  selectedDepartmentId: number | null;
+  departmentForm: DepartmentFormState;
+  departmentsQuery: QueryState<unknown>;
+  departmentDetailQuery: QueryState<DepartmentDetailResponseDto>;
+  createDepartmentMutation: VoidMutationAction;
+  updateDepartmentMutation: VoidMutationAction;
+  deleteDepartmentMutation: VoidMutationAction;
+  setSelectedDepartmentId: Dispatch<SetStateAction<number | null>>;
+  setDepartmentForm: Dispatch<SetStateAction<DepartmentFormState>>;
+  selectDepartment: (item: DepartmentListItemDto) => void;
+  emptyDepartmentForm: DepartmentFormState;
+};
+
+export function AdminDepartmentsSection({
+  departments,
+  selectedDepartmentId,
+  departmentForm,
+  departmentsQuery,
+  departmentDetailQuery,
+  createDepartmentMutation,
+  updateDepartmentMutation,
+  deleteDepartmentMutation,
+  setSelectedDepartmentId,
+  setDepartmentForm,
+  selectDepartment,
+  emptyDepartmentForm,
+}: AdminDepartmentsSectionProps) {
+  return (
+    <TwoColumnGrid>
+      <SectionCard>
+        <SectionHeaderRow>
+          <SectionTitle>부서 목록</SectionTitle>
+          <SmallButton
+            type="button"
+            onClick={() => {
+              setSelectedDepartmentId(null);
+              setDepartmentForm(emptyDepartmentForm);
+            }}
+          >
+            신규 개설
+          </SmallButton>
+        </SectionHeaderRow>
+        <DataState
+          isLoading={departmentsQuery.isLoading}
+          isError={departmentsQuery.isError}
+          isEmpty={departments.length === 0}
+          loadingLabel="부서 목록 불러오는 중"
+          errorLabel="부서 목록을 불러오지 못했습니다."
+          emptyLabel="부서가 없습니다."
+        >
+          <Table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>이름</th>
+                <th>설명</th>
+              </tr>
+            </thead>
+            <tbody>
+              {departments.map((item) => (
+                <tr key={item.id} onClick={() => selectDepartment(item)}>
+                  <td>{item.id}</td>
+                  <td>{item.name}</td>
+                  <td>{item.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </DataState>
+      </SectionCard>
+      <SectionCard>
+        <SectionTitle>{selectedDepartmentId ? "부서 상세/수정" : "부서 생성"}</SectionTitle>
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (selectedDepartmentId) {
+              updateDepartmentMutation.mutate();
+            } else {
+              createDepartmentMutation.mutate();
+            }
+          }}
+        >
+          <Label>
+            이름
+            <TextInput
+              value={departmentForm.name}
+              onChange={(event) =>
+                setDepartmentForm((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            설명
+            <TextInput
+              value={departmentForm.description}
+              onChange={(event) =>
+                setDepartmentForm((current) => ({ ...current, description: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <ButtonRow>
+            <PrimaryButton
+              disabled={createDepartmentMutation.isPending || updateDepartmentMutation.isPending}
+            >
+              {selectedDepartmentId ? "수정" : "생성"}
+            </PrimaryButton>
+            {selectedDepartmentId ? (
+              <DangerButton
+                type="button"
+                disabled={deleteDepartmentMutation.isPending}
+                onClick={() => deleteDepartmentMutation.mutate()}
+              >
+                삭제
+              </DangerButton>
+            ) : null}
+          </ButtonRow>
+        </FormGrid>
+        <Divider />
+        <SectionTitle>소속 사용자/권한</SectionTitle>
+        <DataState
+          isLoading={departmentDetailQuery.isLoading}
+          isError={departmentDetailQuery.isError}
+          isEmpty={!selectedDepartmentId}
+          loadingLabel="부서 상세 불러오는 중"
+          errorLabel="부서 상세를 불러오지 못했습니다."
+          emptyLabel="부서를 선택하세요."
+        >
+          <MetaGrid>
+            <MetaItem>사용자 {departmentDetailQuery.data?.users?.length ?? 0}명</MetaItem>
+            <MetaItem>권한 {departmentDetailQuery.data?.permissions?.length ?? 0}개</MetaItem>
+          </MetaGrid>
+          <List>
+            {departmentDetailQuery.data?.users?.map((item) => (
+              <ListItem key={item.id}>
+                <span>{item.name ?? item.email}</span>
+                <span>{item.role}</span>
+              </ListItem>
+            ))}
+          </List>
+        </DataState>
+      </SectionCard>
+    </TwoColumnGrid>
+  );
+}

--- a/components/admin/posts/AdminPostsSection.tsx
+++ b/components/admin/posts/AdminPostsSection.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import type { ChannelListItemDto } from "@/api/channel/channel.dto";
+import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
+import type { DepartmentListItemDto } from "@/api/department/department.dto";
+import type {
+  PostDetailResponseDto,
+  PostStatus,
+  PostSummaryResponseDto,
+} from "@/api/post/post.dto";
+import type { PostCreateState, PostEditState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  CheckLabel,
+  ControlRow,
+  DangerButton,
+  DataState,
+  EditorField,
+  EditorFieldTitle,
+  FormGrid,
+  Label,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextArea,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+import ToastEditorField from "@/components/admin/posts/ToastEditorField";
+
+type QueryState<TData> = {
+  data?: TData;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type ValueMutationAction<TVariables> = {
+  isPending: boolean;
+  mutate: (variables: TVariables) => void;
+};
+
+type AdminPostsSectionProps = {
+  channels: ChannelListItemDto[];
+  classrooms: ClassroomListItemDto[];
+  departments: DepartmentListItemDto[];
+  posts: PostSummaryResponseDto[];
+  selectedPost: { channelId: number; postId: number } | null;
+  postTitleSearch: string;
+  postCreate: PostCreateState;
+  postEdit: PostEditState;
+  postsQuery: QueryState<unknown>;
+  postDetailQuery: QueryState<PostDetailResponseDto>;
+  createPostMutation: VoidMutationAction;
+  updatePostMutation: VoidMutationAction;
+  pinPostMutation: ValueMutationAction<boolean>;
+  deletePostMutation: VoidMutationAction;
+  setPostTitleSearch: Dispatch<SetStateAction<string>>;
+  setPostCreate: Dispatch<SetStateAction<PostCreateState>>;
+  setPostEdit: Dispatch<SetStateAction<PostEditState>>;
+  selectPost: (item: PostSummaryResponseDto) => void;
+};
+
+export function AdminPostsSection({
+  channels,
+  classrooms,
+  departments,
+  posts,
+  selectedPost,
+  postTitleSearch,
+  postCreate,
+  postEdit,
+  postsQuery,
+  postDetailQuery,
+  createPostMutation,
+  updatePostMutation,
+  pinPostMutation,
+  deletePostMutation,
+  setPostTitleSearch,
+  setPostCreate,
+  setPostEdit,
+  selectPost,
+}: AdminPostsSectionProps) {
+  const noticeChannelId =
+    channels.find((channel) => channel.channelType === "NOTICE" && typeof channel.id === "number")
+      ?.id ?? "";
+  const classroomChannelOptions = classrooms
+    .map((classroom) => {
+      const channel = channels.find(
+        (item) =>
+          item.channelType === "CLASSROOM" &&
+          item.refId === classroom.id &&
+          typeof item.id === "number",
+      );
+
+      return channel?.id
+        ? {
+            targetId: String(classroom.id),
+            channelId: String(channel.id),
+            label: classroom.name,
+          }
+        : null;
+    })
+    .filter((item): item is { targetId: string; channelId: string; label: string } =>
+      Boolean(item),
+    );
+  const departmentChannelOptions = departments
+    .map((department) => {
+      const channel = channels.find(
+        (item) =>
+          item.channelType === "DEPARTMENT" &&
+          item.refId === department.id &&
+          typeof item.id === "number",
+      );
+
+      return channel?.id
+        ? {
+            targetId: String(department.id),
+            channelId: String(channel.id),
+            label: department.name,
+          }
+        : null;
+    })
+    .filter((item): item is { targetId: string; channelId: string; label: string } =>
+      Boolean(item),
+    );
+
+  useEffect(() => {
+    if (postCreate.channelScope === "NOTICE" && noticeChannelId) {
+      const nextChannelId = String(noticeChannelId);
+
+      if (postCreate.channelId !== nextChannelId || postCreate.channelTargetId) {
+        setPostCreate((current) => ({
+          ...current,
+          channelTargetId: "",
+          channelId: nextChannelId,
+        }));
+      }
+    }
+  }, [
+    noticeChannelId,
+    postCreate.channelId,
+    postCreate.channelScope,
+    postCreate.channelTargetId,
+    setPostCreate,
+  ]);
+
+  return (
+    <>
+      <SectionCard>
+        <SectionTitle>게시글 작성</SectionTitle>
+
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            createPostMutation.mutate();
+          }}
+        >
+          <Label>
+            채널 구분
+            <Select
+              value={postCreate.channelScope}
+              onChange={(event) =>
+                setPostCreate((current) => {
+                  const channelScope = event.target.value as PostCreateState["channelScope"];
+
+                  return {
+                    ...current,
+                    channelScope,
+                    channelTargetId: "",
+                    channelId: channelScope === "NOTICE" ? String(noticeChannelId) : "",
+                  };
+                })
+              }
+            >
+              <option value="">채널 선택</option>
+              <option value="NOTICE">공지</option>
+              <option value="CLASSROOM">반별</option>
+              <option value="DEPARTMENT">부서별</option>
+            </Select>
+          </Label>
+
+          {postCreate.channelScope === "CLASSROOM" ? (
+            <Label>
+              반/부서 선택
+              <Select
+                value={postCreate.channelTargetId}
+                onChange={(event) => {
+                  const selectedOption = classroomChannelOptions.find(
+                    (option) => option.targetId === event.target.value,
+                  );
+
+                  setPostCreate((current) => ({
+                    ...current,
+                    channelTargetId: event.target.value,
+                    channelId: selectedOption?.channelId ?? "",
+                  }));
+                }}
+              >
+                <option value="">반 선택</option>
+                {classroomChannelOptions.map((option) => (
+                  <option key={option.targetId} value={option.targetId}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </Label>
+          ) : null}
+
+          {postCreate.channelScope === "DEPARTMENT" ? (
+            <Label>
+              반/부서 선택
+              <Select
+                value={postCreate.channelTargetId}
+                onChange={(event) => {
+                  const selectedOption = departmentChannelOptions.find(
+                    (option) => option.targetId === event.target.value,
+                  );
+
+                  setPostCreate((current) => ({
+                    ...current,
+                    channelTargetId: event.target.value,
+                    channelId: selectedOption?.channelId ?? "",
+                  }));
+                }}
+              >
+                <option value="">부서 선택</option>
+                {departmentChannelOptions.map((option) => (
+                  <option key={option.targetId} value={option.targetId}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </Label>
+          ) : null}
+
+          <Label>
+            제목
+            <TextInput
+              value={postCreate.title}
+              onChange={(event) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  title: event.target.value,
+                }))
+              }
+              required
+            />
+          </Label>
+
+          <Label>
+            상태
+            <Select
+              value={postCreate.status}
+              onChange={(event) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  status: event.target.value as PostStatus,
+                }))
+              }
+            >
+              <option value="PUBLISHED">PUBLISHED</option>
+              <option value="DRAFT">DRAFT</option>
+            </Select>
+          </Label>
+
+          <CheckLabel>
+            <input
+              type="checkbox"
+              checked={postCreate.allowComment}
+              onChange={(event) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  allowComment: event.target.checked,
+                }))
+              }
+            />
+            댓글 허용
+          </CheckLabel>
+
+          <CheckLabel>
+            <input
+              type="checkbox"
+              checked={postCreate.isPinned}
+              onChange={(event) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  isPinned: event.target.checked,
+                }))
+              }
+            />
+            상단 고정
+          </CheckLabel>
+
+          <Label>
+            썸네일 URL
+            <TextInput
+              value={postCreate.thumbnailUrl}
+              onChange={(event) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  thumbnailUrl: event.target.value,
+                }))
+              }
+            />
+          </Label>
+
+          <EditorField>
+            <EditorFieldTitle>본문</EditorFieldTitle>
+            <ToastEditorField
+              initialValue={postCreate.contentHtml}
+              onChange={(contentHtml) =>
+                setPostCreate((current) => ({
+                  ...current,
+                  contentHtml,
+                }))
+              }
+            />
+          </EditorField>
+
+          <PrimaryButton disabled={createPostMutation.isPending || !postCreate.channelId}>
+            게시글 작성
+          </PrimaryButton>
+        </FormGrid>
+      </SectionCard>
+
+      <TwoColumnGrid>
+        <SectionCard>
+          <SectionTitle>게시글 목록</SectionTitle>
+
+          <ControlRow>
+            <TextInput
+              value={postTitleSearch}
+              onChange={(event) => setPostTitleSearch(event.target.value)}
+              placeholder="제목 검색"
+            />
+          </ControlRow>
+
+          <DataState
+            isLoading={postsQuery.isLoading}
+            isError={postsQuery.isError}
+            isEmpty={posts.length === 0}
+            loadingLabel="게시글 목록 불러오는 중"
+            errorLabel="게시글 목록을 불러오지 못했습니다."
+            emptyLabel="게시글이 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>제목</th>
+                  <th>채널</th>
+                  <th>작성자</th>
+                  <th>상태</th>
+                  <th>조회</th>
+                </tr>
+              </thead>
+              <tbody>
+                {posts.map((item) => (
+                  <tr key={item.id} onClick={() => selectPost(item)}>
+                    <td>{item.title}</td>
+                    <td>{item.channelName ?? item.channelId}</td>
+                    <td>{item.authorName ?? "-"}</td>
+                    <td>{item.status}</td>
+                    <td>{item.viewCount ?? 0}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </SectionCard>
+
+        <SectionCard>
+          <SectionTitle>게시글 상세/수정</SectionTitle>
+          <SectionDescription>
+            선택한 게시글의 제목, 상태, 댓글 허용 여부와 본문 HTML을 수정하거나 삭제합니다.
+          </SectionDescription>
+
+          <DataState
+            isLoading={postDetailQuery.isLoading}
+            isError={postDetailQuery.isError}
+            isEmpty={!selectedPost}
+            loadingLabel="게시글 상세 불러오는 중"
+            errorLabel="게시글 상세를 불러오지 못했습니다."
+            emptyLabel="게시글을 선택하세요."
+          >
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                updatePostMutation.mutate();
+              }}
+            >
+              <Label>
+                제목
+                <TextInput
+                  value={postEdit.title}
+                  onChange={(event) =>
+                    setPostEdit((current) => ({
+                      ...current,
+                      title: event.target.value,
+                    }))
+                  }
+                />
+              </Label>
+
+              <Label>
+                상태
+                <Select
+                  value={postEdit.status}
+                  onChange={(event) =>
+                    setPostEdit((current) => ({
+                      ...current,
+                      status: event.target.value as PostStatus,
+                    }))
+                  }
+                >
+                  <option value="PUBLISHED">PUBLISHED</option>
+                  <option value="DRAFT">DRAFT</option>
+                  <option value="ARCHIVED">ARCHIVED</option>
+                </Select>
+              </Label>
+
+              <CheckLabel>
+                <input
+                  type="checkbox"
+                  checked={postEdit.allowComment}
+                  onChange={(event) =>
+                    setPostEdit((current) => ({
+                      ...current,
+                      allowComment: event.target.checked,
+                    }))
+                  }
+                />
+                댓글 허용
+              </CheckLabel>
+
+              <Label>
+                썸네일 URL
+                <TextInput
+                  value={postEdit.thumbnailUrl}
+                  onChange={(event) =>
+                    setPostEdit((current) => ({
+                      ...current,
+                      thumbnailUrl: event.target.value,
+                    }))
+                  }
+                />
+              </Label>
+
+              <Label>
+                본문
+                <TextArea
+                  value={postEdit.contentHtml}
+                  onChange={(event) =>
+                    setPostEdit((current) => ({
+                      ...current,
+                      contentHtml: event.target.value,
+                    }))
+                  }
+                />
+              </Label>
+
+              <ButtonRow>
+                <PrimaryButton disabled={updatePostMutation.isPending}>수정</PrimaryButton>
+                <SmallButton
+                  type="button"
+                  disabled={pinPostMutation.isPending}
+                  onClick={() => pinPostMutation.mutate(!(postDetailQuery.data?.isPinned ?? false))}
+                >
+                  {postDetailQuery.data?.isPinned ? "고정 해제" : "고정"}
+                </SmallButton>
+                <DangerButton
+                  type="button"
+                  disabled={deletePostMutation.isPending}
+                  onClick={() => deletePostMutation.mutate()}
+                >
+                  삭제
+                </DangerButton>
+              </ButtonRow>
+            </FormGrid>
+          </DataState>
+        </SectionCard>
+      </TwoColumnGrid>
+    </>
+  );
+}

--- a/components/admin/posts/ToastEditorField.tsx
+++ b/components/admin/posts/ToastEditorField.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { uploadPostImage } from "@/api/file/file.api";
+
+type ToastEditorFieldProps = {
+  initialValue: string;
+  onChange: (value: string) => void;
+};
+
+type ToastEditorInstance = {
+  destroy: () => void;
+  getHTML: () => string;
+  setHTML: (html: string, cursorToEnd?: boolean) => void;
+};
+
+export default function ToastEditorField({ initialValue, onChange }: ToastEditorFieldProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<ToastEditorInstance | null>(null);
+  const onChangeRef = useRef(onChange);
+  const initialValueRef = useRef(initialValue);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function mountEditor() {
+      const { default: Editor } = await import("@toast-ui/editor");
+
+      if (!mounted || !rootRef.current || editorRef.current) {
+        return;
+      }
+
+      const editor = new Editor({
+        el: rootRef.current,
+        height: "22rem",
+
+        // 핵심: 일반 글쓰기 모드
+        initialEditType: "wysiwyg",
+
+        autofocus: false,
+
+        toolbarItems: [
+          ["heading", "bold", "italic", "strike"],
+          ["hr", "quote"],
+          ["ul", "ol"],
+          ["image", "link"],
+        ],
+
+        // HTML을 initialValue에 바로 넣지 않음
+        initialValue: "",
+
+        hooks: {
+          addImageBlobHook: async (
+            blob: Blob | File,
+            callback: (url: string, altText: string) => void,
+          ) => {
+            const filename = blob instanceof File ? blob.name : "post-image.png";
+            const uploaded = await uploadPostImage(blob, filename);
+
+            if (uploaded.url) {
+              callback(uploaded.url, filename);
+            }
+          },
+        },
+
+        events: {
+          change: () => {
+            const currentEditor = editorRef.current;
+
+            if (!currentEditor) {
+              return;
+            }
+
+            onChangeRef.current(currentEditor.getHTML());
+          },
+        },
+      }) as ToastEditorInstance;
+
+      editorRef.current = editor;
+
+      if (initialValueRef.current) {
+        editor.setHTML(initialValueRef.current, false);
+      }
+    }
+
+    mountEditor();
+
+    return () => {
+      mounted = false;
+      editorRef.current?.destroy();
+      editorRef.current = null;
+    };
+  }, []);
+
+  return <div ref={rootRef} />;
+}

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
+import type {
+  PurchaseRequestListItemDto,
+  PurchaseRequestResponseDto,
+  PurchaseRequestStatus,
+} from "@/api/request/request.dto";
+import type { PurchaseCreateState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  ControlRow,
+  DangerButton,
+  DataState,
+  FormGrid,
+  Label,
+  List,
+  ListItem,
+  MetaGrid,
+  MetaItem,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextArea,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState<TData> = {
+  data?: TData;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type AdminPurchasesSectionProps = {
+  classrooms: ClassroomListItemDto[];
+  purchases: PurchaseRequestListItemDto[];
+  selectedPurchaseId: number | null;
+  purchaseStatus: PurchaseRequestStatus | "";
+  purchaseCreate: PurchaseCreateState;
+  reviewNote: string;
+  approvedAmount: string;
+  purchasesQuery: QueryState<unknown>;
+  purchaseDetailQuery: QueryState<PurchaseRequestResponseDto>;
+  createPurchaseMutation: VoidMutationAction;
+  approvePurchaseMutation: VoidMutationAction;
+  rejectPurchaseMutation: VoidMutationAction;
+  confirmPurchaseMutation: VoidMutationAction;
+  deletePurchaseMutation: VoidMutationAction;
+  setPurchaseStatus: Dispatch<SetStateAction<PurchaseRequestStatus | "">>;
+  setPurchaseCreate: Dispatch<SetStateAction<PurchaseCreateState>>;
+  setSelectedPurchaseId: Dispatch<SetStateAction<number | null>>;
+  setReviewNote: Dispatch<SetStateAction<string>>;
+  setApprovedAmount: Dispatch<SetStateAction<string>>;
+};
+
+export function AdminPurchasesSection({
+  classrooms,
+  purchases,
+  selectedPurchaseId,
+  purchaseStatus,
+  purchaseCreate,
+  reviewNote,
+  approvedAmount,
+  purchasesQuery,
+  purchaseDetailQuery,
+  createPurchaseMutation,
+  approvePurchaseMutation,
+  rejectPurchaseMutation,
+  confirmPurchaseMutation,
+  deletePurchaseMutation,
+  setPurchaseStatus,
+  setPurchaseCreate,
+  setSelectedPurchaseId,
+  setReviewNote,
+  setApprovedAmount,
+}: AdminPurchasesSectionProps) {
+  return (
+    <>
+      <SectionCard>
+        <SectionTitle>구매 요청 작성</SectionTitle>
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            createPurchaseMutation.mutate();
+          }}
+        >
+          <Label>
+            제목
+            <TextInput
+              value={purchaseCreate.title}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({ ...current, title: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            내용
+            <TextArea
+              value={purchaseCreate.content}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({ ...current, content: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            분반
+            <Select
+              value={purchaseCreate.classroomId}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({ ...current, classroomId: event.target.value }))
+              }
+              required
+            >
+              <option value="">분반 선택</option>
+              {classrooms.map((classroom) => (
+                <option key={classroom.id} value={classroom.id}>
+                  {classroom.name}
+                </option>
+              ))}
+            </Select>
+          </Label>
+          <Label>
+            선금 요청 금액
+            <TextInput
+              value={purchaseCreate.advancePaymentRequestedAmount}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({
+                  ...current,
+                  advancePaymentRequestedAmount: event.target.value,
+                }))
+              }
+            />
+          </Label>
+          <Label>
+            품목명
+            <TextInput
+              value={purchaseCreate.itemName}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({ ...current, itemName: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            구매 사유
+            <TextInput
+              value={purchaseCreate.itemReason}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({ ...current, itemReason: event.target.value }))
+              }
+            />
+          </Label>
+          <Label>
+            예상 금액
+            <TextInput
+              value={purchaseCreate.itemExpectedPrice}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({
+                  ...current,
+                  itemExpectedPrice: event.target.value,
+                }))
+              }
+            />
+          </Label>
+          <PrimaryButton disabled={createPurchaseMutation.isPending || !purchaseCreate.classroomId}>
+            구매 요청 작성
+          </PrimaryButton>
+        </FormGrid>
+      </SectionCard>
+      <TwoColumnGrid>
+        <SectionCard>
+          <SectionTitle>구매 요청 목록</SectionTitle>
+          <ControlRow>
+            <Select
+              value={purchaseStatus}
+              onChange={(event) =>
+                setPurchaseStatus(event.target.value as PurchaseRequestStatus | "")
+              }
+            >
+              <option value="">전체</option>
+              <option value="PENDING">PENDING</option>
+              <option value="APPROVED">APPROVED</option>
+              <option value="PURCHASED">PURCHASED</option>
+              <option value="CONFIRMED">CONFIRMED</option>
+              <option value="REJECTED">REJECTED</option>
+            </Select>
+          </ControlRow>
+          <DataState
+            isLoading={purchasesQuery.isLoading}
+            isError={purchasesQuery.isError}
+            isEmpty={purchases.length === 0}
+            loadingLabel="구매 요청 목록 불러오는 중"
+            errorLabel="구매 요청 목록을 불러오지 못했습니다."
+            emptyLabel="구매 요청이 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>제목</th>
+                  <th>분반</th>
+                  <th>요청자</th>
+                  <th>상태</th>
+                  <th>금액</th>
+                </tr>
+              </thead>
+              <tbody>
+                {purchases.map((item) => (
+                  <tr key={item.id} onClick={() => item.id && setSelectedPurchaseId(item.id)}>
+                    <td>{item.title}</td>
+                    <td>{item.classroomName}</td>
+                    <td>{item.requestedByName}</td>
+                    <td>{item.status}</td>
+                    <td>{item.advancePaymentRequestedAmount ?? item.totalPrice ?? 0}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </SectionCard>
+        <SectionCard>
+          <SectionTitle>구매 요청 상세/처리</SectionTitle>
+          <SectionDescription>
+            선택한 구매 요청의 품목을 확인하고 승인, 반려, 결재 확인, 삭제 처리를 수행합니다.
+          </SectionDescription>
+          <DataState
+            isLoading={purchaseDetailQuery.isLoading}
+            isError={purchaseDetailQuery.isError}
+            isEmpty={!selectedPurchaseId}
+            loadingLabel="구매 요청 상세 불러오는 중"
+            errorLabel="구매 요청 상세를 불러오지 못했습니다."
+            emptyLabel="구매 요청을 선택하세요."
+          >
+            <MetaGrid>
+              <MetaItem>제목: {purchaseDetailQuery.data?.title}</MetaItem>
+              <MetaItem>상태: {purchaseDetailQuery.data?.status}</MetaItem>
+              <MetaItem>요청자: {purchaseDetailQuery.data?.requestedByName}</MetaItem>
+              <MetaItem>분반: {purchaseDetailQuery.data?.classroomName}</MetaItem>
+            </MetaGrid>
+            <List>
+              {purchaseDetailQuery.data?.items?.map((item) => (
+                <ListItem key={item.id}>
+                  <span>{item.name}</span>
+                  <span>{item.expectedPrice ?? item.actualPrice ?? 0}원</span>
+                </ListItem>
+              ))}
+            </List>
+            <FormGrid onSubmit={(event) => event.preventDefault()}>
+              <Label>
+                처리 사유
+                <TextInput
+                  value={reviewNote}
+                  onChange={(event) => setReviewNote(event.target.value)}
+                />
+              </Label>
+              <Label>
+                승인 선금
+                <TextInput
+                  value={approvedAmount}
+                  onChange={(event) => setApprovedAmount(event.target.value)}
+                />
+              </Label>
+              <ButtonRow>
+                <PrimaryButton
+                  type="button"
+                  disabled={approvePurchaseMutation.isPending}
+                  onClick={() => approvePurchaseMutation.mutate()}
+                >
+                  승인
+                </PrimaryButton>
+                <DangerButton
+                  type="button"
+                  disabled={rejectPurchaseMutation.isPending}
+                  onClick={() => rejectPurchaseMutation.mutate()}
+                >
+                  반려
+                </DangerButton>
+                <SmallButton
+                  type="button"
+                  disabled={confirmPurchaseMutation.isPending}
+                  onClick={() => confirmPurchaseMutation.mutate()}
+                >
+                  결재 확인
+                </SmallButton>
+                <DangerButton
+                  type="button"
+                  disabled={deletePurchaseMutation.isPending}
+                  onClick={() => deletePurchaseMutation.mutate()}
+                >
+                  삭제
+                </DangerButton>
+              </ButtonRow>
+            </FormGrid>
+          </DataState>
+        </SectionCard>
+      </TwoColumnGrid>
+    </>
+  );
+}

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  PermissionDefinitionDto,
+  PermissionResponseDto,
+  UserListItemDto,
+  UserResponseDto,
+} from "@/api/user/user.dto";
+import type { PermissionFormState, UserFormState } from "@/components/admin/AdminDashboardTypes";
+import {
+  ButtonRow,
+  ControlRow,
+  DangerButton,
+  DataState,
+  Divider,
+  FormGrid,
+  InlineStatus,
+  Label,
+  List,
+  ListItem,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionHeaderRow,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextInput,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+type QueryState<TData> = {
+  data?: TData;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type VoidMutationAction = {
+  isPending: boolean;
+  mutate: () => void;
+};
+
+type ValueMutationAction<TVariables> = {
+  isPending: boolean;
+  mutate: (variables: TVariables) => void;
+};
+
+type AdminUsersSectionProps = {
+  filteredUsers: UserListItemDto[];
+  selectedUserId: number | null;
+  userSearch: string;
+  userForm: UserFormState;
+  permissionForm: PermissionFormState;
+  permissionOptions: PermissionDefinitionDto[];
+  availableActions: string[];
+  canUseGlobalPermission: boolean;
+  canUseTargetPermission: boolean;
+  generatedPermissionCode: string;
+  usersQuery: QueryState<unknown>;
+  userDetailQuery: QueryState<UserResponseDto>;
+  userPermissionsQuery: QueryState<PermissionResponseDto[]>;
+  createUserMutation: VoidMutationAction;
+  updateUserMutation: VoidMutationAction;
+  deleteUserMutation: VoidMutationAction;
+  addPermissionMutation: VoidMutationAction;
+  removePermissionMutation: ValueMutationAction<string>;
+  setSelectedUserId: Dispatch<SetStateAction<number | null>>;
+  setUserSearch: Dispatch<SetStateAction<string>>;
+  setUserForm: Dispatch<SetStateAction<UserFormState>>;
+  setPermissionForm: Dispatch<SetStateAction<PermissionFormState>>;
+  selectUser: (item: UserListItemDto) => void;
+  emptyUserForm: UserFormState;
+};
+
+export function AdminUsersSection({
+  filteredUsers,
+  selectedUserId,
+  userSearch,
+  userForm,
+  permissionForm,
+  permissionOptions,
+  availableActions,
+  canUseGlobalPermission,
+  canUseTargetPermission,
+  generatedPermissionCode,
+  usersQuery,
+  userDetailQuery,
+  userPermissionsQuery,
+  createUserMutation,
+  updateUserMutation,
+  deleteUserMutation,
+  addPermissionMutation,
+  removePermissionMutation,
+  setSelectedUserId,
+  setUserSearch,
+  setUserForm,
+  setPermissionForm,
+  selectUser,
+  emptyUserForm,
+}: AdminUsersSectionProps) {
+  return (
+    <TwoColumnGrid>
+      <SectionCard>
+        <SectionHeaderRow>
+          <SectionTitle>사용자 목록</SectionTitle>
+          <SmallButton
+            type="button"
+            onClick={() => {
+              setSelectedUserId(null);
+              setUserForm(emptyUserForm);
+            }}
+          >
+            신규 생성
+          </SmallButton>
+        </SectionHeaderRow>
+        <ControlRow>
+          <TextInput
+            value={userSearch}
+            onChange={(event) => setUserSearch(event.target.value)}
+            placeholder="이름, 이메일, 역할 검색"
+          />
+        </ControlRow>
+        <DataState
+          isLoading={usersQuery.isLoading}
+          isError={usersQuery.isError}
+          isEmpty={filteredUsers.length === 0}
+          loadingLabel="사용자 목록 불러오는 중"
+          errorLabel="사용자 목록을 불러오지 못했습니다."
+          emptyLabel="사용자가 없습니다."
+        >
+          <Table>
+            <thead>
+              <tr>
+                <th>이름</th>
+                <th>이메일</th>
+                <th>역할</th>
+                <th>부서</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredUsers.map((item) => (
+                <tr key={item.id} onClick={() => selectUser(item)}>
+                  <td>{item.name ?? item.nickname ?? "-"}</td>
+                  <td>{item.email ?? "-"}</td>
+                  <td>{item.role ?? "-"}</td>
+                  <td>{item.departmentId ?? "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </DataState>
+      </SectionCard>
+      <SectionCard>
+        <SectionTitle>{selectedUserId ? "사용자 상세/수정" : "사용자 생성"}</SectionTitle>
+        {userDetailQuery.isLoading ? (
+          <InlineStatus>사용자 상세를 불러오는 중입니다.</InlineStatus>
+        ) : null}
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (selectedUserId) {
+              updateUserMutation.mutate();
+            } else {
+              createUserMutation.mutate();
+            }
+          }}
+        >
+          <Label>
+            이메일
+            <TextInput
+              value={userForm.email}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, email: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            닉네임
+            <TextInput
+              value={userForm.nickname}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, nickname: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            비밀번호
+            <TextInput
+              type="password"
+              value={userForm.password}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, password: event.target.value }))
+              }
+              placeholder={selectedUserId ? "수정 시 변경하지 않음" : ""}
+              required={!selectedUserId}
+            />
+          </Label>
+          <Label>
+            이름
+            <TextInput
+              value={userForm.name}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, name: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            전화번호
+            <TextInput
+              value={userForm.phoneNumber}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, phoneNumber: event.target.value }))
+              }
+            />
+          </Label>
+          <Label>
+            역할
+            <Select
+              value={userForm.role}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, role: event.target.value }))
+              }
+            >
+              <option value="ADMIN">ADMIN</option>
+              <option value="MANAGER">MANAGER</option>
+              <option value="VOLUNTEER">VOLUNTEER</option>
+              <option value="GUEST">GUEST</option>
+            </Select>
+          </Label>
+          <Label>
+            부서 ID
+            <TextInput
+              value={userForm.departmentId}
+              onChange={(event) =>
+                setUserForm((current) => ({ ...current, departmentId: event.target.value }))
+              }
+            />
+          </Label>
+          <ButtonRow>
+            <PrimaryButton disabled={createUserMutation.isPending || updateUserMutation.isPending}>
+              {selectedUserId ? "수정" : "생성"}
+            </PrimaryButton>
+            {selectedUserId ? (
+              <DangerButton
+                type="button"
+                disabled={deleteUserMutation.isPending}
+                onClick={() => deleteUserMutation.mutate()}
+              >
+                삭제
+              </DangerButton>
+            ) : null}
+          </ButtonRow>
+        </FormGrid>
+        <Divider />
+        <SectionTitle>직접 권한</SectionTitle>
+        <DataState
+          isLoading={userPermissionsQuery.isLoading}
+          isError={userPermissionsQuery.isError}
+          isEmpty={!selectedUserId || (userPermissionsQuery.data?.length ?? 0) === 0}
+          loadingLabel="권한 목록 불러오는 중"
+          errorLabel="권한 목록을 불러오지 못했습니다."
+          emptyLabel={selectedUserId ? "직접 부여된 권한이 없습니다." : "사용자를 선택하세요."}
+        >
+          <List>
+            {userPermissionsQuery.data?.map((permission) => {
+              const code = permission.permissionCode ?? permission.code ?? "";
+              return (
+                <ListItem key={code || permission.id}>
+                  <span>{code || permission.label || "-"}</span>
+                  {code ? (
+                    <SmallButton
+                      type="button"
+                      disabled={removePermissionMutation.isPending}
+                      onClick={() => removePermissionMutation.mutate(code)}
+                    >
+                      제거
+                    </SmallButton>
+                  ) : null}
+                </ListItem>
+              );
+            })}
+          </List>
+        </DataState>
+        <FormGrid
+          onSubmit={(event) => {
+            event.preventDefault();
+            addPermissionMutation.mutate();
+          }}
+        >
+          <Label>
+            리소스
+            <Select
+              value={permissionForm.resourceType}
+              onChange={(event) =>
+                setPermissionForm((current) => ({
+                  ...current,
+                  resourceType: event.target.value,
+                  actionType: "",
+                }))
+              }
+            >
+              {Array.from(
+                new Set(permissionOptions.map((option) => option.resourceCode).filter(Boolean)),
+              ).map((resource) => (
+                <option key={resource} value={resource}>
+                  {resource}
+                </option>
+              ))}
+            </Select>
+          </Label>
+          <Label>
+            액션
+            <Select
+              value={permissionForm.actionType}
+              onChange={(event) =>
+                setPermissionForm((current) => ({ ...current, actionType: event.target.value }))
+              }
+            >
+              {availableActions.map((action) => (
+                <option key={action} value={action}>
+                  {action}
+                </option>
+              ))}
+            </Select>
+          </Label>
+          <Label>
+            범위
+            <Select
+              value={permissionForm.scope}
+              onChange={(event) =>
+                setPermissionForm((current) => ({
+                  ...current,
+                  scope: event.target.value as PermissionFormState["scope"],
+                }))
+              }
+            >
+              <option value="GLOBAL" disabled={!canUseGlobalPermission}>
+                전체 권한
+              </option>
+              <option value="TARGET" disabled={!canUseTargetPermission}>
+                특정 대상 권한
+              </option>
+            </Select>
+          </Label>
+          <Label>
+            대상 ID
+            <TextInput
+              value={permissionForm.target}
+              disabled={permissionForm.scope === "GLOBAL"}
+              onChange={(event) =>
+                setPermissionForm((current) => ({ ...current, target: event.target.value }))
+              }
+            />
+          </Label>
+          <PrimaryButton
+            disabled={
+              !selectedUserId ||
+              addPermissionMutation.isPending ||
+              (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
+            }
+          >
+            권한 추가
+          </PrimaryButton>
+        </FormGrid>
+      </SectionCard>
+    </TwoColumnGrid>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import styled from "styled-components";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { headerMenus } from "@/mocks/home";
@@ -41,9 +41,14 @@ const HEADER_BACKDROP_TRANSITION_OPACITY = "0.5s ease";
 
 export default function Header() {
   const router = useRouter();
+  const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { status, signOut } = useAuthSession();
   const isAuthenticated = status === "authenticated";
+
+  if (pathname.startsWith("/admin")) {
+    return null;
+  }
 
   async function handleLogout() {
     await signOut();

--- a/components/staff/StaffSidebar.tsx
+++ b/components/staff/StaffSidebar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import styled from "styled-components";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { colors, layout, typography } from "@/styles/tokens";
 
 const staffSections = [
@@ -40,6 +41,13 @@ const staffSections = [
   },
 ];
 
+const adminSection = {
+  title: "관리자",
+  items: [{ label: "대시보드", href: "/admin/login" }],
+};
+
+type StaffSection = (typeof staffSections)[number];
+
 function isCurrentStaffPath(pathname: string, href: string) {
   if (href === "/staff/class") {
     return (
@@ -52,20 +60,20 @@ function isCurrentStaffPath(pathname: string, href: string) {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-function getCurrentSectionTitle(pathname: string) {
-  return staffSections.find((section) =>
+function getCurrentSectionTitle(pathname: string, sections: StaffSection[]) {
+  return sections.find((section) =>
     section.items.some((item) => isCurrentStaffPath(pathname, item.href)),
   )?.title;
 }
 
-function getOpenSectionsForTitle(title?: string) {
+function getOpenSectionsForTitle(sections: StaffSection[], title?: string) {
   return Object.fromEntries(
-    staffSections.map((section) => [section.title, Boolean(title && section.title === title)]),
+    sections.map((section) => [section.title, Boolean(title && section.title === title)]),
   );
 }
 
-function getOpenSectionsForPath(pathname: string) {
-  return getOpenSectionsForTitle(getCurrentSectionTitle(pathname));
+function getOpenSectionsForPath(pathname: string, sections: StaffSection[]) {
+  return getOpenSectionsForTitle(sections, getCurrentSectionTitle(pathname, sections));
 }
 
 type StaffSidebarProps = {
@@ -74,12 +82,17 @@ type StaffSidebarProps = {
 
 export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) {
   const pathname = usePathname();
+  const { status, user } = useAuthSession();
+  const visibleSections =
+    status === "authenticated" && user?.role === "ADMIN"
+      ? [...staffSections, adminSection]
+      : staffSections;
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(() =>
-    getOpenSectionsForPath(pathname),
+    getOpenSectionsForPath(pathname, staffSections),
   );
   const [overridePathname, setOverridePathname] = useState<string | null>(null);
   const isExpandedMode = mode === "expanded";
-  const routeOpenSections = getOpenSectionsForPath(pathname);
+  const routeOpenSections = getOpenSectionsForPath(pathname, visibleSections);
   const visibleOpenSections = overridePathname === pathname ? openSections : routeOpenSections;
 
   const isCurrent = (href: string) => {
@@ -100,7 +113,7 @@ export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) 
   };
 
   const keepOnlySectionOpen = (title: string) => {
-    const nextOpenSections = getOpenSectionsForTitle(title);
+    const nextOpenSections = getOpenSectionsForTitle(visibleSections, title);
 
     setOpenSections(nextOpenSections);
     setOverridePathname(pathname);
@@ -110,7 +123,7 @@ export default function StaffSidebar({ mode = "accordion" }: StaffSidebarProps) 
     <Sidebar>
       <SidebarHeader>교원</SidebarHeader>
       <SidebarContent>
-        {staffSections.map((section, sectionIndex) => {
+        {visibleSections.map((section, sectionIndex) => {
           const isOpen = isExpandedMode || (visibleOpenSections[section.title] ?? false);
           const sectionId = `staff-sidebar-section-${sectionIndex}`;
 

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -19,4 +19,24 @@ export const queryKeys = {
     purchaseList: () => ["purchase-requests"] as const,
     purchaseDetail: (requestId: number) => ["purchase-request", requestId] as const,
   },
+  admin: {
+    users: (page = 0, size = 20) => ["admin", "users", { page, size }] as const,
+    userDetail: (userId: number) => ["admin", "users", "detail", userId] as const,
+    userPermissions: (userId: number) => ["admin", "users", "permissions", userId] as const,
+    permissionRegistry: () => ["admin", "permission-registry"] as const,
+    channels: () => ["admin", "channels"] as const,
+    channelDetail: (channelId: number) => ["admin", "channels", "detail", channelId] as const,
+    posts: (page = 0, size = 20) => ["admin", "posts", { page, size }] as const,
+    postDetail: (channelId: number, postId: number) =>
+      ["admin", "posts", "detail", { channelId, postId }] as const,
+    departments: () => ["admin", "departments"] as const,
+    departmentDetail: (departmentId: number) =>
+      ["admin", "departments", "detail", departmentId] as const,
+    classrooms: () => ["admin", "classrooms"] as const,
+    classroomDetail: (classroomId: number) =>
+      ["admin", "classrooms", "detail", classroomId] as const,
+    purchaseRequests: (status?: string) => ["admin", "purchase-requests", { status }] as const,
+    purchaseRequestDetail: (requestId: number) =>
+      ["admin", "purchase-requests", "detail", requestId] as const,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@tabler/icons-react": "^3.41.1",
         "@tanstack/react-query": "^5.100.5",
+        "@toast-ui/editor": "^3.2.2",
         "axios": "^1.15.0",
         "dayjs": "^1.11.20",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.75.0",
+        "react-toastify": "^11.1.0",
         "styled-components": "^6.3.12"
       },
       "devDependencies": {
@@ -2249,6 +2251,22 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@toast-ui/editor": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.2.2.tgz",
+      "integrity": "sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^2.3.3",
+        "prosemirror-commands": "^1.1.9",
+        "prosemirror-history": "^1.1.3",
+        "prosemirror-inputrules": "^1.1.3",
+        "prosemirror-keymap": "^1.1.4",
+        "prosemirror-model": "^1.14.1",
+        "prosemirror-state": "^1.3.4",
+        "prosemirror-view": "^1.18.7"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3643,6 +3661,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3938,6 +3965,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6755,6 +6788,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -6981,6 +7020,89 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.6.tgz",
+      "integrity": "sha512-RIm+e9BiqAaJ1mRECv3vR3C+VG8ELoTTI+47tVudGi82yLnFOx3G/p/iSPK1HmHQdKhkkrJ68NJqxh7S+FBVmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -7064,6 +7186,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.1.0.tgz",
+      "integrity": "sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7221,6 +7356,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -8590,6 +8731,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   "dependencies": {
     "@tabler/icons-react": "^3.41.1",
     "@tanstack/react-query": "^5.100.5",
+    "@toast-ui/editor": "^3.2.2",
     "axios": "^1.15.0",
     "dayjs": "^1.11.20",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.75.0",
+    "react-toastify": "^11.1.0",
     "styled-components": "^6.3.12"
   },
   "devDependencies": {

--- a/styles/tokens.ts
+++ b/styles/tokens.ts
@@ -53,6 +53,8 @@ export const layout = {
   maxWidth: "86rem", // 1376px
   homeMaxWidth: "76.75rem", // 1228px
   homeMaxWidthLarge: "115rem", // 1840px
+  adminMaxWidth: "76rem", // 1088px
+  adminMaxWidthLarge: "105rem", // 1680px
   headerHeight: "5rem", // 80px
   breakpointDesktop: "75rem", // 1200px
   breakpointTablet: "62rem", // 992px

--- a/types/toast-ui-editor.d.ts
+++ b/types/toast-ui-editor.d.ts
@@ -1,0 +1,28 @@
+declare module "@toast-ui/editor" {
+  type ImageBlobHook = (
+    blob: Blob | File,
+    callback: (url: string, altText: string) => void,
+  ) => void | Promise<void>;
+
+  type EditorOptions = {
+    el: HTMLElement;
+    height?: string;
+    initialEditType?: "markdown" | "wysiwyg";
+    previewStyle?: "tab" | "vertical";
+    autofocus?: boolean;
+    toolbarItems?: string[][];
+    initialValue?: string;
+    hooks?: {
+      addImageBlobHook?: ImageBlobHook;
+    };
+    events?: {
+      change?: () => void;
+    };
+  };
+
+  export default class Editor {
+    constructor(options: EditorOptions);
+    destroy(): void;
+    getHTML(): string;
+  }
+}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 관리자 콘솔 대시보드 구축
   관리자 권한(ADMIN) 사용자만 접근 가능한 콘솔 화면을 구성했습니다.
   관리자 계정으로 로그인 시, 교원 페이지 사이드바에 관리자 페이지 접근 메뉴가 표시됩니다.
   
   접근 경로: 교원 > 사이드바 메뉴 > 관리자 > 대시보드 > 관리자 페이지 로그인 > 관리자 페이지

   <img width="230" height="447" alt="스크린샷 2026-05-18 130628" src="https://github.com/user-attachments/assets/0699db31-2c08-43fb-a602-03e3502e0b5c" />

2. 사이드바 메뉴 기반 화면 전환
   사용자, 부서, 분반, 구매 요청 현황을 요약 카드로 표시하고, 사이드바 메뉴를 통해 관리 화면을 전환할 수 있도록 구성했습니다.

   <img width="1918" height="862" alt="스크린샷 2026-05-18 130817" src="https://github.com/user-attachments/assets/930de11f-781f-4d81-af72-bf9be0e00407" />


4. 사용자 및 권한 관리 기능 추가
   사용자 목록 조회, 검색, 상세 조회, 생성, 수정, 삭제 기능을 추가했습니다.
   사용자별 권한 조회, 권한 부여, 권한 제거 기능을 함께 구성했습니다.

   <img width="1900" height="862" alt="스크린샷 2026-05-18 130831" src="https://github.com/user-attachments/assets/6fb11c43-baf9-45cf-88a9-ddad3d365a62" />

5. 부서 및 분반 관리 기능 추가
   부서 목록/상세 조회, 생성, 수정, 삭제 기능을 추가했습니다.
   분반 목록/상세 조회, 이름 검색, 생성, 수정, 삭제 기능을 추가했습니다.

   [부서 관리]

   <img width="1898" height="862" alt="스크린샷 2026-05-18 130844" src="https://github.com/user-attachments/assets/2d4932ec-a46e-4522-8de8-f73adf8b8e0c" />

   [반 관리]

   <img width="1918" height="862" alt="스크린샷 2026-05-18 130854" src="https://github.com/user-attachments/assets/334a16ed-6359-4926-b7e9-15d3f1e4f633" />

6. 채널 관리 기능 추가
   채널 목록 조회, 검색, 상세 조회, 생성, 수정, 삭제 기능을 추가했습니다.
   채널 공개/활성 상태와 접근 수준을 관리자 화면에서 관리할 수 있도록 했습니다.

   <img width="1900" height="862" alt="스크린샷 2026-05-18 130916" src="https://github.com/user-attachments/assets/1c2d3edf-19a7-451b-984a-ef83cde1c0f3" />

7. 게시글 관리 기능 추가
   게시글 목록 조회, 제목 검색, 상세 조회, 생성, 수정, 삭제, 고정 처리 기능을 추가했습니다.
   Toast UI Editor 기반 게시글 작성/수정 필드를 추가하고, 공지/반별/부서별 게시글 작성 흐름을 구성했습니다.

   <img width="1898" height="862" alt="스크린샷 2026-05-18 130936" src="https://github.com/user-attachments/assets/e2ba3a0a-a39f-47a7-b586-257be8d60e9c" />

   <img width="1898" height="862" alt="스크린샷 2026-05-18 133052" src="https://github.com/user-attachments/assets/fa862dcb-340b-4f96-8f3a-9f01aad2122e" />

8. 구매 요청 관리 기능 추가
   구매 요청 목록/상세 조회, 상태 필터링, 생성, 승인, 반려, 결재 확인, 삭제 기능을 추가했습니다.
   승인 금액과 검토 의견 입력 흐름을 관리자 화면에 반영했습니다.

   <img width="1898" height="862" alt="스크린샷 2026-05-18 130952" src="https://github.com/user-attachments/assets/156ff268-964f-4452-88b2-c5b1bd26f4cb" />

   <img width="1900" height="862" alt="스크린샷 2026-05-18 133323" src="https://github.com/user-attachments/assets/5e9b7a17-0809-48ef-9c61-c9fbe2a200b6" />

## 📄 의존성 추가/변경 사항

1. @toast-ui/editor@^3.2.2 추가
2. react-toastify@^11.1.0 추가

## 🔍 관련 이슈

Closes #61 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
