### PR TITLE
[REFACTOR] 수업 교환 및 수업 결강 신청 dto 및 UI 개선

### DIFF
--- a/api/dailySchedule/dailySchedule.api.ts
+++ b/api/dailySchedule/dailySchedule.api.ts
@@ -1,0 +1,14 @@
+import authClient from "../client/authClient";
+import type {
+  DailyScheduleListQueryParamsDto,
+  DailyScheduleResponseDto,
+} from "./dailySchedule.dto";
+
+// 조건에 맞는 하루 일정 목록을 조회하는 요청
+export async function getDailySchedules(query: DailyScheduleListQueryParamsDto) {
+  const response = await authClient.get<DailyScheduleResponseDto[]>("/api/v1/daily-schedules", {
+    params: query,
+  });
+
+  return response.data;
+}

--- a/api/dailySchedule/dailySchedule.dto.ts
+++ b/api/dailySchedule/dailySchedule.dto.ts
@@ -1,0 +1,24 @@
+export type DailyScheduleStatus = "SCHEDULED" | "CANCELLED" | "COMPLETED" | string;
+
+export interface DailyScheduleListQueryParamsDto {
+  from: string;
+  to: string;
+  classroomId?: number;
+  teacherId?: number;
+  status?: DailyScheduleStatus;
+}
+
+export interface DailyScheduleResponseDto {
+  dailyScheduleId: number;
+  lessonDate: string;
+  classroomId: number;
+  classroomName: string;
+  teacherId: number;
+  teacherName: string;
+  activityStartTime: string;
+  activityEndTime: string;
+  volunteerServiceMinutes?: number | null;
+  status: DailyScheduleStatus;
+  teacherAttendanceStatus?: string | null;
+  lessonCount: number;
+}

--- a/api/lessonExchange/lessonExchange.api.ts
+++ b/api/lessonExchange/lessonExchange.api.ts
@@ -23,7 +23,7 @@ export async function getLessonExchangeRequests(query?: LessonExchangeListQueryP
       params: query,
     },
   );
