### PR TITLE
[FEAT] 수업 일지 출석부 UI 개선 및 API 연동

### DIFF
--- a/api/student/student.api.test.ts
+++ b/api/student/student.api.test.ts
@@ -29,11 +29,12 @@ describe("student.api", () => {
       }),
     );
 
-    const response = await getStudents({ status: "ENROLLED", page: 0, size: 10 });
+    const response = await getStudents({ status: "ENROLLED", classroomId: 1 });
 
     expect(response).toEqual(STUDENT_LIST_RESPONSE);
     expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
     expect(observedQueryString).toContain("status=ENROLLED");
+    expect(observedQueryString).toContain("classroomId=1");
   });
 
   it("creates a student with the expected POST body", async () => {
@@ -49,6 +50,7 @@ describe("student.api", () => {
           name: "Park Student",
           phoneNumber: "010-4444-5555",
           description: "New student",
+          classrooms: [{ id: 2, name: "장미반" }],
           status: "ENROLLED",
         });
       }),
@@ -58,13 +60,16 @@ describe("student.api", () => {
       name: "Park Student",
       phoneNumber: "010-4444-5555",
       description: "New student",
+      classroomId: 2,
     });
 
     expect(response.name).toBe("Park Student");
+    expect(response.classrooms).toEqual([{ id: 2, name: "장미반" }]);
     expect(observedBody).toEqual({
       name: "Park Student",
       phoneNumber: "010-4444-5555",
       description: "New student",
+      classroomId: 2,
     });
   });
 

--- a/api/student/student.dto.ts
+++ b/api/student/student.dto.ts
@@ -10,6 +10,11 @@ export interface StudentListQueryParamsDto {
   classroomId?: number;
 }
 
