### PR TITLE
[FEAT] 교원 - 인수인계서/시험 문제 자료/서류 양식 섹션 API 연동

### DIFF
--- a/app/staff/archive/document-forms/[postId]/page.tsx
+++ b/app/staff/archive/document-forms/[postId]/page.tsx
@@ -1,32 +1,33 @@
 import { notFound } from "next/navigation";
 import ArchiveDocumentDetailPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage";
-import {
-  archiveDocumentConfigs,
-  getArchiveDocumentById,
-  getArchiveDocuments,
-} from "@/mocks/archiveDocuments";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   params: Promise<{
     postId: string;
   }>;
+  searchParams?: Promise<{
+    channelId?: string;
+  }>;
 };
 
-const config = archiveDocumentConfigs.forms;
-
-export function generateStaticParams() {
-  return getArchiveDocuments("forms").map((document) => ({
-    postId: String(document.id),
-  }));
-}
-
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   const { postId } = await params;
-  const document = getArchiveDocumentById("forms", Number(postId));
+  const resolvedSearchParams = await searchParams;
+  const parsedPostId = Number(postId);
+  const parsedChannelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
 
-  if (!document) {
+  if (!Number.isInteger(parsedPostId) || parsedPostId < 1) {
     notFound();
   }
 
-  return <ArchiveDocumentDetailPage config={config} document={document} />;
+  return (
+    <ArchiveDocumentDetailPage
+      config={archiveDocumentConfigs.forms}
+      postId={parsedPostId}
+      channelId={Number.isInteger(parsedChannelId) ? parsedChannelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/document-forms/new/page.tsx
+++ b/app/staff/archive/document-forms/new/page.tsx
@@ -1,6 +1,25 @@
 import ArchiveDocumentFormPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentFormPage";
 import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
-export default function Page() {
-  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.forms} />;
+type PageProps = {
+  searchParams?: Promise<{
+    channelId?: string;
+    postId?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const postId = resolvedSearchParams?.postId ? Number(resolvedSearchParams.postId) : undefined;
+  const channelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
+
+  return (
+    <ArchiveDocumentFormPage
+      config={archiveDocumentConfigs.forms}
+      editPostId={Number.isInteger(postId) ? postId : undefined}
+      editChannelId={Number.isInteger(channelId) ? channelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/document-forms/page.tsx
+++ b/app/staff/archive/document-forms/page.tsx
@@ -1,11 +1,9 @@
 import { redirect } from "next/navigation";
 import ArchiveDocumentListPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
-import { ARCHIVE_DOCUMENTS_PER_PAGE, archiveDocumentConfigs } from "@/mocks/archiveDocuments";
-import { getChannelPosts } from "@/api/post/post.api";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   searchParams?: Promise<{
-    mineOnly?: string;
     page?: string;
   }>;
 };
@@ -20,39 +18,5 @@ export default async function Page({ searchParams }: PageProps) {
     redirect(config.listPath);
   }
 
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
-
-  const response = await getChannelPosts(
-    {
-      channelId: config.channelId,
-    },
-    {
-      page: parsedPage - 1,
-      size: ARCHIVE_DOCUMENTS_PER_PAGE,
-    },
-  );
-
-  const documents =
-    response.content?.map((post) => ({
-      id: post.id ?? 0,
-      title: post.title ?? "",
-      author: post.authorName ?? "",
-      date: post.createdAt?.slice(0, 10) ?? "",
-    })) ?? [];
-
-  const totalPages = response.totalPages ?? 1;
-
-  if (parsedPage > totalPages) {
-    redirect(config.listPath);
-  }
-
-  return (
-    <ArchiveDocumentListPage
-      config={config}
-      currentPage={parsedPage}
-      documents={documents}
-      mineOnly={mineOnly}
-      totalPages={totalPages}
-    />
-  );
+  return <ArchiveDocumentListPage config={config} initialPage={parsedPage} />;
 }

--- a/app/staff/archive/exam-materials/[postId]/page.tsx
+++ b/app/staff/archive/exam-materials/[postId]/page.tsx
@@ -1,32 +1,33 @@
 import { notFound } from "next/navigation";
 import ArchiveDocumentDetailPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage";
-import {
-  archiveDocumentConfigs,
-  getArchiveDocumentById,
-  getArchiveDocuments,
-} from "@/mocks/archiveDocuments";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   params: Promise<{
     postId: string;
   }>;
+  searchParams?: Promise<{
+    channelId?: string;
+  }>;
 };
 
-const config = archiveDocumentConfigs.exam;
-
-export function generateStaticParams() {
-  return getArchiveDocuments("exam").map((document) => ({
-    postId: String(document.id),
-  }));
-}
-
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   const { postId } = await params;
-  const document = getArchiveDocumentById("exam", Number(postId));
+  const resolvedSearchParams = await searchParams;
+  const parsedPostId = Number(postId);
+  const parsedChannelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
 
-  if (!document) {
+  if (!Number.isInteger(parsedPostId) || parsedPostId < 1) {
     notFound();
   }
 
-  return <ArchiveDocumentDetailPage config={config} document={document} />;
+  return (
+    <ArchiveDocumentDetailPage
+      config={archiveDocumentConfigs.exam}
+      postId={parsedPostId}
+      channelId={Number.isInteger(parsedChannelId) ? parsedChannelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/exam-materials/new/page.tsx
+++ b/app/staff/archive/exam-materials/new/page.tsx
@@ -1,6 +1,25 @@
 import ArchiveDocumentFormPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentFormPage";
 import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
-export default function Page() {
-  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.exam} />;
+type PageProps = {
+  searchParams?: Promise<{
+    channelId?: string;
+    postId?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const postId = resolvedSearchParams?.postId ? Number(resolvedSearchParams.postId) : undefined;
+  const channelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
+
+  return (
+    <ArchiveDocumentFormPage
+      config={archiveDocumentConfigs.exam}
+      editPostId={Number.isInteger(postId) ? postId : undefined}
+      editChannelId={Number.isInteger(channelId) ? channelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/exam-materials/page.tsx
+++ b/app/staff/archive/exam-materials/page.tsx
@@ -1,14 +1,9 @@
 import { redirect } from "next/navigation";
 import ArchiveDocumentListPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
-import {
-  ARCHIVE_DOCUMENTS_PER_PAGE,
-  archiveDocumentConfigs,
-  getArchiveDocuments,
-} from "@/mocks/archiveDocuments";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   searchParams?: Promise<{
-    mineOnly?: string;
     page?: string;
   }>;
 };
@@ -18,26 +13,10 @@ const config = archiveDocumentConfigs.exam;
 export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const parsedPage = resolvedSearchParams?.page ? Number(resolvedSearchParams.page) : 1;
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
-  const filteredDocuments = mineOnly
-    ? getArchiveDocuments("exam").filter((document) => document.author === "홍길동")
-    : getArchiveDocuments("exam");
-  const totalPages = Math.max(1, Math.ceil(filteredDocuments.length / ARCHIVE_DOCUMENTS_PER_PAGE));
 
-  if (!Number.isInteger(parsedPage) || parsedPage < 1 || parsedPage > totalPages) {
+  if (!Number.isInteger(parsedPage) || parsedPage < 1) {
     redirect(config.listPath);
   }
 
-  const startIndex = (parsedPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE;
-  const documents = filteredDocuments.slice(startIndex, startIndex + ARCHIVE_DOCUMENTS_PER_PAGE);
-
-  return (
-    <ArchiveDocumentListPage
-      config={config}
-      currentPage={parsedPage}
-      documents={documents}
-      mineOnly={mineOnly}
-      totalPages={totalPages}
-    />
-  );
+  return <ArchiveDocumentListPage config={config} initialPage={parsedPage} />;
 }

--- a/app/staff/archive/handover-documents/[postId]/page.tsx
+++ b/app/staff/archive/handover-documents/[postId]/page.tsx
@@ -1,32 +1,33 @@
 import { notFound } from "next/navigation";
 import ArchiveDocumentDetailPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage";
-import {
-  archiveDocumentConfigs,
-  getArchiveDocumentById,
-  getArchiveDocuments,
-} from "@/mocks/archiveDocuments";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   params: Promise<{
     postId: string;
   }>;
+  searchParams?: Promise<{
+    channelId?: string;
+  }>;
 };
 
-const config = archiveDocumentConfigs.handover;
-
-export function generateStaticParams() {
-  return getArchiveDocuments("handover").map((document) => ({
-    postId: String(document.id),
-  }));
-}
-
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   const { postId } = await params;
-  const document = getArchiveDocumentById("handover", Number(postId));
+  const resolvedSearchParams = await searchParams;
+  const parsedPostId = Number(postId);
+  const parsedChannelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
 
-  if (!document) {
+  if (!Number.isInteger(parsedPostId) || parsedPostId < 1) {
     notFound();
   }
 
-  return <ArchiveDocumentDetailPage config={config} document={document} />;
+  return (
+    <ArchiveDocumentDetailPage
+      config={archiveDocumentConfigs.handover}
+      postId={parsedPostId}
+      channelId={Number.isInteger(parsedChannelId) ? parsedChannelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/handover-documents/new/page.tsx
+++ b/app/staff/archive/handover-documents/new/page.tsx
@@ -1,6 +1,25 @@
 import ArchiveDocumentFormPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentFormPage";
 import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
-export default function Page() {
-  return <ArchiveDocumentFormPage config={archiveDocumentConfigs.handover} />;
+type PageProps = {
+  searchParams?: Promise<{
+    channelId?: string;
+    postId?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const postId = resolvedSearchParams?.postId ? Number(resolvedSearchParams.postId) : undefined;
+  const channelId = resolvedSearchParams?.channelId
+    ? Number(resolvedSearchParams.channelId)
+    : undefined;
+
+  return (
+    <ArchiveDocumentFormPage
+      config={archiveDocumentConfigs.handover}
+      editPostId={Number.isInteger(postId) ? postId : undefined}
+      editChannelId={Number.isInteger(channelId) ? channelId : undefined}
+    />
+  );
 }

--- a/app/staff/archive/handover-documents/page.tsx
+++ b/app/staff/archive/handover-documents/page.tsx
@@ -1,11 +1,9 @@
 import { redirect } from "next/navigation";
 import ArchiveDocumentListPage from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
-import { getChannelPosts } from "@/api/post/post.api";
-import { ARCHIVE_DOCUMENTS_PER_PAGE, archiveDocumentConfigs } from "@/mocks/archiveDocuments";
+import { archiveDocumentConfigs } from "@/mocks/archiveDocuments";
 
 type PageProps = {
   searchParams?: Promise<{
-    mineOnly?: string;
     page?: string;
   }>;
 };
@@ -15,49 +13,10 @@ const config = archiveDocumentConfigs.handover;
 export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const parsedPage = resolvedSearchParams?.page ? Number(resolvedSearchParams.page) : 1;
+
   if (!Number.isInteger(parsedPage) || parsedPage < 1) {
     redirect(config.listPath);
   }
 
-  const mineOnly = resolvedSearchParams?.mineOnly === "1";
-  let response: Awaited<ReturnType<typeof getChannelPosts>> | undefined;
-
-  try {
-    response = await getChannelPosts(
-      {
-        channelId: config.channelId,
-      },
-      {
-        page: parsedPage - 1,
-        size: ARCHIVE_DOCUMENTS_PER_PAGE,
-      },
-    );
-  } catch (error) {
-    console.error("게시글 조회 실패:", error);
-    response = undefined;
-  }
-
-  const documents =
-    response?.content?.map((post) => ({
-      id: post.id ?? 0,
-      title: post.title ?? "",
-      author: post.authorName ?? "",
-      date: post.createdAt?.slice(0, 10) ?? "",
-    })) ?? [];
-
-  const totalPages = Math.max(1, response?.totalPages ?? 1);
-
-  if (parsedPage > totalPages) {
-    redirect(config.listPath);
-  }
-
-  return (
-    <ArchiveDocumentListPage
-      config={config}
-      currentPage={parsedPage}
-      documents={documents}
-      mineOnly={mineOnly}
-      totalPages={totalPages}
-    />
-  );
+  return <ArchiveDocumentListPage config={config} initialPage={parsedPage} />;
 }

--- a/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
@@ -1,32 +1,102 @@
+"use client";
+
 import { IconDownload } from "@tabler/icons-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { getChannels } from "@/api/channel/channel.api";
+import { deletePost, getPost } from "@/api/post/post.api";
+import ToastViewerField from "@/components/admin/posts/ToastViewerField";
+import { resolveArchiveChannel } from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
 import {
   ActionButton,
   ActionLink,
   ContentStack,
-  DateBar,
   DocumentSection,
-  FieldBox,
-  Label,
-  TextBox,
-  Toolbar,
-  ToolbarRight,
-} from "@/components/staff/archive/meeting-records/MeetingRecordDocument.styles";
-import {
   DownloadBadge,
+  FieldBox,
   FileLink,
   FileList,
-} from "@/components/staff/archive/archive-document-section/ArchiveDocumentPages.styles";
-import type { ArchiveDocument, ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+  Label,
+  MetaBar,
+  StateMessage,
+  Toolbar,
+  ToolbarRight,
+  ViewerBox,
+} from "@/components/staff/board/BoardDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import type { ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type ArchiveDocumentDetailPageProps = {
   config: ArchiveDocumentConfig;
-  document: ArchiveDocument;
+  postId: number;
+  channelId?: number;
 };
 
 export default function ArchiveDocumentDetailPage({
   config,
-  document,
+  postId,
+  channelId: initialChannelId,
 }: ArchiveDocumentDetailPageProps) {
+  const router = useRouter();
+  const { user } = useAuthSession();
+
+  const channelsQuery = useQuery({
+    queryKey: ["staff", "archive", "channels"],
+    queryFn: () => getChannels({ channelType: "CUSTOM", isActive: true }),
+    enabled: typeof initialChannelId !== "number",
+    retry: false,
+  });
+
+  const channel = resolveArchiveChannel(channelsQuery.data, config);
+  const channelId = initialChannelId ?? channel?.id ?? config.channelId;
+  const hasChannelId = typeof channelId === "number" && Number.isFinite(channelId);
+
+  const postQuery = useQuery({
+    queryKey: queryKeys.posts.boardDetail(channelId ?? 0, postId),
+    queryFn: () => getPost({ channelId: channelId ?? 0, postId }),
+    enabled: hasChannelId,
+    retry: false,
+  });
+
+  const visiblePost = postQuery.data;
+  const date = formatUtcToKstShortDate(visiblePost?.createdAt ?? visiblePost?.updatedAt);
+  const title = visiblePost?.title ?? "제목";
+  const author = visiblePost?.authorName ?? "홍길동";
+  const content = visiblePost?.contentHtml?.trim() || "설명";
+  const attachments = visiblePost?.attachments ?? [];
+  const editHref =
+    hasChannelId && visiblePost?.id
+      ? `${config.listPath}/new?postId=${visiblePost.id}&channelId=${channelId}`
+      : `${config.listPath}/new`;
+  const canManagePost =
+    user?.role === "ADMIN" ||
+    (typeof user?.id === "number" && visiblePost?.authorId === user.id) ||
+    Boolean(
+      visiblePost?.authorName &&
+        (visiblePost.authorName === user?.name ||
+          visiblePost.authorName === user?.nickname ||
+          visiblePost.authorName === user?.email),
+    );
+
+  const deletePostMutation = useMutation({
+    mutationFn: () => deletePost({ channelId: channelId ?? 0, postId }),
+    onSuccess: () => {
+      router.push(config.listPath);
+    },
+  });
+
+  const stateMessage = !hasChannelId
+    ? `${config.title} 채널 정보를 찾지 못했습니다.`
+    : postQuery.isLoading
+      ? `${config.title}를 불러오는 중입니다.`
+      : postQuery.isError && !visiblePost
+        ? `${config.title}를 불러오지 못했습니다.`
+        : deletePostMutation.isError
+          ? `${config.title} 삭제에 실패했습니다.`
+          : "";
+
   return (
     <DocumentSection>
       <Toolbar>
@@ -34,36 +104,61 @@ export default function ArchiveDocumentDetailPage({
           목록
         </ActionLink>
 
-        <ToolbarRight>
-          <ActionButton type="button" $variant="danger">
-            삭제
-          </ActionButton>
-          <ActionButton type="button">수정</ActionButton>
-        </ToolbarRight>
+        {canManagePost ? (
+          <ToolbarRight>
+            <ActionButton
+              type="button"
+              $variant="danger"
+              disabled={!hasChannelId || deletePostMutation.isPending}
+              onClick={() => deletePostMutation.mutate()}
+            >
+              삭제
+            </ActionButton>
+            <ActionLink href={editHref}>수정</ActionLink>
+          </ToolbarRight>
+        ) : null}
       </Toolbar>
 
+      {stateMessage ? <StateMessage>{stateMessage}</StateMessage> : null}
+
       <ContentStack>
-        <DateBar>{document.date}</DateBar>
+        <MetaBar>
+          <span />
+          <span>{date}</span>
+        </MetaBar>
 
         <Label>제목</Label>
-        <FieldBox>{document.title}</FieldBox>
+        <FieldBox>{title}</FieldBox>
 
         <Label>작성자</Label>
-        <FieldBox>{document.author}</FieldBox>
+        <FieldBox>{author}</FieldBox>
 
         <Label>설명</Label>
-        <TextBox>{document.description}</TextBox>
+        <ViewerBox>
+          <ToastViewerField value={content} />
+        </ViewerBox>
 
         <Label>자료</Label>
         <FileList>
-          {document.files.map((file) => (
-            <FileLink key={file} href="#" aria-label={`${file} 다운로드`}>
-              <span>{file}</span>
-              <DownloadBadge aria-hidden="true">
-                <IconDownload size={16} stroke={2.25} />
-              </DownloadBadge>
+          {attachments.length > 0 ? (
+            attachments.map((file, index) => {
+              const fileName = file.originalName ?? file.fileId ?? `자료 ${index + 1}`;
+              const fileUrl = file.downloadUrl ?? file.url ?? "#";
+
+              return (
+                <FileLink key={`${file.fileId ?? fileName}-${index}`} href={fileUrl}>
+                  <span>{fileName}</span>
+                  <DownloadBadge aria-hidden="true">
+                    <IconDownload size={16} stroke={2.25} />
+                  </DownloadBadge>
+                </FileLink>
+              );
+            })
+          ) : (
+            <FileLink href="#" aria-disabled="true">
+              <span>첨부된 자료가 없습니다.</span>
             </FileLink>
-          ))}
+          )}
         </FileList>
       </ContentStack>
     </DocumentSection>

--- a/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
@@ -2,13 +2,14 @@
 
 import { IconDownload } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import styled, { css } from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
 import { deletePost, getPost } from "@/api/post/post.api";
 import ToastViewerField from "@/components/admin/posts/ToastViewerField";
 import { resolveArchiveChannel } from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
 import {
-  ActionButton,
   ActionLink,
   ContentStack,
   DocumentSection,
@@ -26,6 +27,7 @@ import {
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import type { ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+import { colors, radii, spacing, typography } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type ArchiveDocumentDetailPageProps = {
@@ -106,15 +108,17 @@ export default function ArchiveDocumentDetailPage({
 
         {canManagePost ? (
           <ToolbarRight>
-            <ActionButton
+            <ArchiveActionButton
               type="button"
-              $variant="danger"
+              $tone="danger"
               disabled={!hasChannelId || deletePostMutation.isPending}
               onClick={() => deletePostMutation.mutate()}
             >
               삭제
-            </ActionButton>
-            <ActionLink href={editHref}>수정</ActionLink>
+            </ArchiveActionButton>
+            <ArchiveActionLink href={editHref} $tone="edit">
+              수정
+            </ArchiveActionLink>
           </ToolbarRight>
         ) : null}
       </Toolbar>
@@ -164,3 +168,46 @@ export default function ArchiveDocumentDetailPage({
     </DocumentSection>
   );
 }
+
+const archiveActionStyle = css<{ $tone: "danger" | "edit" }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.9375rem;
+  min-height: 2.6875rem;
+  border: 1px solid ${({ $tone }) => ($tone === "danger" ? colors.notice : colors.point)};
+  border-radius: ${radii.radius15};
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${({ $tone }) => ($tone === "danger" ? colors.notice : colors.point)};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ $tone }) => ($tone === "danger" ? colors.noticeSoft : colors.pointSoft)};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-width: 5.9375rem;
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ArchiveActionButton = styled.button<{ $tone: "danger" | "edit" }>`
+  ${archiveActionStyle}
+`;
+
+const ArchiveActionLink = styled(Link)<{ $tone: "danger" | "edit" }>`
+  ${archiveActionStyle}
+`;

--- a/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
@@ -1,62 +1,231 @@
+"use client";
+
+import { useState } from "react";
 import { IconPaperclip } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { getChannels } from "@/api/channel/channel.api";
+import {
+  attachPostAttachment,
+  createPost,
+  getPost,
+  updatePost,
+} from "@/api/post/post.api";
+import { resolveArchiveChannel } from "@/components/staff/archive/archive-document-section/ArchiveDocumentListPage";
 import {
   ActionButton,
   DocumentSection,
+  FileSelectLabel,
+  FileUploadPanel,
   Form,
+  HiddenFileInput,
   Input,
   Label,
   PageTitle,
+  StateMessage,
   Textarea,
   Toolbar,
-} from "@/components/staff/archive/meeting-records/MeetingRecordDocument.styles";
-import {
-  FileLink,
-  FileSelectLabel,
-  FileUploadPanel,
-  HiddenFileInput,
-} from "@/components/staff/archive/archive-document-section/ArchiveDocumentPages.styles";
+} from "@/components/staff/board/BoardDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import type { ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
 
 type ArchiveDocumentFormPageProps = {
   config: ArchiveDocumentConfig;
+  editPostId?: number;
+  editChannelId?: number;
 };
 
-export default function ArchiveDocumentFormPage({ config }: ArchiveDocumentFormPageProps) {
+export default function ArchiveDocumentFormPage({
+  config,
+  editPostId,
+  editChannelId,
+}: ArchiveDocumentFormPageProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useAuthSession();
+  const isEditMode = typeof editPostId === "number" && typeof editChannelId === "number";
+  const [title, setTitle] = useState<string | undefined>(undefined);
+  const [description, setDescription] = useState<string | undefined>(undefined);
+  const [files, setFiles] = useState<File[]>([]);
+
+  const channelsQuery = useQuery({
+    queryKey: ["staff", "archive", "channels"],
+    queryFn: () => getChannels({ channelType: "CUSTOM", isActive: true }),
+    enabled: !isEditMode,
+    retry: false,
+  });
+
+  const channel = resolveArchiveChannel(channelsQuery.data, config);
+  const channelId = isEditMode ? editChannelId : (channel?.id ?? config.channelId);
+
+  const postDetailQuery = useQuery({
+    queryKey: queryKeys.posts.boardDetail(editChannelId ?? 0, editPostId ?? 0),
+    queryFn: () => getPost({ channelId: editChannelId ?? 0, postId: editPostId ?? 0 }),
+    enabled: isEditMode,
+    retry: false,
+  });
+
+  const currentUserName = user?.name ?? user?.nickname ?? user?.email ?? "";
+  const visibleTitle = title ?? postDetailQuery.data?.title ?? "";
+  const visibleAuthor = postDetailQuery.data?.authorName ?? currentUserName;
+  const visibleDescription = description ?? postDetailQuery.data?.contentHtml ?? "";
+  const existingAttachments = postDetailQuery.data?.attachments ?? [];
+  const canManagePost =
+    !isEditMode ||
+    user?.role === "ADMIN" ||
+    (typeof user?.id === "number" && postDetailQuery.data?.authorId === user.id) ||
+    Boolean(
+      postDetailQuery.data?.authorName &&
+        (postDetailQuery.data.authorName === user?.name ||
+          postDetailQuery.data.authorName === user?.nickname ||
+          postDetailQuery.data.authorName === user?.email),
+    );
+
+  const { mutate, isPending, isError } = useMutation({
+    mutationFn: async () => {
+      if (!channelId) {
+        throw new Error(`${config.title} 채널을 찾을 수 없습니다.`);
+      }
+
+      const post = isEditMode
+        ? await updatePost(
+            { channelId, postId: editPostId },
+            {
+              title: visibleTitle.trim(),
+              contentHtml: visibleDescription.trim(),
+              status: "PUBLISHED",
+              allowComment: false,
+            },
+          )
+        : await createPost(
+            { channelId },
+            {
+              title: visibleTitle.trim(),
+              contentHtml: visibleDescription.trim(),
+              status: "PUBLISHED",
+              allowComment: false,
+            },
+          );
+
+      if (typeof post.id === "number") {
+        await Promise.all(
+          files.map((file) =>
+            attachPostAttachment({ channelId, postId: post.id as number }, file, file.name),
+          ),
+        );
+      }
+
+      return post;
+    },
+    onSuccess: async (post) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["posts"] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) }),
+        typeof post.channelId === "number" && typeof post.id === "number"
+          ? queryClient.invalidateQueries({
+              queryKey: queryKeys.posts.boardDetail(post.channelId, post.id),
+            })
+          : Promise.resolve(),
+      ]);
+
+      router.push(config.listPath);
+    },
+  });
+
+  const canSubmit =
+    visibleTitle.trim().length > 0 &&
+    visibleDescription.trim().length > 0 &&
+    Boolean(channelId) &&
+    canManagePost &&
+    !isPending;
+
   return (
     <DocumentSection>
       <Toolbar>
-        <PageTitle>{config.writeTitle}</PageTitle>
-        <ActionButton type="submit" form={`${config.category}-form`}>
-          작성 완료
+        <PageTitle>{isEditMode ? `${config.title} 수정하기` : config.writeTitle}</PageTitle>
+        <ActionButton type="submit" form={`${config.category}-form`} disabled={!canSubmit}>
+          {isEditMode ? "수정 완료" : "작성 완료"}
         </ActionButton>
       </Toolbar>
 
-      <Form id={`${config.category}-form`}>
+      <Form
+        id={`${config.category}-form`}
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (canSubmit) mutate();
+        }}
+      >
         <Label as="label" htmlFor={`${config.category}-title`}>
           제목
         </Label>
-        <Input id={`${config.category}-title`} name="title" placeholder="제목" />
+        <Input
+          id={`${config.category}-title`}
+          name="title"
+          placeholder="제목"
+          value={visibleTitle}
+          onChange={(event) => setTitle(event.target.value)}
+        />
 
         <Label as="label" htmlFor={`${config.category}-author`}>
           작성자
         </Label>
-        <Input id={`${config.category}-author`} name="author" placeholder="홍길동" />
+        <Input
+          id={`${config.category}-author`}
+          name="author"
+          placeholder="홍길동"
+          value={visibleAuthor}
+          readOnly
+        />
 
         <Label as="label" htmlFor={`${config.category}-description`}>
           설명
         </Label>
-        <Textarea id={`${config.category}-description`} name="description" placeholder="설명" />
+        <Textarea
+          id={`${config.category}-description`}
+          name="description"
+          placeholder="설명"
+          value={visibleDescription}
+          onChange={(event) => setDescription(event.target.value)}
+        />
 
         <Label>자료</Label>
         <FileUploadPanel>
-          <FileLink href="#">{config.fileBaseName}.pdf</FileLink>
-          <FileLink href="#">{config.fileBaseName}.png</FileLink>
+          {existingAttachments.map((file, index) => (
+            <span key={`${file.fileId ?? file.originalName}-${index}`}>
+              {file.originalName ?? file.fileId ?? `자료 ${index + 1}`}
+            </span>
+          ))}
+          {files.length > 0 ? (
+            files.map((file) => <span key={`${file.name}-${file.lastModified}`}>{file.name}</span>)
+          ) : existingAttachments.length === 0 ? (
+            <span>선택된 파일이 없습니다.</span>
+          ) : null}
           <FileSelectLabel>
             <IconPaperclip aria-hidden="true" size={16} stroke={2.25} />
             <span>파일 선택</span>
-            <HiddenFileInput type="file" name="files" multiple />
+            <HiddenFileInput
+              type="file"
+              name="files"
+              multiple
+              onChange={(event) => {
+                setFiles(Array.from(event.target.files ?? []));
+              }}
+            />
           </FileSelectLabel>
         </FileUploadPanel>
+
+        {postDetailQuery.isError ? (
+          <StateMessage>수정할 {config.title} 내용을 불러오지 못했습니다.</StateMessage>
+        ) : null}
+        {!canManagePost ? (
+          <StateMessage>이 글을 수정할 권한이 없습니다.</StateMessage>
+        ) : null}
+        {isError ? (
+          <StateMessage>
+            {isEditMode ? `${config.title} 수정에 실패했습니다.` : `${config.title} 작성에 실패했습니다.`}
+          </StateMessage>
+        ) : null}
       </Form>
     </DocumentSection>
   );

--- a/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { IconPaperclip } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import styled from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
 import {
   attachPostAttachment,
@@ -15,20 +16,17 @@ import { resolveArchiveChannel } from "@/components/staff/archive/archive-docume
 import {
   ActionButton,
   DocumentSection,
-  FileSelectLabel,
-  FileUploadPanel,
   Form,
   HiddenFileInput,
-  Input,
   Label,
   PageTitle,
   StateMessage,
-  Textarea,
   Toolbar,
 } from "@/components/staff/board/BoardDocument.styles";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import type { ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 type ArchiveDocumentFormPageProps = {
   config: ArchiveDocumentConfig;
@@ -159,7 +157,7 @@ export default function ArchiveDocumentFormPage({
         <Label as="label" htmlFor={`${config.category}-title`}>
           제목
         </Label>
-        <Input
+        <ArchiveInput
           id={`${config.category}-title`}
           name="title"
           placeholder="제목"
@@ -170,7 +168,7 @@ export default function ArchiveDocumentFormPage({
         <Label as="label" htmlFor={`${config.category}-author`}>
           작성자
         </Label>
-        <Input
+        <ArchiveInput
           id={`${config.category}-author`}
           name="author"
           placeholder="홍길동"
@@ -181,7 +179,7 @@ export default function ArchiveDocumentFormPage({
         <Label as="label" htmlFor={`${config.category}-description`}>
           설명
         </Label>
-        <Textarea
+        <ArchiveTextarea
           id={`${config.category}-description`}
           name="description"
           placeholder="설명"
@@ -230,3 +228,125 @@ export default function ArchiveDocumentFormPage({
     </DocumentSection>
   );
 }
+
+const ArchiveInput = styled.input`
+  width: 100%;
+  min-height: 2.6875rem;
+  border: 1px solid ${colors.muted};
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  &:read-only {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ArchiveTextarea = styled.textarea`
+  width: 100%;
+  min-height: 2.6875rem;
+  resize: vertical;
+  border: 1px solid ${colors.muted};
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const FileUploadPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${spacing.space20};
+  width: 100%;
+  min-height: 6.875rem;
+  border: 1px solid ${colors.muted};
+  background-color: ${colors.white};
+  padding: ${spacing.space20};
+
+  > span {
+    color: ${colors.text};
+    font-size: ${typography.fontSize14};
+    font-weight: 500;
+    line-height: ${typography.lineHeight130};
+    text-decoration: underline;
+    text-underline-position: from-font;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 9.6875rem;
+    gap: 1.875rem;
+
+    > span {
+      font-size: ${typography.fontSize20};
+    }
+  }
+`;
+
+const FileSelectLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space4};
+  min-height: 1.9375rem;
+  border: 1px solid ${colors.point};
+  border-radius: ${radii.radius15};
+  background-color: ${colors.pointSoft};
+  padding: 0.5rem 0.625rem;
+  color: ${colors.point};
+  font-size: ${typography.fontSize13};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  &:hover {
+    background-color: #e5f5db;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.75rem;
+    padding: 0.625rem 0.9375rem;
+    font-size: ${typography.fontSize20};
+
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;

--- a/components/staff/archive/archive-document-section/ArchiveDocumentListPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentListPage.tsx
@@ -1,38 +1,146 @@
-import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPanel";
-import { ARCHIVE_DOCUMENTS_PER_PAGE, type ArchiveDocumentConfig } from "@/mocks/archiveDocuments";
+"use client";
 
-export type ArchiveDocumentListItem = {
-  id: number;
-  title: string;
-  author: string;
-  date: string;
-};
+import { useMemo, useState } from "react";
+import { IconSearch } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+import { getChannels } from "@/api/channel/channel.api";
+import type { ChannelResponseDto } from "@/api/channel/channel.dto";
+import { getPosts } from "@/api/post/post.api";
+import type { PostSummaryResponseDto } from "@/api/post/post.dto";
+import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPanel";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  ARCHIVE_DOCUMENTS_PER_PAGE,
+  type ArchiveDocumentConfig,
+} from "@/mocks/archiveDocuments";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+const FETCH_SIZE = 100;
 
 type ArchiveDocumentListPageProps = {
   config: ArchiveDocumentConfig;
-  currentPage: number;
-  documents: ArchiveDocumentListItem[];
-  mineOnly: boolean;
-  totalPages: number;
+  initialPage: number;
 };
+
+export function resolveArchiveChannel(
+  channels: ChannelResponseDto[] | undefined,
+  config: ArchiveDocumentConfig,
+) {
+  return (
+    channels?.find(
+      (channel) => channel.channelType === "CUSTOM" && channel.name?.trim() === config.title,
+    ) ??
+    channels?.find(
+      (channel) => channel.channelType === "CUSTOM" && channel.name?.includes(config.title),
+    ) ??
+    channels?.find((channel) => channel.id === config.channelId)
+  );
+}
+
+function getPostTime(post: PostSummaryResponseDto) {
+  const dateValue = post.createdAt ?? post.updatedAt;
+  if (!dateValue) return 0;
+
+  const time = new Date(dateValue).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
 
 export default function ArchiveDocumentListPage({
   config,
-  currentPage,
-  documents,
-  mineOnly,
-  totalPages,
+  initialPage,
 }: ArchiveDocumentListPageProps) {
-  const rows: ListPanelRow[] = documents.map((document, index) => ({
-    id: document.id,
-    no: String((currentPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE + index + 1).padStart(2, "0"),
+  const router = useRouter();
+  const { user } = useAuthSession();
+  const [mineOnly, setMineOnly] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const requestedPage = Number.isInteger(initialPage) && initialPage >= 1 ? initialPage : 1;
+  const currentAuthor = user?.name ?? user?.nickname ?? user?.email;
+  const resetToFirstPage = () => {
+    if (requestedPage > 1) {
+      router.replace(config.listPath, { scroll: false });
+    }
+  };
+
+  const channelsQuery = useQuery({
+    queryKey: ["staff", "archive", "channels"],
+    queryFn: () => getChannels({ channelType: "CUSTOM", isActive: true }),
+    retry: false,
+  });
+
+  const channel = useMemo(
+    () => resolveArchiveChannel(channelsQuery.data, config),
+    [channelsQuery.data, config],
+  );
+  const channelId = channel?.id ?? config.channelId;
+
+  const postsQuery = useQuery({
+    queryKey: queryKeys.posts.boardList({
+      page: requestedPage,
+      channelType: "CUSTOM",
+      boardScope: String(channelId),
+      searchKeyword,
+      mineOnly,
+      author: currentAuthor,
+      refreshNonce,
+    }),
+    queryFn: () =>
+      getPosts({
+        channelType: "CUSTOM",
+        channelId,
+        title: searchKeyword.trim() || undefined,
+        page: 0,
+        size: FETCH_SIZE,
+      }),
+    enabled: Boolean(channelId),
+    retry: false,
+  });
+
+  const filteredPosts = (postsQuery.data?.content ?? [])
+    .filter((post) => {
+      if (!mineOnly) return true;
+      if (typeof user?.id === "number" && post.authorId === user.id) return true;
+      return Boolean(
+        currentAuthor &&
+          (post.authorName === user?.name ||
+            post.authorName === user?.nickname ||
+            post.authorName === user?.email),
+      );
+    })
+    .sort((a, b) => getPostTime(b) - getPostTime(a));
+
+  const totalPages = Math.max(1, Math.ceil(filteredPosts.length / ARCHIVE_DOCUMENTS_PER_PAGE));
+  const currentPage = requestedPage > totalPages ? 1 : requestedPage;
+  const pagedPosts = filteredPosts.slice(
+    (currentPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE,
+    currentPage * ARCHIVE_DOCUMENTS_PER_PAGE,
+  );
+  const totalCount = filteredPosts.length;
+
+  const rows: ListPanelRow[] = pagedPosts.map((post, index) => ({
+    id: post.id ?? index + 1,
+    no: String(
+      Math.max(1, totalCount - ((currentPage - 1) * ARCHIVE_DOCUMENTS_PER_PAGE + index)),
+    ).padStart(2, "0"),
     className: "",
-    title: document.title,
-    author: document.author,
-    date: document.date,
+    title: post.title ?? "제목 없음",
+    author: post.authorName ?? "-",
+    date: formatUtcToKstShortDate(post.createdAt ?? post.updatedAt),
     status: "",
-    detailHref: `${config.listPath}/${document.id}`,
+    detailHref: `${config.listPath}/${post.id ?? ""}?channelId=${post.channelId ?? channelId}`,
   }));
+
+  const emptyMessage = postsQuery.isLoading
+    ? `${config.title}를 불러오는 중입니다.`
+    : postsQuery.isError
+      ? `${config.title}를 불러오지 못했습니다.`
+      : config.emptyMessage;
 
   return (
     <ListPanel
@@ -43,11 +151,92 @@ export default function ArchiveDocumentListPage({
       rows={rows}
       currentPage={currentPage}
       totalPages={totalPages}
+      stableTableRows={ARCHIVE_DOCUMENTS_PER_PAGE}
       mineOnly={mineOnly}
-      emptyMessage={config.emptyMessage}
+      showMineOnlyToggle
+      toggleLabel="내가 작성한 글만 보기"
+      toggleAriaLabel="내가 작성한 글만 보기"
+      onMineOnlyToggle={() => setMineOnly((current) => !current)}
+      emptyMessage={emptyMessage}
       headerTone="archive"
       showClassColumn={false}
       showStatusColumn={false}
+      searchSlot={
+        <SearchForm
+          role="search"
+          onSubmit={(event) => {
+            event.preventDefault();
+            resetToFirstPage();
+            setSearchKeyword(searchInput);
+            setRefreshNonce((current) => current + 1);
+          }}
+        >
+          <SearchInput
+            aria-label={`${config.title} 검색`}
+            placeholder="검색어를 입력해주세요"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+          <SearchButton type="submit" aria-label="검색">
+            <IconSearch size={18} stroke={2.25} />
+          </SearchButton>
+        </SearchForm>
+      }
     />
   );
 }
+
+const SearchForm = styled.form`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;
+
+const SearchInput = styled.input`
+  width: 13.75rem;
+  min-height: 2.25rem;
+  border: 0;
+  border-bottom: 1px solid ${colors.muted};
+  background: ${colors.white};
+  padding: 0.5rem 0;
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+
+  &::placeholder {
+    color: ${colors.muted};
+  }
+
+  @media (min-width: 120rem) {
+    width: 20.625rem;
+    min-height: 3rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+`;
+
+const SearchButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: ${radii.radius30};
+  background: ${colors.text};
+  color: ${colors.white};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+`;

--- a/components/staff/board/BoardListPageClient.tsx
+++ b/components/staff/board/BoardListPageClient.tsx
@@ -42,6 +42,10 @@ function isPinnedPost(post: PostSummaryResponseDto) {
   return Boolean(post.isPinned);
 }
 
+function isArchivePost(post: PostSummaryResponseDto) {
+  return post.channelType === "CUSTOM";
+}
+
 function getPostTime(post: PostSummaryResponseDto) {
   const dateValue = post.createdAt ?? post.updatedAt;
   if (!dateValue) return 0;
@@ -187,7 +191,7 @@ export default function BoardListPageClient({ initialPage }: BoardListPageClient
     retry: false,
   });
 
-  const rawPosts = data?.content ?? [];
+  const rawPosts = (data?.content ?? []).filter((post) => !isArchivePost(post));
   const posts = rawPosts.filter((post) => {
     if (!mineOnly) return true;
     if (typeof user?.id === "number" && post.authorId === user.id) return true;


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 교원 - 인수인계서/시험 문제 자료/서류 양식 섹션 구현
   목록/상세/작성/수정/삭제 흐름을 기존 교원 게시판 구조와 동일하게 구성하였습니다.
   + 내 글만 보기, 페이지 이동, 검색 기능 추가/로딩 중 UI가 덜컹거리지 않도록 안정적인 테이블 행 높이 유지

   [인수인계서]

   <img width="1918" height="865" alt="스크린샷 2026-05-19 155732" src="https://github.com/user-attachments/assets/8ccb7b43-2fa3-49fb-b4d1-6bc3e1b7a2e6" />

   <img width="1918" height="862" alt="스크린샷 2026-05-19 155750" src="https://github.com/user-attachments/assets/64e8f860-4671-4e61-a3e4-6777cb69e615" />

   [시험 문제 자료]

   <img width="1918" height="867" alt="스크린샷 2026-05-19 155814" src="https://github.com/user-attachments/assets/23042b56-9404-4a21-bfde-2d94cb1d7f5a" />

   <img width="1898" height="863" alt="스크린샷 2026-05-19 161028" src="https://github.com/user-attachments/assets/c83c62f5-ac87-4057-8f9b-65b77e04c717" />

   [서류 양식]

   <img width="1918" height="862" alt="스크린샷 2026-05-19 161112" src="https://github.com/user-attachments/assets/c3ee5be9-df26-4c00-a01b-77a0c9be9fe6" />

   <img width="1900" height="867" alt="스크린샷 2026-05-19 161124" src="https://github.com/user-attachments/assets/ca6eacd7-d3a9-425a-9f24-923df36e3a70" />

2. 권한 처리 적용
   관리자 계정은 모든 글 수정/삭제 가능
   일반 계정은 본인이 작성한 글만 수정/삭제 가능

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #70 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