-  return response.data.content;
+  return response.data;
 }
 
 // 수업 교환 요청을 생성하는 요청

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -26,7 +26,7 @@ export interface LessonExchangeListQueryParamsDto {
 }
 
 export interface CreateLessonExchangeRequestDto {
-  lessonDate: string;
+  dailyScheduleId: number;
   title: string;
   content: string;
   expiresAt: string;

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -26,7 +26,7 @@ export interface LessonExchangeListQueryParamsDto {
 }
 
 export interface CreateLessonExchangeRequestDto {
-  dailyScheduleId: number;
+  lessonDate: string;
   title: string;
   content: string;
   expiresAt: string;

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -19,7 +19,10 @@ export interface LessonExchangeProposalPathParamsDto extends LessonExchangePathP
 
 export interface LessonExchangeListQueryParamsDto {
   status?: LessonExchangeRequestStatus;
-  mine: boolean;
+  mine?: boolean;
+  keyword?: string;
+  page?: number;
+  size?: number;
 }
 
 export interface CreateLessonExchangeRequestDto {
@@ -64,17 +67,22 @@ export interface LessonExchangeRequestDetailDto {
   createdAt?: string;
 }
 
-export interface LessonExchangeListResponseDto {
+export interface LessonExchangeRequestListItemDto {
   id: number;
+  dailyScheduleId: number;
   classroomName: string;
-  requestedName: string;
+  requestedByName: string;
   title: string;
   status: LessonExchangeRequestStatus;
   createdAt: string;
 }
 
 export interface LessonExchangeRequestListResponseDto {
-  content: LessonExchangeRequestDetailDto[];
+  content: LessonExchangeRequestListItemDto[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 }
 
 export interface LessonExchangeProposalRequestDto {

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -86,12 +86,12 @@ export interface LessonExchangeRequestListResponseDto {
 }
 
 export interface LessonExchangeProposalRequestDto {
-  dailyScheduleId: number;
+  lessonDate?: string;
   content: string;
 }
 
 export interface UpdateLessonExchangeProposalRequestDto {
-  dailyScheduleId?: number;
+  lessonDate?: string;
   content?: string;
 }
 

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -50,6 +50,7 @@ export interface ApproveLessonExchangeRequestDto {
 
 export interface LessonExchangeRequestDetailDto {
   id?: number;
+  dailyScheduleId?: number;
   classroomName?: string;
   lessonDate?: string;
   requestedById?: number;
@@ -57,7 +58,6 @@ export interface LessonExchangeRequestDetailDto {
   title?: string;
   content?: string;
   status?: LessonExchangeRequestStatus;
-  scope?: string;
   expiresAt?: string;
   processedAt?: string;
   processedByName?: string;
@@ -86,18 +86,19 @@ export interface LessonExchangeRequestListResponseDto {
 }
 
 export interface LessonExchangeProposalRequestDto {
-  lessonDate?: string;
+  dailyScheduleId: number;
   content: string;
 }
 
 export interface UpdateLessonExchangeProposalRequestDto {
-  lessonDate?: string;
+  dailyScheduleId?: number;
   content?: string;
 }
 
 export interface LessonExchangeProposalDto {
   id?: number;
   requestId?: number;
+  dailyScheduleId?: number;
   classroomName?: string;
   proposedById?: number;
   proposedByName?: string;

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -16,6 +16,7 @@ import type {
   RequestReconfirmationResponseDto,
   ReviewPurchaseRequestDto,
   RequestStatusQueryParamsDto,
+  UpdateAbsenceRequestDto,
 } from "./request.dto";
 
 // 결석 요청 목록을 조회하는 요청
@@ -26,7 +27,7 @@ export async function getAbsenceRequests(query?: RequestStatusQueryParamsDto) {
       params: query,
     },
   );
-  return response.data.content;
+  return response.data;
 }
 
 // 결석 요청을 생성하는 요청
@@ -42,6 +43,18 @@ export async function createAbsenceRequest(body: CreateAbsenceRequestDto) {
 export async function getAbsenceRequestDetail(pathParams: RequestPathParamsDto) {
   const response = await authClient.get<AbsenceRequestResponseDto>(
     `/api/v1/absence-requests/${pathParams.requestId}`,
+  );
+  return response.data;
+}
+
+// 특정 결석 요청을 수정하는 요청
+export async function updateAbsenceRequest(
+  pathParams: RequestPathParamsDto,
+  body: UpdateAbsenceRequestDto,
+) {
+  const response = await authClient.patch<AbsenceRequestResponseDto>(
+    `/api/v1/absence-requests/${pathParams.requestId}`,
+    body,
   );
   return response.data;
 }

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -8,6 +8,10 @@ export type PurchaseRequestStatus =
 
 export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
+  mine?: boolean;
+  keyword?: string;
+  page?: number;
+  size?: number;
 }
 
 export interface PurchaseRequestStatusQueryParamsDto {
@@ -23,13 +27,23 @@ export interface CreateAbsenceRequestDto {
   reason: string;
 }
 
+export interface UpdateAbsenceRequestDto {
+  title: string;
+  reason: string;
+}
+
 export interface AbsenceRequestResponseDto {
   id?: number;
   lessonId?: number;
+  dailyScheduleId?: number;
   lessonDate?: string;
+  classroomId?: number;
+  classroomName?: string;
   requestedById?: number;
   requestedByName?: string;
+  title?: string;
   reason?: string;
+  expiresAt?: string;
   status?: RequestStatus;
   approvalAt?: string;
   approvalByName?: string;
@@ -39,6 +53,10 @@ export interface AbsenceRequestResponseDto {
 
 export interface AbsenceRequestListResponseDto {
   content: AbsenceRequestResponseDto[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 }
 
 export type AbsenceRequestListItemDto = AbsenceRequestResponseDto;

--- a/app/staff/class-management/absence-request/[postId]/page.tsx
+++ b/app/staff/class-management/absence-request/[postId]/page.tsx
@@ -9,12 +9,20 @@ import {
   getAbsenceRequestDetail,
   updateAbsenceRequest,
 } from "@/api/request/request.api";
+import type { RequestStatus } from "@/api/request/request.dto";
 import { Button } from "@/components/common/VariantButton";
+import { StatusBadge, type ExchangeStatus } from "@/components/staff/class-management/exchange-request/ExchangeRequestDetail";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+function normalizeStatusTone(status?: RequestStatus): ExchangeStatus {
+  if (status === "APPROVED") return "APPROVED";
+  if (status === "REJECTED") return "REJECTED";
+  return "PENDING";
+}
 
 export default function AbsencePostPage() {
   const params = useParams<{ postId: string }>();
@@ -66,6 +74,7 @@ export default function AbsencePostPage() {
   const detailStatus = isError ? "확인 불가" : formatRequestStatus(data?.status);
   const detailTitle = isLoading ? "불러오는 중..." : data?.title ?? "-";
   const isPendingRequest = data?.status === "PENDING";
+  const detailStatusTone = normalizeStatusTone(data?.status);
 
   const handleDelete = async () => {
     if (!isValidPostId || !isPendingRequest || deleteAbsenceMutation.isPending) return;
@@ -165,7 +174,7 @@ export default function AbsencePostPage() {
           )}
 
           <Label>신청 현황</Label>
-          <StatusBox>{detailStatus}</StatusBox>
+          <StatusBadge $tone={detailStatusTone}>{detailStatus}</StatusBadge>
         </PostSection>
       </ContentColumn>
     </PageWrapper>
@@ -310,15 +319,6 @@ const TextBox = styled(ValueBox)`
   @media (min-width: 120rem) {
     min-height: 9.6875rem;
     padding-top: 1.1875rem;
-  }
-`;
-
-const StatusBox = styled(ValueBox)`
-  width: fit-content;
-  padding-inline: ${spacing.space20};
-
-  @media (min-width: 120rem) {
-    padding-inline: 1.875rem;
   }
 `;
 

--- a/app/staff/class-management/absence-request/[postId]/page.tsx
+++ b/app/staff/class-management/absence-request/[postId]/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import Link from "next/link";
+import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
-import { deleteAbsenceRequest, getAbsenceRequestDetail } from "@/api/request/request.api";
-import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import {
+  deleteAbsenceRequest,
+  getAbsenceRequestDetail,
+  updateAbsenceRequest,
+} from "@/api/request/request.api";
+import { Button } from "@/components/common/VariantButton";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
@@ -14,10 +19,14 @@ import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 export default function AbsencePostPage() {
   const params = useParams<{ postId: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { status: authStatus } = useAuthSession();
   const isAuthenticated = authStatus === "authenticated";
   const postId = Number(params.postId);
   const isValidPostId = Number.isInteger(postId) && postId > 0;
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editReason, setEditReason] = useState("");
   const deleteAbsenceMutation = useMutation({
     mutationFn: deleteAbsenceRequest,
     onSuccess: () => {
@@ -26,6 +35,19 @@ export default function AbsencePostPage() {
     },
     onError: () => {
       window.alert("결강 신청서 삭제에 실패했습니다.");
+    },
+  });
+  const updateAbsenceMutation = useMutation({
+    mutationFn: (body: { title: string; reason: string }) =>
+      updateAbsenceRequest({ requestId: postId }, body),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.requests.absenceDetail(postId) });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.requests.absenceList() });
+      setIsEditing(false);
+      window.alert("결강 신청서가 수정되었습니다.");
+    },
+    onError: () => {
+      window.alert("결강 신청서 수정에 실패했습니다.");
     },
   });
 
@@ -38,25 +60,77 @@ export default function AbsencePostPage() {
 
   const detailCreatedDate = formatUtcToKstShortDate(data?.createdAt);
   const detailLessonDate = formatUtcToKstShortDate(data?.lessonDate);
+  const detailClassroomName = data?.classroomName ?? "-";
   const detailWriter = data?.requestedByName ?? "-";
   const detailReason = isError ? "결강 신청 사유를 불러오지 못했습니다." : data?.reason ?? "결강 신청 사유";
   const detailStatus = isError ? "확인 불가" : formatRequestStatus(data?.status);
-  const detailTitle = isLoading ? "불러오는 중..." : "-";
+  const detailTitle = isLoading ? "불러오는 중..." : data?.title ?? "-";
+  const isPendingRequest = data?.status === "PENDING";
 
   const handleDelete = async () => {
-    if (!isValidPostId || deleteAbsenceMutation.isPending) return;
+    if (!isValidPostId || !isPendingRequest || deleteAbsenceMutation.isPending) return;
     if (!window.confirm("결강 신청서를 삭제하시겠습니까?")) return;
     deleteAbsenceMutation.mutate({ requestId: postId });
+  };
+
+  const handleStartEdit = () => {
+    if (!isPendingRequest) return;
+    setEditTitle(data?.title ?? "");
+    setEditReason(data?.reason ?? "");
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    if (!updateAbsenceMutation.isPending) {
+      setIsEditing(false);
+    }
+  };
+
+  const handleSaveEdit = () => {
+    const title = editTitle.trim();
+    const reason = editReason.trim();
+
+    if (!title || !reason) {
+      window.alert("제목과 결강 신청 사유를 입력해 주세요.");
+      return;
+    }
+
+    updateAbsenceMutation.mutate({ title, reason });
   };
 
   return (
     <PageWrapper>
       <TopButtonRow>
-        <ToolbarDangerButton type="button" onClick={handleDelete} disabled={deleteAbsenceMutation.isPending}>
+        <Button
+          type="button"
+          $variant="danger"
+          onClick={handleDelete}
+          disabled={!isPendingRequest || deleteAbsenceMutation.isPending}
+        >
           {deleteAbsenceMutation.isPending ? "삭제 중..." : "삭제"}
-        </ToolbarDangerButton>
-        <ToolbarPrimaryButton type="button">수정</ToolbarPrimaryButton>
-        <ToolbarListLink href="/staff/class-management/absence-request">목록</ToolbarListLink>
+        </Button>
+        {isEditing ? (
+          <>
+            <Button
+              type="button"
+              $variant="edit"
+              onClick={handleCancelEdit}
+              disabled={updateAbsenceMutation.isPending}
+            >
+              취소
+            </Button>
+            <Button type="button" onClick={handleSaveEdit} disabled={updateAbsenceMutation.isPending}>
+              {updateAbsenceMutation.isPending ? "저장 중..." : "저장"}
+            </Button>
+          </>
+        ) : (
+          <Button type="button" $variant="edit" onClick={handleStartEdit} disabled={!isPendingRequest}>
+            수정
+          </Button>
+        )}
+        <Button type="button" $variant="neutral" onClick={() => router.push("/staff/class-management/absence-request")}>
+          목록
+        </Button>
       </TopButtonRow>
 
       <ContentColumn>
@@ -64,12 +138,16 @@ export default function AbsencePostPage() {
 
         <PostSection>
           <Label>제목</Label>
-          <ValueBox>{detailTitle}</ValueBox>
+          {isEditing ? (
+            <EditInput value={editTitle} onChange={(event) => setEditTitle(event.target.value)} />
+          ) : (
+            <ValueBox>{detailTitle}</ValueBox>
+          )}
 
           <Label>신청자 정보</Label>
           <InfoRow>
             <FieldLabel>반 이름</FieldLabel>
-            <FieldValue>-</FieldValue>
+            <FieldValue>{detailClassroomName}</FieldValue>
             <FieldLabel>수업 일자</FieldLabel>
             <FieldValue>{detailLessonDate}</FieldValue>
             <FieldLabel>작성자</FieldLabel>
@@ -77,7 +155,14 @@ export default function AbsencePostPage() {
           </InfoRow>
 
           <Label>결강 신청 사유</Label>
-          <TextBox>{detailReason}</TextBox>
+          {isEditing ? (
+            <EditInput
+              value={editReason}
+              onChange={(event) => setEditReason(event.target.value)}
+            />
+          ) : (
+            <TextBox>{detailReason}</TextBox>
+          )}
 
           <Label>신청 현황</Label>
           <StatusBox>{detailStatus}</StatusBox>
@@ -115,65 +200,6 @@ const TopButtonRow = styled.div`
 
   @media (max-width: ${layout.breakpointMobile}) {
     flex-wrap: wrap;
-  }
-`;
-
-const toolbarButtonBase = `
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 3.9375rem;
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space20};
-  border: 0;
-  font-size: ${typography.fontSize14};
-  font-weight: 500;
-  line-height: ${typography.lineHeight130};
-  white-space: nowrap;
-  cursor: pointer;
-  border-radius: ${radii.radius12};
-
-  @media (min-width: 120rem) {
-    min-width: 5.9375rem;
-    min-height: 4rem;
-    padding: ${spacing.space20} 1.875rem;
-    font-size: ${typography.fontSize20};
-  }
-`;
-
-const ToolbarDangerButton = styled.button`
-  ${toolbarButtonBase}
-  background: #fde4e2;
-  color: #da3a30;
-
-  &:hover:not(:disabled) {
-    filter: brightness(0.97);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-`;
-
-const ToolbarPrimaryButton = styled.button`
-  ${toolbarButtonBase}
-  background: ${colors.point};
-  color: ${colors.white};
-
-  &:hover {
-    filter: brightness(0.95);
-  }
-`;
-
-const ToolbarListLink = styled(Link)`
-  ${toolbarButtonBase}
-  background: ${colors.point};
-  color: ${colors.white};
-  text-decoration: none;
-
-  &:hover {
-    filter: brightness(0.95);
   }
 `;
 
@@ -293,5 +319,22 @@ const StatusBox = styled(ValueBox)`
 
   @media (min-width: 120rem) {
     padding-inline: 1.875rem;
+  }
+`;
+
+const EditInput = styled.input`
+  width: 100%;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid #c0c0c0;
+  background: #ffffff;
+  outline: none;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
   }
 `;

--- a/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
+++ b/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
@@ -1,72 +1,77 @@
 "use client";
 
-import { useMemo } from "react";
-import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { IconSearch } from "@tabler/icons-react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
 import { getLessonExchangeRequests } from "@/api/lessonExchange/lessonExchange.api";
 import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPanel";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
+const STABLE_TABLE_ROWS = 11;
 
 export default function ExchangeListPageClient() {
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const { status: authStatus, user } = useAuthSession();
+  const { status: authStatus } = useAuthSession();
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   const isAuthenticated = authStatus === "authenticated";
   const rawPage = searchParams.get("page");
   const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
+  const requestedPage = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
 
   const {
-    data: exchangeRequests = [],
+    data: exchangeRequestPage,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.requests.lessonExchangeList(),
-    queryFn: () => getLessonExchangeRequests(),
+    queryKey: [
+      ...queryKeys.requests.lessonExchangeList(),
+      requestedPage,
+      ITEMS_PER_PAGE,
+      mineOnly,
+      searchKeyword,
+    ],
+    queryFn: () =>
+      getLessonExchangeRequests({
+        keyword: searchKeyword.trim() || undefined,
+        mine: mineOnly,
+        page: requestedPage - 1,
+        size: ITEMS_PER_PAGE,
+      }),
     enabled: isAuthenticated,
     retry: false,
   });
 
-  const currentUserName = user?.name?.trim();
+  const exchangeRequests = exchangeRequestPage?.content ?? [];
 
-  const filteredRequests = useMemo(
-    () =>
-      mineOnly
-        ? exchangeRequests.filter((request) => {
-            const requestedByName = request.requestedByName?.trim();
-            return Boolean(currentUserName) && requestedByName === currentUserName;
-          })
-        : exchangeRequests,
-    [currentUserName, exchangeRequests, mineOnly],
-  );
+  const totalPages = Math.max(1, exchangeRequestPage?.totalPages ?? 1);
 
-  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
-
-  const currentPage =
-    Number.isInteger(parsedPage) && parsedPage >= 1 && parsedPage <= totalPages ? parsedPage : 1;
-
+  const currentPage = requestedPage <= totalPages ? requestedPage : totalPages;
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
 
-  const rows: ListPanelRow[] = filteredRequests
-    .slice(startIndex, startIndex + ITEMS_PER_PAGE)
-    .map((item, index) => ({
-      id: item.id ?? startIndex + index + 1,
-      no: String(startIndex + index + 1).padStart(2, "0"),
-      className: item.classroomName ?? "-",
-      title: item.title ?? "제목 없음",
-      author: item.requestedByName ?? "-",
-      date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
+  const rows: ListPanelRow[] = exchangeRequests.map((item, index) => ({
+    id: item.id ?? startIndex + index + 1,
+    no: String(startIndex + index + 1).padStart(2, "0"),
+    className: item.classroomName ?? "-",
+    title: item.title ?? "제목 없음",
+    author: item.requestedByName ?? "-",
+    date: formatUtcToKstShortDate(item.createdAt),
 
-      status: formatRequestStatus(item.status),
-      statusType: item.status as "PENDING" | "APPROVED" | "REJECTED",
+    status: formatRequestStatus(item.status),
+    statusType: item.status as "PENDING" | "APPROVED" | "REJECTED",
 
-      detailHref: `/staff/class-management/exchange-request/${item.id ?? ""}`,
-    }));
+    detailHref: `/staff/class-management/exchange-request/${item.id ?? ""}`,
+  }));
 
   const emptyMessage =
     authStatus === "loading"
@@ -88,9 +93,89 @@ export default function ExchangeListPageClient() {
       rows={rows}
       currentPage={currentPage}
       totalPages={totalPages}
+      stableTableRows={STABLE_TABLE_ROWS}
       mineOnly={mineOnly}
       emptyMessage={emptyMessage}
       headerTone="journal"
+      searchSlot={
+        <SearchForm
+          role="search"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setSearchKeyword(searchInput);
+            if (requestedPage > 1) {
+              router.replace("/staff/class-management/exchange-request", { scroll: false });
+            }
+          }}
+        >
+          <SearchInput
+            aria-label="수업 교환 신청 검색"
+            placeholder="검색어를 입력하세요"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+          <SearchButton type="submit" aria-label="검색">
+            <IconSearch size={18} stroke={2.25} />
+          </SearchButton>
+        </SearchForm>
+      }
     />
   );
 }
+
+const SearchForm = styled.form`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;
+
+const SearchInput = styled.input`
+  width: 13.75rem;
+  min-height: 2.25rem;
+  border: 0;
+  border-bottom: 1px solid #c0c0c0;
+  border-radius: 0;
+  background: ${colors.white};
+  padding: 0.5rem ${spacing.space16};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  outline: none;
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    width: 20.625rem;
+    min-height: 3rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+`;
+
+const SearchButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: 999px;
+  background: #414141;
+  color: ${colors.white};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3rem;
+    height: 3rem;
+  }
+`;

--- a/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
+++ b/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
@@ -10,7 +10,10 @@ import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPane
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
-import { formatRequestStatus } from "@/utils/formatRequestStatus";
+import {
+  formatRequestStatus,
+  normalizeRequestStatusTone,
+} from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
@@ -68,7 +71,7 @@ export default function ExchangeListPageClient() {
     date: formatUtcToKstShortDate(item.createdAt),
 
     status: formatRequestStatus(item.status),
-    statusType: item.status as "PENDING" | "APPROVED" | "REJECTED",
+    statusType: normalizeRequestStatusTone(item.status),
 
     detailHref: `/staff/class-management/exchange-request/${item.id ?? ""}`,
   }));

--- a/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
+++ b/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
@@ -39,7 +39,7 @@ function normalizeLessonDateForApi(value: string): string | undefined {
 }
 
 interface ProposalFormValues {
-  lessonDate: string;
+  dailyScheduleId: string;
   content: string;
 }
 
@@ -72,7 +72,7 @@ export function useExchangePostPage() {
 
   const proposalForm = useForm<ProposalFormValues>({
     defaultValues: {
-      lessonDate: "",
+      dailyScheduleId: "",
       content: "",
     },
   });
@@ -204,7 +204,13 @@ export function useExchangePostPage() {
   });
 
   const submitProposal = proposalForm.handleSubmit((data) => {
+    const dailyScheduleId = Number.parseInt(data.dailyScheduleId, 10);
     const content = data.content.trim();
+
+    if (!Number.isInteger(dailyScheduleId) || dailyScheduleId <= 0) {
+      window.alert("하루 일정 ID를 입력해 주세요.");
+      return;
+    }
 
     if (!content) {
       window.alert("내용을 입력해 주세요.");
@@ -212,7 +218,7 @@ export function useExchangePostPage() {
     }
 
     createProposalMutation.mutate({
-      lessonDate: normalizeLessonDateForApi(data.lessonDate),
+      dailyScheduleId,
       content,
     });
   });

--- a/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
+++ b/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
@@ -39,7 +39,7 @@ function normalizeLessonDateForApi(value: string): string | undefined {
 }
 
 interface ProposalFormValues {
-  dailyScheduleId: string;
+  lessonDate: string;
   content: string;
 }
 
@@ -72,7 +72,7 @@ export function useExchangePostPage() {
 
   const proposalForm = useForm<ProposalFormValues>({
     defaultValues: {
-      dailyScheduleId: "",
+      lessonDate: "",
       content: "",
     },
   });
@@ -204,11 +204,11 @@ export function useExchangePostPage() {
   });
 
   const submitProposal = proposalForm.handleSubmit((data) => {
-    const dailyScheduleId = Number.parseInt(data.dailyScheduleId, 10);
     const content = data.content.trim();
+    const lessonDate = normalizeLessonDateForApi(data.lessonDate);
 
-    if (!Number.isInteger(dailyScheduleId) || dailyScheduleId <= 0) {
-      window.alert("하루 일정 ID를 입력해 주세요.");
+    if (!lessonDate) {
+      window.alert("수업 일자를 입력해 주세요.");
       return;
     }
 
@@ -218,7 +218,7 @@ export function useExchangePostPage() {
     }
 
     createProposalMutation.mutate({
-      dailyScheduleId,
+      lessonDate,
       content,
     });
   });

--- a/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
+++ b/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
@@ -9,6 +9,7 @@ import type {
   UpdateLessonExchangeRequestDto,
 } from "@/api/lessonExchange/lessonExchange.dto";
 import {
+  acceptLessonExchangeProposal,
   cancelLessonExchangeRequest,
   createLessonExchangeProposal,
   getLessonExchangeRequestDetail,
@@ -130,6 +131,29 @@ export function useExchangePostPage() {
     },
   });
 
+  const acceptProposalMutation = useMutation({
+    mutationFn: (proposalId: number) =>
+      acceptLessonExchangeProposal({ requestId: postId, proposalId }),
+    onSuccess: async (_, proposalId) => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeDetail(postId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeProposals(postId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeList(),
+      });
+
+      router.push(
+        `/staff/class-management/exchange-request/${postId}/accepted?proposalId=${proposalId}`,
+      );
+    },
+    onError: (error) => {
+      window.alert(error instanceof Error ? error.message : "교환 제안 수락에 실패했습니다.");
+    },
+  });
+
   const cancelRequestMutation = useMutation({
     mutationFn: () => cancelLessonExchangeRequest({ requestId: postId }),
     onSuccess: async () => {
@@ -234,6 +258,13 @@ export function useExchangePostPage() {
     router.push("/staff/class-management/exchange-request");
   };
 
+  const acceptProposal = (proposalId: number) => {
+    if (!Number.isInteger(proposalId) || proposalId <= 0) return;
+    if (!window.confirm("이 교환 제안을 수락할까요?")) return;
+
+    acceptProposalMutation.mutate(proposalId);
+  };
+
   return {
     postId,
     isAuthenticated,
@@ -254,11 +285,13 @@ export function useExchangePostPage() {
 
     isUpdating: updateRequestMutation.isPending,
     isCreatingProposal: createProposalMutation.isPending,
+    isAcceptingProposal: acceptProposalMutation.isPending,
 
     startEdit,
     cancelEdit,
     saveEdit,
     submitProposal,
+    acceptProposal,
     deleteRequest,
     backToList,
   };

--- a/app/staff/class-management/exchange-request/new/page.tsx
+++ b/app/staff/class-management/exchange-request/new/page.tsx
@@ -6,12 +6,17 @@ import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
-import { koreanShortDateToLocalDateTime } from "@/utils/kstShortDate";
+import {
+  koreanShortDateToLocalDateTime,
+  parseKoreanShortDateToIsoDate,
+} from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
+  const [lessonDateText, setLessonDateText] = useState("");
   const [expireDateText, setExpireDateText] = useState("");
 
+  const lessonDateInputRef = useRef<HTMLInputElement>(null);
   const expireDateInputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
@@ -57,15 +62,15 @@ export default function Page() {
     const formData = new FormData(event.currentTarget);
     const title = String(formData.get("title") ?? "").trim();
     const content = String(formData.get("reason") ?? "").trim();
-    const dailyScheduleId = Number.parseInt(String(formData.get("dailyScheduleId") ?? ""), 10);
+    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateText.trim());
     const expiresAt = koreanShortDateToLocalDateTime(expireDateText.trim());
 
     if (!title || !content) {
       window.alert("필수 입력값을 확인해주세요.");
       return;
     }
-    if (!Number.isInteger(dailyScheduleId) || dailyScheduleId <= 0) {
-      window.alert("하루 일정 ID를 입력해 주세요.");
+    if (!lessonDate) {
+      window.alert("수업 일자를 선택해 주세요.");
       return;
     }
     if (!expiresAt) {
@@ -74,7 +79,7 @@ export default function Page() {
     }
 
     createLessonExchangeMutation.mutate({
-      dailyScheduleId,
+      lessonDate,
       title,
       content,
       expiresAt,
@@ -108,14 +113,31 @@ export default function Page() {
               <InlineInput id="className" name="className" placeholder="반 이름" />
               <FieldLabel htmlFor="writer">작성자</FieldLabel>
               <InlineInput id="writer" name="writer" placeholder="홍길동" />
-              <FieldLabel htmlFor="dailyScheduleId">하루 일정 ID</FieldLabel>
-              <InlineInput
-                id="dailyScheduleId"
-                name="dailyScheduleId"
-                type="number"
-                min="1"
-                placeholder="하루 일정 ID"
-              />
+              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
+              <DateRow>
+                <DateInput
+                  id="lessonDate"
+                  name="lessonDate"
+                  placeholder="00.00.00"
+                  value={lessonDateText}
+                  readOnly
+                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
+                />
+                <HiddenNativeDateInput
+                  ref={lessonDateInputRef}
+                  type="date"
+                  onChange={(e) => handleDateChange(e, setLessonDateText)}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                />
+                <CalendarButton
+                  type="button"
+                  aria-label="수업 일자 달력 열기"
+                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
+                >
+                  <IconCalendarMonth size={16} stroke={2} color={colors.white} />
+                </CalendarButton>
+              </DateRow>
             </InfoPairRow>
           </InfoStack>
         </Section>

--- a/app/staff/class-management/exchange-request/new/page.tsx
+++ b/app/staff/class-management/exchange-request/new/page.tsx
@@ -6,20 +6,12 @@ import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
-import {
-  getKstTodayShortDate,
-  koreanShortDateToLocalDateTime,
-  parseKoreanShortDateToIsoDate,
-} from "@/utils/kstShortDate";
+import { koreanShortDateToLocalDateTime } from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function Page() {
-  //const kstToday = getKstTodayShortDate();
-
-  const [lessonDateText, setLessonDateText] = useState("");
   const [expireDateText, setExpireDateText] = useState("");
 
-  const lessonDateInputRef = useRef<HTMLInputElement>(null);
   const expireDateInputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
@@ -65,21 +57,15 @@ export default function Page() {
     const formData = new FormData(event.currentTarget);
     const title = String(formData.get("title") ?? "").trim();
     const content = String(formData.get("reason") ?? "").trim();
-    const lessonDateRaw = String(formData.get("lessonDate") ?? "").trim();
-    const periodFromRaw = String(formData.get("lessonPeriodFrom") ?? "").trim();
-    const periodToRaw = String(formData.get("lessonPeriodTo") ?? "").trim();
-
-    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateRaw);
+    const dailyScheduleId = Number.parseInt(String(formData.get("dailyScheduleId") ?? ""), 10);
     const expiresAt = koreanShortDateToLocalDateTime(expireDateText.trim());
-    const startPeriod = Number.parseInt(periodFromRaw, 10);
-    const endPeriod = Number.parseInt(periodToRaw, 10);
 
     if (!title || !content) {
       window.alert("필수 입력값을 확인해주세요.");
       return;
     }
-    if (!lessonDate) {
-      window.alert("수업 일자를 YY.MM.DD 형식으로 입력해 주세요.");
+    if (!Number.isInteger(dailyScheduleId) || dailyScheduleId <= 0) {
+      window.alert("하루 일정 ID를 입력해 주세요.");
       return;
     }
     if (!expiresAt) {
@@ -88,7 +74,7 @@ export default function Page() {
     }
 
     createLessonExchangeMutation.mutate({
-      lessonDate,
+      dailyScheduleId,
       title,
       content,
       expiresAt,
@@ -122,31 +108,14 @@ export default function Page() {
               <InlineInput id="className" name="className" placeholder="반 이름" />
               <FieldLabel htmlFor="writer">작성자</FieldLabel>
               <InlineInput id="writer" name="writer" placeholder="홍길동" />
-              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-              <DateRow>
-                <DateInput
-                  id="lessonDate"
-                  name="lessonDate"
-                  placeholder="00.00.00"
-                  value={lessonDateText}
-                  readOnly
-                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
-                />
-                <HiddenNativeDateInput
-                  ref={lessonDateInputRef}
-                  type="date"
-                  onChange={(e) => handleDateChange(e, setLessonDateText)}
-                  aria-hidden="true"
-                  tabIndex={-1}
-                />
-                <CalendarButton
-                  type="button"
-                  aria-label="수업 일자 달력 열기"
-                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
-                >
-                  <IconCalendarMonth size={16} stroke={2} color={colors.white} />
-                </CalendarButton>
-              </DateRow>
+              <FieldLabel htmlFor="dailyScheduleId">하루 일정 ID</FieldLabel>
+              <InlineInput
+                id="dailyScheduleId"
+                name="dailyScheduleId"
+                type="number"
+                min="1"
+                placeholder="하루 일정 ID"
+              />
             </InfoPairRow>
           </InfoStack>
         </Section>

--- a/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
+++ b/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
@@ -10,7 +10,10 @@ import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPane
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
-import { formatRequestStatus } from "@/utils/formatRequestStatus";
+import {
+  formatRequestStatus,
+  normalizeRequestStatusTone,
+} from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
@@ -66,7 +69,7 @@ export default function AbsenceListPageClient() {
     author: item.requestedByName ?? "-",
     date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
     status: formatRequestStatus(item.status),
-    statusType: item.status as "PENDING" | "APPROVED" | "REJECTED",
+    statusType: normalizeRequestStatusTone(item.status),
     detailHref: `/staff/class-management/absence-request/${item.id ?? ""}`,
   }));
 

--- a/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
+++ b/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
@@ -1,69 +1,73 @@
 "use client";
 
-import { useMemo } from "react";
-import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { IconSearch } from "@tabler/icons-react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
 import { getAbsenceRequests } from "@/api/request/request.api";
 import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPanel";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 const ITEMS_PER_PAGE = 9;
+const STABLE_TABLE_ROWS = 11;
 
 export default function AbsenceListPageClient() {
+  const router = useRouter();
   const searchParams = useSearchParams();
-  const { status: authStatus, user } = useAuthSession();
+  const { status: authStatus } = useAuthSession();
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
 
   const isAuthenticated = authStatus === "authenticated";
   const rawPage = searchParams.get("page");
   const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
+  const requestedPage = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
 
   const {
-    data: absenceRequests = [],
+    data: absenceRequestPage,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: queryKeys.requests.absenceList(),
-    queryFn: () => getAbsenceRequests(),
+    queryKey: [
+      ...queryKeys.requests.absenceList(),
+      requestedPage,
+      ITEMS_PER_PAGE,
+      mineOnly,
+      searchKeyword,
+    ],
+    queryFn: () =>
+      getAbsenceRequests({
+        keyword: searchKeyword.trim() || undefined,
+        mine: mineOnly,
+        page: requestedPage - 1,
+        size: ITEMS_PER_PAGE,
+      }),
     enabled: isAuthenticated,
     retry: false,
   });
 
-  const currentUserName = user?.name?.trim();
+  const absenceRequests = absenceRequestPage?.content ?? [];
+  const totalPages = Math.max(1, absenceRequestPage?.totalPages ?? 1);
 
-  const filteredRequests = useMemo(
-    () =>
-      mineOnly
-        ? absenceRequests.filter((request) => {
-            const requestedByName = request.requestedByName?.trim();
-            return Boolean(currentUserName) && requestedByName === currentUserName;
-          })
-        : absenceRequests,
-    [absenceRequests, currentUserName, mineOnly],
-  );
-
-  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / ITEMS_PER_PAGE));
-
-  const currentPage =
-    Number.isInteger(parsedPage) && parsedPage >= 1 && parsedPage <= totalPages ? parsedPage : 1;
-
+  const currentPage = requestedPage <= totalPages ? requestedPage : totalPages;
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
 
-  const rows: ListPanelRow[] = filteredRequests
-    .slice(startIndex, startIndex + ITEMS_PER_PAGE)
-    .map((item, index) => ({
-      id: item.id ?? startIndex + index + 1,
-      no: String(startIndex + index + 1).padStart(2, "0"),
-      className: "-",
-      title: "-",
-      author: item.requestedByName ?? "-",
-      date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
-      status: formatRequestStatus(item.status),
-      detailHref: `/staff/class-management/absence-request/${item.id ?? ""}`,
-    }));
+  const rows: ListPanelRow[] = absenceRequests.map((item, index) => ({
+    id: item.id ?? startIndex + index + 1,
+    no: String(startIndex + index + 1).padStart(2, "0"),
+    className: item.classroomName ?? "-",
+    title: item.title ?? item.reason ?? "제목 없음",
+    author: item.requestedByName ?? "-",
+    date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
+    status: formatRequestStatus(item.status),
+    detailHref: `/staff/class-management/absence-request/${item.id ?? ""}`,
+  }));
 
   const emptyMessage =
     authStatus === "loading"
@@ -85,9 +89,89 @@ export default function AbsenceListPageClient() {
       rows={rows}
       currentPage={currentPage}
       totalPages={totalPages}
+      stableTableRows={STABLE_TABLE_ROWS}
       mineOnly={mineOnly}
       emptyMessage={emptyMessage}
       headerTone="journal"
+      searchSlot={
+        <SearchForm
+          role="search"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setSearchKeyword(searchInput);
+            if (requestedPage > 1) {
+              router.replace("/staff/class-management/absence-request", { scroll: false });
+            }
+          }}
+        >
+          <SearchInput
+            aria-label="수업 결강 신청 검색"
+            placeholder="검색어를 입력하세요"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+          <SearchButton type="submit" aria-label="검색">
+            <IconSearch size={18} stroke={2.25} />
+          </SearchButton>
+        </SearchForm>
+      }
     />
   );
 }
+
+const SearchForm = styled.form`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 100%;
+  }
+`;
+
+const SearchInput = styled.input`
+  width: 13.75rem;
+  min-height: 2.25rem;
+  border: 0;
+  border-bottom: 1px solid #c0c0c0;
+  border-radius: 0;
+  background: ${colors.white};
+  padding: 0.5rem ${spacing.space16};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  outline: none;
+
+  &::placeholder {
+    color: ${colors.placeholder};
+  }
+
+  @media (min-width: 120rem) {
+    width: 20.625rem;
+    min-height: 3rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+`;
+
+const SearchButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: 999px;
+  background: #414141;
+  color: ${colors.white};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3rem;
+    height: 3rem;
+  }
+`;

--- a/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
+++ b/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
@@ -66,6 +66,7 @@ export default function AbsenceListPageClient() {
     author: item.requestedByName ?? "-",
     date: formatUtcToKstShortDate(item.createdAt ?? item.lessonDate),
     status: formatRequestStatus(item.status),
+    statusType: item.status as "PENDING" | "APPROVED" | "REJECTED",
     detailHref: `/staff/class-management/absence-request/${item.id ?? ""}`,
   }));
 

--- a/components/staff/class-management/exchange-request/ExchangeProposalList.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeProposalList.tsx
@@ -11,6 +11,8 @@ interface ExchangeProposalListProps {
   acceptLabel?: string;
   showAcceptLink?: boolean;
   showCardTopBorder?: boolean;
+  isAccepting?: boolean;
+  onAcceptProposal?: (proposal: LessonExchangeProposalDto) => void;
   proposals: LessonExchangeProposalDto[];
   proposalsLoading: boolean;
   proposalsError: boolean;
@@ -21,6 +23,8 @@ export function ExchangeProposalList({
   acceptLabel = "제안 수락하기",
   showAcceptLink = true,
   showCardTopBorder = true,
+  isAccepting = false,
+  onAcceptProposal,
   proposals,
   proposalsLoading,
   proposalsError,
@@ -39,6 +43,8 @@ export function ExchangeProposalList({
         proposals.map((proposal, index) => {
           const acceptHref =
             typeof acceptedHref === "function" ? acceptedHref(proposal) : acceptedHref;
+          const canShowAccept =
+            showAcceptLink && (proposal.status === "ACTIVE" || proposal.status == null);
 
           return (
             <ProposalCard key={proposal.id ?? index} $showTopBorder={showCardTopBorder}>
@@ -62,9 +68,19 @@ export function ExchangeProposalList({
 
               <ProposalContent>{proposal.content ?? "—"}</ProposalContent>
 
-              {showAcceptLink ? (
+              {canShowAccept ? (
                 <ProposalFooter>
-                  <AcceptLink href={acceptHref}>{acceptLabel}</AcceptLink>
+                  {onAcceptProposal ? (
+                    <AcceptButton
+                      type="button"
+                      disabled={isAccepting}
+                      onClick={() => onAcceptProposal(proposal)}
+                    >
+                      {acceptLabel}
+                    </AcceptButton>
+                  ) : (
+                    <AcceptLink href={acceptHref}>{acceptLabel}</AcceptLink>
+                  )}
                 </ProposalFooter>
               ) : null}
             </ProposalCard>
@@ -196,7 +212,7 @@ const ProposalDate = styled.span`
   }
 `;
 
-const AcceptLink = styled(Link)`
+const acceptActionStyle = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -209,5 +225,22 @@ const AcceptLink = styled(Link)`
 
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const AcceptLink = styled(Link)`
+  ${acceptActionStyle}
+`;
+
+const AcceptButton = styled.button`
+  ${acceptActionStyle}
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;

--- a/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
@@ -77,10 +77,11 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
               />
               <FieldInput
                 $tone="proposal"
-                aria-label="수업 일자"
-                placeholder="수업 일자"
-                type="text"
-                {...page.proposalForm.register("lessonDate")}
+                aria-label="하루 일정 ID"
+                placeholder="하루 일정 ID"
+                type="number"
+                min="1"
+                {...page.proposalForm.register("dailyScheduleId")}
               />
 
               <ProposalFormTextarea

--- a/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
@@ -77,11 +77,10 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
               />
               <FieldInput
                 $tone="proposal"
-                aria-label="하루 일정 ID"
-                placeholder="하루 일정 ID"
-                type="number"
-                min="1"
-                {...page.proposalForm.register("dailyScheduleId")}
+                aria-label="수업 일자"
+                placeholder="00.00.00"
+                type="text"
+                {...page.proposalForm.register("lessonDate")}
               />
 
               <ProposalFormTextarea

--- a/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
@@ -23,7 +23,10 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
   const canEdit = page.isAuthenticated && page.isValidPostId && !page.requestError && !isLocked;
   const acceptedHref = `/staff/class-management/exchange-request/${page.postId}/accepted`;
   const canAcceptProposal =
-    page.isAuthenticated && page.user?.id != null && page.user.id === page.request?.requestedById;
+    page.isAuthenticated &&
+    page.user?.id != null &&
+    page.user.id === page.request?.requestedById &&
+    page.request?.status === "APPROVED";
 
   return (
     <PageWrapper>
@@ -96,6 +99,10 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
                 proposal.id ? `${acceptedHref}?proposalId=${proposal.id}` : acceptedHref
               }
               showAcceptLink={canAcceptProposal}
+              isAccepting={page.isAcceptingProposal}
+              onAcceptProposal={(proposal) => {
+                if (proposal.id) page.acceptProposal(proposal.id);
+              }}
               proposals={page.proposals}
               proposalsLoading={page.proposalsLoading}
               proposalsError={page.proposalsError}

--- a/components/staff/common/ListPanel.tsx
+++ b/components/staff/common/ListPanel.tsx
@@ -169,9 +169,7 @@ export default function ListPanel({
               ))
             ) : (
               <Tr $tone={headerTone}>
-                <EmptyTd colSpan={columnCount}>
-                  {emptyMessage}
-                </EmptyTd>
+                <EmptyTd colSpan={columnCount}>{emptyMessage}</EmptyTd>
               </Tr>
             )}
           </tbody>
@@ -367,11 +365,11 @@ const WriteButton = styled(Link)<{ $tone: ListPanelTone }>`
 const TableSection = styled.section<{ $stableRows?: number }>`
   width: 100%;
   min-height: ${({ $stableRows }) =>
-    $stableRows ? `calc(2.5rem + ${$stableRows} * 2.375rem)` : "0"};
+    $stableRows ? `calc(2.5rem + ${$stableRows} * 1.875rem)` : "0"};
 
   @media (min-width: 120rem) {
     min-height: ${({ $stableRows }) =>
-      $stableRows ? `calc(3.75rem + ${$stableRows} * 3.625rem)` : "0"};
+      $stableRows ? `calc(3.75rem + ${$stableRows} * 2.75rem)` : "0"};
   }
 `;
 
@@ -413,7 +411,7 @@ const Tr = styled.tr<{ $tone: ListPanelTone }>`
 
 const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: boolean }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
-  padding: 0.65625rem ${spacing.space12};
+  padding: 0.40625rem ${spacing.space12};
   color: ${({ $isNotice }) => ($isNotice ? colors.notice : colors.text)};
   font-size: ${typography.fontSize14};
   font-weight: ${({ $isNotice }) => ($isNotice ? 700 : 400)};
@@ -422,7 +420,7 @@ const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: bool
 
   @media (min-width: 120rem) {
     width: ${({ $width1080, $width720 }) => $width1080 ?? $width720 ?? "auto"};
-    padding: 1.1875rem ${spacing.space12};
+    padding: 0.75rem ${spacing.space12};
     font-size: ${typography.fontSize20};
   }
 `;

--- a/utils/formatRequestStatus.ts
+++ b/utils/formatRequestStatus.ts
@@ -1,7 +1,20 @@
 import type { RequestStatus } from "@/api/request/request.dto";
 
+export type RequestStatusTone = "PENDING" | "APPROVED" | "REJECTED";
+
 export function formatRequestStatus(status?: RequestStatus | string) {
   if (status === "APPROVED") return "승인";
   if (status === "REJECTED") return "거절됨";
+  if (status === "COMPLETED") return "완료";
+  if (status === "EXPIRED") return "만료";
+  if (status === "CANCELLED") return "취소됨";
+  if (status === "PENDING") return "대기 중";
   return "대기 중";
+}
+
+/** 목록 배지 색상용: COMPLETED·EXPIRED·CANCELLED 등을 3-tone으로 묶음 */
+export function normalizeRequestStatusTone(status?: string): RequestStatusTone {
+  if (status === "APPROVED" || status === "COMPLETED") return "APPROVED";
+  if (status === "REJECTED" || status === "EXPIRED" || status === "CANCELLED") return "REJECTED";
+  return "PENDING";
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 수업 교환 목록: 백엔드 페이지네이션 및 검색 API 연동, 신청 현황 문구 및 배지 색상 수정
- 교환 제안서: dailyScheduleId 입력 제거 → lessonDate 수기 입력으로 변경
- 제안 수락: 제안 수락하기 버튼에 PATCH `/lesson-exchange-requests/{requestId}/proposals/{proposalId}/accept` 연동
- 결강 신청: 목록 API / DTO 반영, 신청 현황 배지 개선
- 결강 신청 목록 : 백엔드 페이지네이션 및 검색 API 연동, 신청 현황 문구 및 배지 색상 수정
- 공통: ListPanel 행 높이 조정, dailySchedule 조회 API 클라이언트 추가
 
## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #67 

## 💬 기타 사항

추가로 공유할 내용, 논의할 주제, 고민점이 있다면 적어주세요.

## 📂 참고 자료

> N/A