+export interface StudentClassroomDto {
+  id: number;
+  name: string;
+}
+
 export interface CreateStudentRequestDto {
   name: string;
   phoneNumber?: string;
@@ -30,9 +35,8 @@ export interface StudentResponseDto {
   name?: string;
   phoneNumber?: string;
   description?: string;
-  classroomId?: number;
-  classroomName?: string;
-  status?: StudentStatus | string;
+  classrooms?: StudentClassroomDto[];
+  status?: StudentStatus;
 }
 
 export type StudentListItemDto = StudentResponseDto;

--- a/components/staff/archive/phone-book/useStudentContactSection.ts
+++ b/components/staff/archive/phone-book/useStudentContactSection.ts
@@ -9,6 +9,7 @@ import {
   updateStudent,
 } from "@/api/student/student.api";
 import type { StudentListResponseDto } from "@/api/student/student.dto";
+import { queryKeys } from "@/lib/queryKeys";
 import type {
   StudentClass,
   StudentContact,
@@ -24,22 +25,34 @@ function mapStudentsToClasses(students: StudentListResponseDto): StudentClass[] 
   const grouped = new Map<string, StudentClass>();
 
   students.forEach((student) => {
-    const classId = String(student.classroomId ?? student.classroomName ?? "unknown");
-    const className = student.classroomName ?? "미지정";
+    const classrooms =
+      student.classrooms && student.classrooms.length > 0
+        ? student.classrooms
+        : [{ id: -1, name: "미지정" }];
 
-    if (!grouped.has(classId)) {
-      grouped.set(classId, {
-        id: classId,
-        name: className,
-        isOpen: grouped.size === 0,
-        students: [],
+    classrooms.forEach((classroom) => {
+      const classId = String(classroom.id);
+      const className = classroom.name;
+
+      if (!grouped.has(classId)) {
+        grouped.set(classId, {
+          id: classId,
+          name: className,
+          isOpen: grouped.size === 0,
+          students: [],
+        });
+      }
+
+      const classStudents = grouped.get(classId)?.students;
+      const studentId = student.id ?? Date.now();
+
+      if (classStudents?.some((item) => item.id === studentId)) return;
+
+      classStudents?.push({
+        id: studentId,
+        name: student.name ?? "",
+        phone: student.phoneNumber ?? "",
       });
-    }
-
-    grouped.get(classId)?.students.push({
-      id: student.id ?? Date.now(),
-      name: student.name ?? "",
-      phone: student.phoneNumber ?? "",
     });
   });
 
@@ -50,7 +63,7 @@ export function useStudentContactSection(initialClasses: StudentClass[] = []) {
   const queryClient = useQueryClient();
 
   const { data: students = [] } = useQuery({
-    queryKey: ["students"],
+    queryKey: queryKeys.students.list(),
     queryFn: () => getStudents(),
   });
 
@@ -228,7 +241,7 @@ export function useStudentContactSection(initialClasses: StudentClass[] = []) {
         ...deletedStudents.map((student) => deleteStudentMutation.mutateAsync(student.id)),
       ]);
 
-      await queryClient.invalidateQueries({ queryKey: ["students"] });
+      await queryClient.invalidateQueries({ queryKey: ["students", "list"] });
 
       setClasses(cleanedClasses);
       setIsEditing(false);

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
 import type {
   DailyScheduleLessonResponseDto,
@@ -115,6 +115,7 @@ function buildLessonJournals(
 
 export default function ClassJournalCreatePage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const todayIsoDate = useMemo(() => getKstTodayIsoDate(), []);
   const [lessonDateText, setLessonDateText] = useState("");
   const [classroomNameText, setClassroomNameText] = useState("");
@@ -181,13 +182,14 @@ export default function ClassJournalCreatePage() {
     }) => {
       const journal = await createJournal(journalBody);
 
-      if (attendances.length > 0) {
-        await updateStudentAttendances({ dailyScheduleId }, { attendances });
-      }
+      if (attendances.length === 0) return journal;
 
-      return journal;
+      return updateStudentAttendances({ dailyScheduleId }, { attendances });
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
+      await queryClient.invalidateQueries({ queryKey: ["daily-schedules", "list"] });
+      queryClient.setQueryData(["daily-schedules", "detail", data.dailyScheduleId], data);
+
       window.alert("수업 일지가 등록되었습니다.");
       if (data.dailyScheduleId) {
         router.push(`/staff/class-management/${data.dailyScheduleId}`);

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -17,7 +17,13 @@ import {
 import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
 import { getCurrentUser } from "@/api/user/user.api";
-import { formatPhone } from "@/lib/googleSheet/classJournal/classJournalSheetPayload";
+import { buildClassAttendanceSheetPayload } from "@/lib/googleSheet/classAttendance/classAttendanceSheetPayload";
+import { sendClassAttendanceToGoogleSheet } from "@/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet";
+import {
+  buildClassJournalSheetPayloadFromFormData,
+  formatPhone,
+} from "@/lib/googleSheet/classJournal/classJournalSheetPayload";
+import { sendClassJournalToGoogleSheet } from "@/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 import { getKstTodayIsoDate, parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
@@ -175,16 +181,36 @@ export default function ClassJournalCreatePage() {
       journalBody,
       dailyScheduleId,
       attendances,
+      googleSheet,
     }: {
       journalBody: Parameters<typeof createJournal>[0];
       dailyScheduleId: number;
       attendances: UpdateDailyStudentAttendanceItemRequestDto[];
+      googleSheet: {
+        journal: ReturnType<typeof buildClassJournalSheetPayloadFromFormData>;
+        attendance: ReturnType<typeof buildClassAttendanceSheetPayload>;
+      };
     }) => {
       const journal = await createJournal(journalBody);
 
-      if (attendances.length === 0) return journal;
+      const schedule =
+        attendances.length > 0
+          ? await updateStudentAttendances({ dailyScheduleId }, { attendances })
+          : journal;
 
-      return updateStudentAttendances({ dailyScheduleId }, { attendances });
+      try {
+        await sendClassJournalToGoogleSheet(googleSheet.journal);
+
+        if (googleSheet.attendance.attendances.length > 0) {
+          await sendClassAttendanceToGoogleSheet(googleSheet.attendance);
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "구글 시트 연동에 실패했습니다.";
+        throw new Error(`수업 일지는 저장되었으나 ${message}`);
+      }
+
+      return schedule;
     },
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ["daily-schedules", "list"] });
@@ -301,6 +327,15 @@ export default function ClassJournalCreatePage() {
         personalInfoConsent,
         residentRegistrationNumberPrefix,
         lessonJournals,
+      },
+      googleSheet: {
+        journal: buildClassJournalSheetPayloadFromFormData(formData),
+        attendance: buildClassAttendanceSheetPayload(
+          formData,
+          enrolledStudents,
+          classroomNameValue,
+          lessonDateValue.trim(),
+        ),
       },
     });
   };

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -9,6 +9,7 @@ import type {
   LessonJournalRequestDto,
 } from "@/api/dailySchedule/dailySchedule.dto";
 import { createJournal, getDailyScheduleDetail } from "@/api/dailySchedule/dailySchedule.api";
+import { getStudents } from "@/api/student/student.api";
 import { getCurrentUser } from "@/api/user/user.api";
 import { formatPhone } from "@/lib/googleSheet/classJournal/classJournalSheetPayload";
 import { queryKeys } from "@/lib/queryKeys";
@@ -18,6 +19,13 @@ import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const lessonPeriods = [1, 2, 3] as const;
 const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
+
+/** TODO: users/me classroomId 필드가 고정 될 때까지 테스트를 위해 기본값으로 설정 */
+const CLASS_JOURNAL_FORM_DEFAULTS = {
+  classroomId: 1,
+  residentRegistrationNumberPrefix: "900101",
+  phoneNumber: "01012345678",
+} as const;
 
 function trimTrailingClockSeconds(time?: string) {
   if (!time) return "";
@@ -63,9 +71,12 @@ export default function ClassJournalCreatePage() {
   const router = useRouter();
   const todayIsoDate = useMemo(() => getKstTodayIsoDate(), []);
   const [lessonDateText, setLessonDateText] = useState("");
-  const [classroomId, setClassroomId] = useState("");
+  const [classroomId, setClassroomId] = useState(String(CLASS_JOURNAL_FORM_DEFAULTS.classroomId));
   const [classroomName, setClassroomName] = useState("");
-  const [birthPrefix, setBirthPrefix] = useState("");
+  const [birthPrefix, setBirthPrefix] = useState(
+    CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix,
+  );
+  const [phoneNumber, setPhoneNumber] = useState(CLASS_JOURNAL_FORM_DEFAULTS.phoneNumber);
   const [activityTime, setActivityTime] = useState("");
   const [attendanceRowCount, setAttendanceRowCount] = useState(1);
 
@@ -75,16 +86,35 @@ export default function ClassJournalCreatePage() {
     retry: false,
   });
 
-  const userClassroomId = currentUserQuery.data?.classroom?.id;
+  const parsedClassroomId = Number.parseInt(classroomId, 10);
+  const enrollmentClassroomId =
+    Number.isFinite(parsedClassroomId) && parsedClassroomId > 0
+      ? parsedClassroomId
+      : CLASS_JOURNAL_FORM_DEFAULTS.classroomId;
+
+  const studentsQuery = useQuery({
+    queryKey: queryKeys.students.list({
+      classroomId: enrollmentClassroomId,
+      status: "ENROLLED",
+    }),
+    queryFn: () =>
+      getStudents({
+        classroomId: enrollmentClassroomId as number,
+        status: "ENROLLED",
+      }),
+    enabled: typeof enrollmentClassroomId === "number" && enrollmentClassroomId > 0,
+    retry: false,
+  });
+
+  const enrolledStudents = studentsQuery.data ?? [];
 
   const dailyScheduleDetailQuery = useQuery({
-    queryKey: ["daily-schedules", "detail", userClassroomId, todayIsoDate] as const,
+    queryKey: ["daily-schedules", "detail", enrollmentClassroomId, todayIsoDate] as const,
     queryFn: () =>
       getDailyScheduleDetail({
-        classroomId: userClassroomId as number,
+        classroomId: enrollmentClassroomId,
         lessonDate: todayIsoDate,
       }),
-    enabled: typeof userClassroomId === "number" && userClassroomId > 0,
     retry: false,
   });
 
@@ -108,18 +138,22 @@ export default function ClassJournalCreatePage() {
   const scheduleDetail = dailyScheduleDetailQuery.data;
 
   const writerName = scheduleDetail?.teacherName ?? currentUser?.name ?? "";
-  const phoneNumber = scheduleDetail?.teacherPhoneNumber ?? currentUser?.phoneNumber ?? "";
 
   useEffect(() => {
     const detail = dailyScheduleDetailQuery.data;
     if (!detail) return;
 
     setLessonDateText(formatUtcToKstShortDate(`${detail.lessonDate}T00:00:00`));
-    setClassroomId(String(detail.classroomId));
     setClassroomName(detail.classroomName ?? "");
-    setBirthPrefix(detail.residentRegistrationNumberPrefix ?? "");
     setActivityTime(formatLessonsActivityTime(detail.lessons));
   }, [dailyScheduleDetailQuery.data]);
+
+  useEffect(() => {
+    if (enrolledStudents.length === 0) return;
+
+    const requiredRows = Math.ceil(enrolledStudents.length / attendanceColumns.length);
+    setAttendanceRowCount((current) => Math.max(current, requiredRows));
+  }, [enrolledStudents.length]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -148,11 +182,14 @@ export default function ClassJournalCreatePage() {
       return;
     }
 
+    const residentRegistrationNumberPrefix =
+      birthPrefix.trim() || CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix;
+
     createJournalMutation.mutate({
       lessonDate,
       classroomId: parsedClassroomId,
       personalInfoConsent,
-      residentRegistrationNumberPrefix: "900101", // TODO: 주민번호 앞자리 실제 값 연동
+      residentRegistrationNumberPrefix,
       lessonJournals,
     });
   };
@@ -210,7 +247,7 @@ export default function ClassJournalCreatePage() {
               id="phone"
               name="phone"
               type="text"
-              value={phoneNumber ? formatPhone(phoneNumber) : ""}
+              value={formatPhone(phoneNumber)}
               placeholder="010-0000-0000"
               disabled
               readOnly
@@ -277,14 +314,18 @@ export default function ClassJournalCreatePage() {
                   key={rowIndex}
                   aria-label={rowIndex === 0 ? "출석부" : `출석부 ${rowIndex + 1}`}
                 >
-                  {attendanceColumns.map((column) => (
-                    <AttendanceInput
-                      key={`student-${rowIndex}-${column}`}
-                      name={`studentName${rowIndex * 10 + column + 1}`}
-                      aria-label={`${rowIndex * 10 + column + 1}번 학생 이름`}
-                      placeholder={rowIndex === 0 && column < 4 ? "최양진" : ""}
-                    />
-                  ))}
+                  {attendanceColumns.map((column) => {
+                    const student = enrolledStudents[rowIndex * 10 + column];
+
+                    return (
+                      <AttendanceInput
+                        key={`student-${rowIndex}-${column}-${student?.id ?? "empty"}`}
+                        name={`studentName${rowIndex * 10 + column + 1}`}
+                        aria-label={`${rowIndex * 10 + column + 1}번 학생 이름`}
+                        defaultValue={student?.name ?? ""}
+                      />
+                    );
+                  })}
                   {attendanceColumns.map((column) => (
                     <AttendanceInput
                       key={`attendance-${rowIndex}-${column}`}

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -7,8 +7,13 @@ import styled from "styled-components";
 import type {
   DailyScheduleLessonResponseDto,
   LessonJournalRequestDto,
+  UpdateDailyStudentAttendanceItemRequestDto,
 } from "@/api/dailySchedule/dailySchedule.dto";
-import { createJournal, getDailyScheduleDetail } from "@/api/dailySchedule/dailySchedule.api";
+import {
+  createJournal,
+  getDailyScheduleDetail,
+  updateStudentAttendances,
+} from "@/api/dailySchedule/dailySchedule.api";
 import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
 import { getCurrentUser } from "@/api/user/user.api";
@@ -61,6 +66,27 @@ function formatLessonsActivityTime(lessons?: DailyScheduleLessonResponseDto[]) {
 
   if (start && end) return `${start} - ${end}`;
   return start || end || "";
+}
+
+function buildStudentAttendances(
+  formData: FormData,
+  students: StudentListResponseDto,
+): UpdateDailyStudentAttendanceItemRequestDto[] {
+  return students.flatMap((student, index) => {
+    if (typeof student.id !== "number") return [];
+
+    const rowIndex = Math.floor(index / attendanceColumns.length);
+    const column = index % attendanceColumns.length;
+    const statusIndex = rowIndex * attendanceColumns.length + column + 1;
+    const isPresent = formData.get(`attendanceStatus${statusIndex}`) === "on";
+
+    return [
+      {
+        studentId: student.id,
+        status: isPresent ? "PRESENT" : "ABSENT",
+      },
+    ];
+  });
 }
 
 function buildLessonJournals(
@@ -143,8 +169,24 @@ export default function ClassJournalCreatePage() {
     retry: false,
   });
 
-  const createJournalMutation = useMutation({
-    mutationFn: createJournal,
+  const submitMutation = useMutation({
+    mutationFn: async ({
+      journalBody,
+      dailyScheduleId,
+      attendances,
+    }: {
+      journalBody: Parameters<typeof createJournal>[0];
+      dailyScheduleId: number;
+      attendances: UpdateDailyStudentAttendanceItemRequestDto[];
+    }) => {
+      const journal = await createJournal(journalBody);
+
+      if (attendances.length > 0) {
+        await updateStudentAttendances({ dailyScheduleId }, { attendances });
+      }
+
+      return journal;
+    },
     onSuccess: (data) => {
       window.alert("수업 일지가 등록되었습니다.");
       if (data.dailyScheduleId) {
@@ -158,7 +200,7 @@ export default function ClassJournalCreatePage() {
     },
   });
 
-  const isSubmitting = createJournalMutation.isPending;
+  const isSubmitting = submitMutation.isPending;
   const currentUser = currentUserQuery.data;
   const scheduleDetail = dailyScheduleDetailQuery.data;
 
@@ -239,15 +281,25 @@ export default function ClassJournalCreatePage() {
       return;
     }
 
+    const dailyScheduleId = scheduleDetail?.dailyScheduleId;
+    if (!dailyScheduleId) {
+      window.alert("일정 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
+      return;
+    }
+
     const residentRegistrationNumberPrefix =
       birthPrefix.trim() || CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix;
 
-    createJournalMutation.mutate({
-      lessonDate,
-      classroomId: parsedClassroomId,
-      personalInfoConsent,
-      residentRegistrationNumberPrefix,
-      lessonJournals,
+    submitMutation.mutate({
+      dailyScheduleId,
+      attendances: buildStudentAttendances(formData, enrolledStudents),
+      journalBody: {
+        lessonDate,
+        classroomId: parsedClassroomId,
+        personalInfoConsent,
+        residentRegistrationNumberPrefix,
+        lessonJournals,
+      },
     });
   };
 
@@ -389,13 +441,19 @@ export default function ClassJournalCreatePage() {
                       />
                     );
                   })}
-                  {attendanceColumns.map((column) => (
-                    <AttendanceInput
-                      key={`attendance-${rowIndex}-${column}`}
-                      name={`attendanceStatus${rowIndex * 10 + column + 1}`}
-                      aria-label={`${rowIndex * 10 + column + 1}번 출석 상태`}
-                    />
-                  ))}
+                  {attendanceColumns.map((column) => {
+                    const statusIndex = rowIndex * 10 + column + 1;
+
+                    return (
+                      <AttendanceCheckboxCell key={`attendance-${rowIndex}-${column}`}>
+                        <ConsentCheckbox
+                          type="checkbox"
+                          name={`attendanceStatus${statusIndex}`}
+                          aria-label={`${statusIndex}번 출석`}
+                        />
+                      </AttendanceCheckboxCell>
+                    );
+                  })}
                 </AttendanceGrid>
               ))}
             </AttendanceBlocks>
@@ -753,6 +811,21 @@ const AttendanceInput = styled.input`
   @media (min-width: 120rem) {
     min-height: 3.875rem;
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const AttendanceCheckboxCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 2.75rem;
+  border-right: 1px solid #c0c0c0;
+  border-bottom: 1px solid #c0c0c0;
+  background-color: transparent;
+
+  @media (min-width: 120rem) {
+    min-height: 3.875rem;
   }
 `;
 

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
@@ -9,6 +9,7 @@ import type {
   LessonJournalRequestDto,
 } from "@/api/dailySchedule/dailySchedule.dto";
 import { createJournal, getDailyScheduleDetail } from "@/api/dailySchedule/dailySchedule.api";
+import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
 import { getCurrentUser } from "@/api/user/user.api";
 import { formatPhone } from "@/lib/googleSheet/classJournal/classJournalSheetPayload";
@@ -23,9 +24,28 @@ const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
 /** TODO: users/me classroomId 필드가 고정 될 때까지 테스트를 위해 기본값으로 설정 */
 const CLASS_JOURNAL_FORM_DEFAULTS = {
   classroomId: 1,
+  classroomName: "벚꽃반",
   residentRegistrationNumberPrefix: "900101",
   phoneNumber: "01012345678",
 } as const;
+
+function buildAttendanceNameKey(rowIndex: number, column: number) {
+  return `${rowIndex}-${column}`;
+}
+
+function resolveClassroomName(
+  classroomId: number,
+  students: StudentListResponseDto,
+  detailClassroomName?: string,
+) {
+  if (detailClassroomName?.trim()) return detailClassroomName;
+
+  const fromStudents = students
+    .flatMap((student) => student.classrooms ?? [])
+    .find((classroom) => classroom.id === classroomId)?.name;
+
+  return fromStudents?.trim() ? fromStudents : CLASS_JOURNAL_FORM_DEFAULTS.classroomName;
+}
 
 function trimTrailingClockSeconds(time?: string) {
   if (!time) return "";
@@ -71,14 +91,14 @@ export default function ClassJournalCreatePage() {
   const router = useRouter();
   const todayIsoDate = useMemo(() => getKstTodayIsoDate(), []);
   const [lessonDateText, setLessonDateText] = useState("");
-  const [classroomId, setClassroomId] = useState(String(CLASS_JOURNAL_FORM_DEFAULTS.classroomId));
-  const [classroomName, setClassroomName] = useState("");
-  const [birthPrefix, setBirthPrefix] = useState(
-    CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix,
-  );
-  const [phoneNumber, setPhoneNumber] = useState(CLASS_JOURNAL_FORM_DEFAULTS.phoneNumber);
-  const [activityTime, setActivityTime] = useState("");
-  const [attendanceRowCount, setAttendanceRowCount] = useState(1);
+  const [classroomNameText, setClassroomNameText] = useState("");
+  const [activityTimeText, setActivityTimeText] = useState("");
+  const [attendanceNameOverrides, setAttendanceNameOverrides] = useState<Record<string, string>>({});
+  const [additionalAttendanceRows, setAdditionalAttendanceRows] = useState(0);
+
+  const classroomId = String(CLASS_JOURNAL_FORM_DEFAULTS.classroomId);
+  const birthPrefix = CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix;
+  const phoneNumber = CLASS_JOURNAL_FORM_DEFAULTS.phoneNumber;
 
   const currentUserQuery = useQuery({
     queryKey: queryKeys.user.me(),
@@ -106,7 +126,12 @@ export default function ClassJournalCreatePage() {
     retry: false,
   });
 
-  const enrolledStudents = studentsQuery.data ?? [];
+  const enrolledStudents = useMemo(() => {
+    const students = studentsQuery.data ?? [];
+    return students.filter((student) =>
+      student.classrooms?.some((classroom) => classroom.id === enrollmentClassroomId),
+    );
+  }, [studentsQuery.data, enrollmentClassroomId]);
 
   const dailyScheduleDetailQuery = useQuery({
     queryKey: ["daily-schedules", "detail", enrollmentClassroomId, todayIsoDate] as const,
@@ -139,21 +164,53 @@ export default function ClassJournalCreatePage() {
 
   const writerName = scheduleDetail?.teacherName ?? currentUser?.name ?? "";
 
-  useEffect(() => {
-    const detail = dailyScheduleDetailQuery.data;
-    if (!detail) return;
+  const resolvedLessonDate = useMemo(() => {
+    if (!scheduleDetail?.lessonDate) return "";
+    return formatUtcToKstShortDate(`${scheduleDetail.lessonDate}T00:00:00`);
+  }, [scheduleDetail?.lessonDate]);
 
-    setLessonDateText(formatUtcToKstShortDate(`${detail.lessonDate}T00:00:00`));
-    setClassroomName(detail.classroomName ?? "");
-    setActivityTime(formatLessonsActivityTime(detail.lessons));
-  }, [dailyScheduleDetailQuery.data]);
+  const resolvedActivityTime = useMemo(
+    () => formatLessonsActivityTime(scheduleDetail?.lessons),
+    [scheduleDetail?.lessons],
+  );
 
-  useEffect(() => {
-    if (enrolledStudents.length === 0) return;
+  const resolvedClassroomName = useMemo(
+    () =>
+      resolveClassroomName(
+        enrollmentClassroomId,
+        enrolledStudents,
+        scheduleDetail?.classroomName,
+      ),
+    [enrollmentClassroomId, enrolledStudents, scheduleDetail?.classroomName],
+  );
 
-    const requiredRows = Math.ceil(enrolledStudents.length / attendanceColumns.length);
-    setAttendanceRowCount((current) => Math.max(current, requiredRows));
-  }, [enrolledStudents.length]);
+  const lessonDateValue = lessonDateText || resolvedLessonDate;
+  const classroomNameValue = classroomNameText || resolvedClassroomName;
+  const activityTimeValue = activityTimeText || resolvedActivityTime;
+
+  const apiAttendanceNames = useMemo(() => {
+    const names: Record<string, string> = {};
+
+    enrolledStudents.forEach((student, index) => {
+      const rowIndex = Math.floor(index / attendanceColumns.length);
+      const column = index % attendanceColumns.length;
+      names[buildAttendanceNameKey(rowIndex, column)] = student.name ?? "";
+    });
+
+    return names;
+  }, [enrolledStudents]);
+
+  const minAttendanceRows = useMemo(
+    () => Math.max(1, Math.ceil(enrolledStudents.length / attendanceColumns.length)),
+    [enrolledStudents.length],
+  );
+
+  const attendanceRowCount = minAttendanceRows + additionalAttendanceRows;
+
+  const getAttendanceName = (nameKey: string) =>
+    nameKey in attendanceNameOverrides
+      ? attendanceNameOverrides[nameKey]
+      : (apiAttendanceNames[nameKey] ?? "");
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -162,8 +219,8 @@ export default function ClassJournalCreatePage() {
 
     const form = event.currentTarget;
     const formData = new FormData(form);
-    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateText.trim());
-    const parsedClassroomId = Number.parseInt(classroomId, 10);
+    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateValue.trim());
+    const parsedClassroomId = enrollmentClassroomId;
     const personalInfoConsent = formData.get("privacyConsent") === "on";
     const lessonJournals = buildLessonJournals(scheduleDetail?.lessons, formData);
 
@@ -261,8 +318,8 @@ export default function ClassJournalCreatePage() {
               name="classroomName"
               type="text"
               placeholder="장미반"
-              value={classroomName}
-              onChange={(event) => setClassroomName(event.target.value)}
+              value={classroomNameValue}
+              onChange={(event) => setClassroomNameText(event.target.value)}
             />
           </InfoField>
 
@@ -273,7 +330,7 @@ export default function ClassJournalCreatePage() {
               name="lessonDate"
               type="text"
               placeholder="00.00.00"
-              value={lessonDateText}
+              value={lessonDateValue}
               onChange={(event) => setLessonDateText(event.target.value)}
             />
           </InfoField>
@@ -285,8 +342,8 @@ export default function ClassJournalCreatePage() {
               name="activityTime"
               type="text"
               placeholder="14:00 - 15:00"
-              value={activityTime}
-              onChange={(event) => setActivityTime(event.target.value)}
+              value={activityTimeValue}
+              onChange={(event) => setActivityTimeText(event.target.value)}
             />
           </InfoField>
         </InfoGrid>
@@ -315,14 +372,20 @@ export default function ClassJournalCreatePage() {
                   aria-label={rowIndex === 0 ? "출석부" : `출석부 ${rowIndex + 1}`}
                 >
                   {attendanceColumns.map((column) => {
-                    const student = enrolledStudents[rowIndex * 10 + column];
+                    const nameKey = buildAttendanceNameKey(rowIndex, column);
 
                     return (
                       <AttendanceInput
-                        key={`student-${rowIndex}-${column}-${student?.id ?? "empty"}`}
+                        key={`student-${rowIndex}-${column}`}
                         name={`studentName${rowIndex * 10 + column + 1}`}
                         aria-label={`${rowIndex * 10 + column + 1}번 학생 이름`}
-                        defaultValue={student?.name ?? ""}
+                        value={getAttendanceName(nameKey)}
+                        onChange={(event) =>
+                          setAttendanceNameOverrides((current) => ({
+                            ...current,
+                            [nameKey]: event.target.value,
+                          }))
+                        }
                       />
                     );
                   })}
@@ -338,7 +401,7 @@ export default function ClassJournalCreatePage() {
             </AttendanceBlocks>
             <AddAttendanceButton
               type="button"
-              onClick={() => setAttendanceRowCount((count) => count + 1)}
+              onClick={() => setAdditionalAttendanceRows((count) => count + 1)}
             >
               출석부 추가하기
             </AddAttendanceButton>

--- a/lib/googleSheet/classAttendance/classAttendanceSheetPayload.ts
+++ b/lib/googleSheet/classAttendance/classAttendanceSheetPayload.ts
@@ -1,0 +1,48 @@
+import type { StudentListResponseDto } from "@/api/student/student.dto";
+import { parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
+
+const ATTENDANCE_COLUMNS = 10;
+
+export type ClassAttendanceSheetPayload = {
+  date: string;
+  className: string;
+  attendances: {
+    name: string;
+    status: string;
+  }[];
+};
+
+export function toAttendanceSheetDate(date: string) {
+  return parseKoreanShortDateToIsoDate(date) ?? date;
+}
+
+export function buildClassAttendanceSheetPayload(
+  formData: FormData,
+  students: StudentListResponseDto,
+  className: string,
+  date: string,
+): ClassAttendanceSheetPayload {
+  return {
+    date: toAttendanceSheetDate(date),
+    className,
+    attendances: students.flatMap((student, index) => {
+      if (typeof student.id !== "number") return [];
+
+      const rowIndex = Math.floor(index / ATTENDANCE_COLUMNS);
+      const column = index % ATTENDANCE_COLUMNS;
+      const slotIndex = rowIndex * ATTENDANCE_COLUMNS + column + 1;
+      const name = String(formData.get(`studentName${slotIndex}`) ?? student.name ?? "").trim();
+
+      if (!name) return [];
+
+      const isPresent = formData.get(`attendanceStatus${slotIndex}`) === "on";
+
+      return [
+        {
+          name,
+          status: isPresent ? "O" : "X",
+        },
+      ];
+    }),
+  };
+}

--- a/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
+++ b/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
@@ -1,23 +1,18 @@
+import type { ClassAttendanceSheetPayload } from "@/lib/googleSheet/classAttendance/classAttendanceSheetPayload";
+import {
+  isGoogleAppsScriptSuccess,
+  postToGoogleAppsScript,
+} from "@/lib/googleSheet/postToGoogleAppsScript";
+
 const GOOGLE_APPS_SCRIPT_URL =
   "https://script.google.com/macros/s/AKfycbxZ9VY6A9rXkNInZnXt_cSO6SVgkd196DV7_mfqeXJViUmFSVgSRfvM9tX9oOy63P-n7Q/exec";
 
-export async function sendClassAttendanceToGoogleSheet(payload: {
-  date: string;
-  className: string;
-  attendances: {
-    name: string;
-    status: string;
-  }[];
-}) {
-  const response = await fetch(GOOGLE_APPS_SCRIPT_URL, {
-    method: "POST",
-    redirect: "follow",
-    body: JSON.stringify(payload),
-  });
+export async function sendClassAttendanceToGoogleSheet(payload: ClassAttendanceSheetPayload) {
+  const data = await postToGoogleAppsScript(GOOGLE_APPS_SCRIPT_URL, payload);
 
-  if (!response.ok) {
-    throw new Error("출석 저장 실패");
+  if (!isGoogleAppsScriptSuccess(data)) {
+    throw new Error(data.message ?? "출석 시트 저장 실패");
   }
 
-  return response.json();
+  return data;
 }

--- a/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
+++ b/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet.ts
@@ -2,13 +2,15 @@ import type { ClassAttendanceSheetPayload } from "@/lib/googleSheet/classAttenda
 import {
   isGoogleAppsScriptSuccess,
   postToGoogleAppsScript,
+  requireGoogleAppsScriptUrl,
 } from "@/lib/googleSheet/postToGoogleAppsScript";
 
-const GOOGLE_APPS_SCRIPT_URL =
-  "https://script.google.com/macros/s/AKfycbxZ9VY6A9rXkNInZnXt_cSO6SVgkd196DV7_mfqeXJViUmFSVgSRfvM9tX9oOy63P-n7Q/exec";
-
 export async function sendClassAttendanceToGoogleSheet(payload: ClassAttendanceSheetPayload) {
-  const data = await postToGoogleAppsScript(GOOGLE_APPS_SCRIPT_URL, payload);
+  const url = requireGoogleAppsScriptUrl(
+    process.env.NEXT_PUBLIC_APPS_SCRIPT_CLASS_ATTENDANCE_SHEET_URL,
+    "출석",
+  );
+  const data = await postToGoogleAppsScript(url, payload);
 
   if (!isGoogleAppsScriptSuccess(data)) {
     throw new Error(data.message ?? "출석 시트 저장 실패");

--- a/lib/googleSheet/classJournal/classJournalSheetPayload.ts
+++ b/lib/googleSheet/classJournal/classJournalSheetPayload.ts
@@ -1,9 +1,11 @@
 import type { SendClassJournalToGoogleSheetPayload } from "@/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet";
+import { parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
 
 export function getDayLabel(dateValue: string) {
   if (!dateValue) return "";
 
-  const date = new Date(dateValue);
+  const isoDate = parseKoreanShortDateToIsoDate(dateValue) ?? dateValue;
+  const date = new Date(`${isoDate}T00:00:00`);
   if (Number.isNaN(date.getTime())) return "";
 
   return ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
@@ -23,14 +25,20 @@ export function formatPhone(value: string) {
 export function buildSendClassNotePayloadFromFormData(
   formData: FormData,
 ): SendClassJournalToGoogleSheetPayload {
-  const activityDate = String(formData.get("activityDate") ?? "").trim();
+  return buildClassJournalSheetPayloadFromFormData(formData);
+}
+
+export function buildClassJournalSheetPayloadFromFormData(
+  formData: FormData,
+): SendClassJournalToGoogleSheetPayload {
+  const activityDate = String(formData.get("lessonDate") ?? "").trim();
 
   return {
     name: String(formData.get("writer") ?? "").trim(),
     birth: String(formData.get("birthPrefix") ?? "").trim(),
     phone: String(formData.get("phone") ?? "").trim(),
-    volunteerNote: String(formData.get("className") ?? "").trim(),
-    agree: formData.get("privacyConsent") ? "동의" : "미동의",
+    volunteerNote: String(formData.get("classroomName") ?? "").trim(),
+    agree: formData.get("privacyConsent") === "on" ? "동의" : "미동의",
     date: activityDate,
     time: String(formData.get("activityTime") ?? "").trim(),
     day: getDayLabel(activityDate),

--- a/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
+++ b/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
@@ -1,6 +1,7 @@
 import {
   isGoogleAppsScriptSuccess,
   postToGoogleAppsScript,
+  requireGoogleAppsScriptUrl,
 } from "@/lib/googleSheet/postToGoogleAppsScript";
 
 export type SendClassJournalToGoogleSheetPayload = {
@@ -17,11 +18,12 @@ export type SendClassJournalToGoogleSheetPayload = {
   period3: string;
 };
 
-const GOOGLE_APPS_SCRIPT_URL =
-  "https://script.google.com/macros/s/AKfycbxAQTwUuRT6X7Hysjhxnx1rp_Env0P-0xPIVuoUXjJtP-EZruBJOEEqDxXbRVpJkxpxFg/exec";
-
 export async function sendClassJournalToGoogleSheet(payload: SendClassJournalToGoogleSheetPayload) {
-  const data = await postToGoogleAppsScript(GOOGLE_APPS_SCRIPT_URL, payload);
+  const url = requireGoogleAppsScriptUrl(
+    process.env.NEXT_PUBLIC_APPS_SCRIPT_CLASS_JOURNAL_SHEET_URL,
+    "수업 일지",
+  );
+  const data = await postToGoogleAppsScript(url, payload);
 
   if (!isGoogleAppsScriptSuccess(data)) {
     throw new Error(data.message ?? "구글 시트 저장 실패");

--- a/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
+++ b/lib/googleSheet/classJournal/sendClassJournalToGoogleSheet.ts
@@ -1,3 +1,8 @@
+import {
+  isGoogleAppsScriptSuccess,
+  postToGoogleAppsScript,
+} from "@/lib/googleSheet/postToGoogleAppsScript";
+
 export type SendClassJournalToGoogleSheetPayload = {
   name: string;
   birth: string;
@@ -16,26 +21,9 @@ const GOOGLE_APPS_SCRIPT_URL =
   "https://script.google.com/macros/s/AKfycbxAQTwUuRT6X7Hysjhxnx1rp_Env0P-0xPIVuoUXjJtP-EZruBJOEEqDxXbRVpJkxpxFg/exec";
 
 export async function sendClassJournalToGoogleSheet(payload: SendClassJournalToGoogleSheetPayload) {
-  const res = await fetch(GOOGLE_APPS_SCRIPT_URL, {
-    method: "POST",
-    redirect: "follow",
-    body: JSON.stringify(payload),
-  });
+  const data = await postToGoogleAppsScript(GOOGLE_APPS_SCRIPT_URL, payload);
 
-  if (!res.ok) {
-    throw new Error(`요청 실패: ${res.status}`);
-  }
-
-  const text = await res.text();
-
-  let data;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    throw new Error("응답이 JSON이 아닙니다");
-  }
-
-  if (!data.success) {
+  if (!isGoogleAppsScriptSuccess(data)) {
     throw new Error(data.message ?? "구글 시트 저장 실패");
   }
 

--- a/lib/googleSheet/postToGoogleAppsScript.ts
+++ b/lib/googleSheet/postToGoogleAppsScript.ts
@@ -4,10 +4,14 @@ type GoogleAppsScriptResponse = {
   message?: string;
 };
 
-/**
- * GAS 웹앱은 application/json 시 CORS preflight(OPTIONS)에서 405가 날 수 있어
- * text/plain으로 JSON 문자열을 보낸다. doPost의 JSON.parse(e.postData.contents)는 동일하게 동작한다.
- */
+export function requireGoogleAppsScriptUrl(url: string | undefined, label: string) {
+  const trimmed = url?.trim();
+  if (!trimmed) {
+    throw new Error(`${label} Apps Script URL이 설정되지 않았습니다.`);
+  }
+  return trimmed;
+}
+
 export async function postToGoogleAppsScript(
   url: string,
   payload: Record<string, unknown>,

--- a/lib/googleSheet/postToGoogleAppsScript.ts
+++ b/lib/googleSheet/postToGoogleAppsScript.ts
@@ -1,0 +1,37 @@
+type GoogleAppsScriptResponse = {
+  ok?: boolean;
+  success?: boolean;
+  message?: string;
+};
+
+/**
+ * GAS 웹앱은 application/json 시 CORS preflight(OPTIONS)에서 405가 날 수 있어
+ * text/plain으로 JSON 문자열을 보낸다. doPost의 JSON.parse(e.postData.contents)는 동일하게 동작한다.
+ */
+export async function postToGoogleAppsScript(
+  url: string,
+  payload: Record<string, unknown>,
+): Promise<GoogleAppsScriptResponse> {
+  const response = await fetch(url, {
+    method: "POST",
+    redirect: "follow",
+    headers: { "Content-Type": "text/plain;charset=utf-8" },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`Apps Script 요청 실패: ${response.status}`);
+  }
+
+  try {
+    return JSON.parse(text) as GoogleAppsScriptResponse;
+  } catch {
+    throw new Error("Apps Script 응답이 JSON이 아닙니다");
+  }
+}
+
+export function isGoogleAppsScriptSuccess(data: GoogleAppsScriptResponse) {
+  return Boolean(data.ok ?? data.success);
+}

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -22,6 +22,10 @@ export const queryKeys = {
   classrooms: {
     list: () => ["classrooms", "list"] as const,
   },
+  students: {
+    list: (params?: { name?: string; status?: string; classroomId?: number }) =>
+      ["students", "list", params ?? {}] as const,
+  },
   requests: {
     lessonExchangeList: () => ["lesson-exchange-requests"] as const,
     lessonExchangeDetail: (requestId: number) => ["lesson-exchange-request", requestId] as const,

--- a/mocks/handlers/student.handlers.ts
+++ b/mocks/handlers/student.handlers.ts
@@ -2,19 +2,23 @@ import { HttpResponse, http, type RequestHandler } from "msw";
 
 import { API_BASE_URL, REFRESHED_ACCESS_TOKEN, VALID_ACCESS_TOKEN } from "./auth.handlers";
 
-export const STUDENT_LIST_RESPONSE = {
-  content: [{ id: 1, name: "Kim Student", phoneNumber: "010-1111-2222", status: "ENROLLED" }],
-  page: 0,
-  size: 10,
-  totalElements: 1,
-  totalPages: 1,
-};
+export const STUDENT_LIST_RESPONSE = [
+  {
+    id: 1,
+    name: "Kim Student",
+    phoneNumber: "010-1111-2222",
+    description: "Middle school student",
+    classrooms: [{ id: 1, name: "벚꽃반" }],
+    status: "ENROLLED",
+  },
+];
 
 export const STUDENT_DETAIL_RESPONSE = {
   id: 1,
   name: "Kim Student",
   phoneNumber: "010-1111-2222",
   description: "Middle school student",
+  classrooms: [{ id: 1, name: "벚꽃반" }],
   status: "ENROLLED",
 };
 
@@ -32,16 +36,38 @@ export const studentHandlers: RequestHandler[] = [
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    return HttpResponse.json(STUDENT_LIST_RESPONSE);
+    const url = new URL(request.url);
+    const classroomId = url.searchParams.get("classroomId");
+    const status = url.searchParams.get("status");
+
+    let students = [...STUDENT_LIST_RESPONSE];
+
+    if (classroomId) {
+      const parsedClassroomId = Number(classroomId);
+      students = students.filter((student) =>
+        student.classrooms.some((classroom) => classroom.id === parsedClassroomId),
+      );
+    }
+
+    if (status) {
+      students = students.filter((student) => student.status === status);
+    }
+
+    return HttpResponse.json(students);
   }),
   http.post(`${API_BASE_URL}/api/v1/students`, async ({ request }) => {
     if (!hasValidAuthorization(request)) {
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    const body = (await request.json()) as { name?: string; phoneNumber?: string; description?: string };
+    const body = (await request.json()) as {
+      name?: string;
+      phoneNumber?: string;
+      description?: string;
+      classroomId?: number;
+    };
 
-    if (!body.name) {
+    if (!body.name || !body.classroomId) {
       return HttpResponse.json({ message: "Invalid student payload" }, { status: 400 });
     }
 
@@ -50,6 +76,7 @@ export const studentHandlers: RequestHandler[] = [
       name: body.name,
       phoneNumber: body.phoneNumber,
       description: body.description,
+      classrooms: [{ id: body.classroomId, name: "벚꽃반" }],
       status: "ENROLLED",
     });
   }),


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 수업 일지 작성 페이지에 학생 출석 연동을 추가하고, 학생 API 명세 변경을 반영했습니다. 
- 출석부 UI를 개선하고 DTO 변경에 따른 Google Apps Script(수업 일지·출석) 연동을 수정했습니다.

- 학생 API `GET /api/v1/students`
    - 응답을 배열 + classrooms: { id, name }[] 구조로 정리 (classroomId / classroomName 제거)
    - MSW mock·테스트를 명세에 맞게 수정
    - 연락망(useStudentContactSection)을 classrooms[] 기준 그룹핑으로 변경
  
- 수업 일지 작성 출석부 `ClassJournalCreatePage`
    - users/me classroom 필드 없을 경우를 대비해 임시 값 하드코딩 (classroomId, 주민번호 앞자리, 연락처, 반 이름)
    - getStudents({ classroomId, status: "ENROLLED" })로 출석부 이름 행 자동 채움
    - 출석 하단 행: 정보 제공 동의와 동일 스타일 체크박스 (체크 PRESENT / 미체크 ABSENT)
    - 제출 직후 상세 출석 표시: PATCH 응답으로 React Query 캐시 갱신
    - 폼/API 동기화: useEffect setState 대신 useMemo + override 패턴 (lint 대응)

[수업 일지 작성 페이지 출석부]
<img width="815" height="200" alt="스크린샷 2026-05-25 오전 1 47 21" src="https://github.com/user-attachments/assets/62bd9302-85ad-4af4-b4b5-87f93548153e" />

[수업 일지 상세 페이지 출석부]
<img width="819" height="577" alt="스크린샷 2026-05-25 오전 1 48 06" src="https://github.com/user-attachments/assets/866e9d70-b5ff-4e43-88f3-332c05d9b70d" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #85

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
