### PR TITLE
[FEAT] 관리자 페이지 수업 섹션 구현 

### DIFF
--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -13,6 +13,7 @@ import { AdminClassroomsSection } from "@/components/admin/classes/AdminClassroo
 import { AdminDepartmentsSection } from "@/components/admin/departments/AdminDepartmentsSection";
 import { AdminPostsSection } from "@/components/admin/posts/AdminPostsSection";
 import { AdminPurchasesSection } from "@/components/admin/purchase-requests/AdminPurchasesSection";
+import { AdminLessonManagementSection } from "@/components/admin/lesson-management/AdminLessonManagementSection";
 import { AdminUsersSection } from "@/components/admin/users/AdminUsersSection";
 import type {
   AdminMenu,
@@ -87,6 +88,7 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "users", label: "사용자" },
   { key: "departments", label: "부서" },
   { key: "classrooms", label: "분반" },
+  { key: "lessons", label: "수업" },
   { key: "channels", label: "채널" },
   { key: "posts", label: "게시글" },
   { key: "purchases", label: "구매 요청" },
@@ -915,6 +917,7 @@ export default function AdminDashboardPage() {
     departments:
       "부서 목록과 상세 정보를 조회하고 부서 생성/수정/삭제, 소속 사용자와 권한 정보를 확인합니다.",
     classrooms: "분반 목록과 상세 정보를 조회하고 분반 생성/수정/삭제 및 이름 검색을 제공합니다.",
+    lessons: "수업 목록을 조회하고 새 수업을 생성합니다.",
     purchases: "구매 요청 작성, 목록/상세 조회, 승인/반려/결재 확인/삭제 처리를 제공합니다.",
   }[activeMenu];
 
@@ -1071,6 +1074,7 @@ export default function AdminDashboardPage() {
               emptyClassroomForm={emptyClassroomForm}
             />
           ) : null}
+          {activeMenu === "lessons" ? <AdminLessonManagementSection /> : null}
           {activeMenu === "purchases" ? (
             <AdminPurchasesSection
               classrooms={classrooms}

--- a/components/admin/AdminDashboardSectionParts.tsx
+++ b/components/admin/AdminDashboardSectionParts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
@@ -339,6 +339,16 @@ export const CheckLabel = styled.label`
   font-weight: 800;
 `;
 
+const inputFocusStyle = css`
+  outline: none;
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: ${colors.point};
+  }
+`;
+
 export const TextInput = styled.input`
   width: 100%;
   min-height: 2.375rem;
@@ -347,6 +357,7 @@ export const TextInput = styled.input`
   padding: 0 ${spacing.space12};
   font-family: inherit;
   font-size: ${typography.fontSize14};
+  ${inputFocusStyle}
 `;
 
 export const TextArea = styled.textarea`
@@ -358,6 +369,7 @@ export const TextArea = styled.textarea`
   font-family: inherit;
   font-size: ${typography.fontSize14};
   resize: vertical;
+  ${inputFocusStyle}
 `;
 
 export const Select = styled.select`
@@ -369,6 +381,7 @@ export const Select = styled.select`
   background-color: ${colors.white};
   font-family: inherit;
   font-size: ${typography.fontSize14};
+  ${inputFocusStyle}
 `;
 
 export const ButtonRow = styled.div`

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -3,7 +3,15 @@ import type { ClassroomType } from "@/api/classroom/classroom.dto";
 import type { PostStatus } from "@/api/post/post.dto";
 import type { UserRole } from "@/api/user/user.dto";
 
-export type AdminMenu = "dashboard" | "users" | "channels" | "posts" | "departments" | "classrooms" | "purchases";
+export type AdminMenu =
+  | "dashboard"
+  | "users"
+  | "channels"
+  | "posts"
+  | "departments"
+  | "classrooms"
+  | "lessons"
+  | "purchases";
 
 export type UserFormState = {
   email: string;

--- a/components/admin/lesson-management/AdminLessonCreateForm.tsx
+++ b/components/admin/lesson-management/AdminLessonCreateForm.tsx
@@ -30,6 +30,14 @@ import {
 } from "@/components/admin/lesson-management/lessonCreateError";
 import { colors, spacing, typography } from "@/styles/tokens";
 
+const LessonFormGrid = styled(FormGrid)`
+  input,
+  select,
+  ${StatePanel} {
+    font-weight: 500;
+  }
+`;
+
 const SubjectGrid = styled(ActionGrid)`
   margin-top: ${spacing.space4};
 `;
@@ -70,13 +78,6 @@ const TeacherSelect = styled(Select)`
   appearance: none;
   -webkit-appearance: none;
   padding-right: 2.25rem;
-  outline: none;
-  transition: border-color 0.2s ease;
-
-  &:focus {
-    outline: none;
-    border-color: ${colors.point};
-  }
 `;
 
 const TeacherSelectChevron = styled(IconChevronDown)`
@@ -169,7 +170,7 @@ export function AdminLessonCreateForm() {
         과목, 담당 교사, 일자, 교시, 시간을 입력해 새 수업을 등록합니다.
       </SectionDescription>
 
-      <FormGrid
+      <LessonFormGrid
         onSubmit={(event) => {
           event.preventDefault();
           submitLesson();
@@ -308,7 +309,7 @@ export function AdminLessonCreateForm() {
             {isSubmitting ? "생성 중..." : "수업 생성"}
           </PrimaryButton>
         </ButtonRow>
-      </FormGrid>
+      </LessonFormGrid>
     </>
   );
 }

--- a/components/admin/lesson-management/AdminLessonCreateForm.tsx
+++ b/components/admin/lesson-management/AdminLessonCreateForm.tsx
@@ -1,21 +1,17 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import styled from "styled-components";
 import { IconChevronDown } from "@tabler/icons-react";
 import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import {
-  ActionCardButton,
-  ActionGrid,
-  ActionTitle,
-  ButtonRow,
-  DataState,
   FormGrid,
   InlineStatus,
   Label,
   PrimaryButton,
   SectionDescription,
   Select,
-  StatePanel,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
 import {
@@ -28,42 +24,147 @@ import {
   formatLessonTimeForDisplay,
   snapLessonTimeToFiveMinutes,
 } from "@/components/admin/lesson-management/lessonCreateError";
-import { colors, spacing, typography } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const LessonFormGrid = styled(FormGrid)`
   input,
-  select,
-  ${StatePanel} {
+  select {
     font-weight: 500;
   }
 `;
 
-const SubjectGrid = styled(ActionGrid)`
-  margin-top: ${spacing.space4};
+const CreateTopRow = styled.div`
+  display: grid;
+  grid-template-columns: 11rem minmax(0, 1fr);
+  gap: ${spacing.space12};
+  align-items: start;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+  }
 `;
 
-const SubjectOption = styled(ActionCardButton)<{ $selected: boolean }>`
-  border-color: ${({ $selected }) => ($selected ? colors.point : "#e1e5e3")};
-  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : colors.white)};
+const TeacherField = styled(Label)`
+  width: 11rem;
+  max-width: 100%;
 `;
 
-const SubjectMeta = styled.p`
-  margin: ${spacing.space4} 0 0;
+const SubjectFieldBox = styled.div`
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  height: 4.25rem;
+  padding: ${spacing.space4};
+  box-sizing: border-box;
+  border: 1px solid #e6e9e7;
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+`;
+
+const SubjectInner = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space4};
+  text-align: center;
+`;
+
+const SubjectInnerText = styled.p`
+  margin: 0;
   color: #64706c;
-  font-size: ${typography.fontSize13};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
   line-height: ${typography.lineHeight130};
 `;
 
-const TimeRow = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: ${spacing.space12};
+const SUBJECT_BLOCK_WIDTH = "9rem";
+
+const SubjectGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${spacing.space4};
+  width: 100%;
+  height: 100%;
+  align-items: stretch;
 `;
 
-const TimeField = styled(Label)`
-  justify-items: stretch;
+const SubjectOption = styled.button<{ $selected: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: ${spacing.space4};
+  width: ${SUBJECT_BLOCK_WIDTH};
+  flex-shrink: 0;
+  height: 100%;
+  min-height: 0;
+  margin: 0;
+  padding: ${spacing.space8} ${spacing.space12};
+  box-sizing: border-box;
+  border: 1px solid ${({ $selected }) => ($selected ? colors.point : "#e1e5e3")};
+  border-radius: 0.5rem;
+  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : colors.white)};
+  font-family: inherit;
   text-align: left;
+  cursor: pointer;
+
+  &:not(:disabled):hover {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    cursor: default;
+  }
 `;
+
+const SubjectOptionName = styled.span<{ $selected?: boolean }>`
+  color: ${({ $selected }) => ($selected ? colors.text : "#64706c")};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+`;
+
+const SubjectOptionMeta = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+`;
+
+const CreateBottomRow = styled.div`
+  display: grid;
+  grid-template-columns:
+    minmax(8rem, 1fr)
+    minmax(5rem, 0.6fr)
+    minmax(7rem, 0.8fr)
+    minmax(7rem, 0.8fr)
+    auto;
+  gap: ${spacing.space12};
+  align-items: end;
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+`;
+
+const SubmitField = styled.div`
+  display: flex;
+  align-items: flex-end;
+  min-height: 2.375rem;
+`;
+
+const SubjectPlaceholder = ({
+  children,
+  ...props
+}: ComponentProps<typeof SubjectInnerText>) => (
+  <SubjectInner>
+    <SubjectInnerText {...props}>{children}</SubjectInnerText>
+  </SubjectInner>
+);
+
+const SubjectLoadingWrap = styled(SubjectInner)``;
 
 const TimeInput = styled(TextInput)`
   width: 100%;
@@ -101,7 +202,20 @@ function SubjectPicker({
   onSelectSubject: (subjectId: number) => void;
 }) {
   if (subjects.length === 0) {
-    return <StatePanel>등록된 과목이 없습니다.</StatePanel>;
+    return <SubjectPlaceholder>등록된 과목이 없습니다.</SubjectPlaceholder>;
+  }
+
+  if (subjects.length === 1) {
+    const subject = subjects[0];
+    const subjectId = getSubjectId(subject);
+    const isSelected = subjectId != null && selectedSubjectId === subjectId;
+
+    return (
+      <SubjectOption type="button" $selected={isSelected} disabled>
+        <SubjectOptionName $selected={isSelected}>{subject.name ?? "—"}</SubjectOptionName>
+        {subject.classroomName ? <SubjectOptionMeta>{subject.classroomName}</SubjectOptionMeta> : null}
+      </SubjectOption>
+    );
   }
 
   return (
@@ -111,7 +225,6 @@ function SubjectPicker({
         if (subjectId == null) return null;
 
         const isSelected = selectedSubjectId === subjectId;
-        const isSingle = subjects.length === 1;
 
         return (
           <SubjectOption
@@ -119,15 +232,74 @@ function SubjectPicker({
             type="button"
             $selected={isSelected}
             aria-pressed={isSelected}
-            disabled={isSingle}
             onClick={() => onSelectSubject(subjectId)}
           >
-            <ActionTitle $accent={isSelected}>{subject.name ?? "—"}</ActionTitle>
-            {subject.classroomName ? <SubjectMeta>{subject.classroomName}</SubjectMeta> : null}
+            <SubjectOptionName $selected={isSelected}>{subject.name ?? "—"}</SubjectOptionName>
+            {subject.classroomName ? (
+              <SubjectOptionMeta>{subject.classroomName}</SubjectOptionMeta>
+            ) : null}
           </SubjectOption>
         );
       })}
     </SubjectGrid>
+  );
+}
+
+function renderSubjectContent({
+  selectedTeacherId,
+  classroomId,
+  teacherDetailQuery,
+  subjectsQuery,
+  subjects,
+  selectedSubjectId,
+  onSelectSubject,
+}: {
+  selectedTeacherId: number | null;
+  classroomId: number | null | undefined;
+  teacherDetailQuery: { isLoading: boolean; isError: boolean };
+  subjectsQuery: { isLoading: boolean; isError: boolean };
+  subjects: SubjectDetailResponseDto[];
+  selectedSubjectId: number | null;
+  onSelectSubject: (subjectId: number) => void;
+}) {
+  if (!selectedTeacherId) {
+    return <SubjectPlaceholder>담당 교사를 먼저 선택해 주세요.</SubjectPlaceholder>;
+  }
+
+  if (classroomId == null) {
+    if (teacherDetailQuery.isLoading) {
+      return (
+        <SubjectLoadingWrap>
+          <LoadingSpinner label="교사 정보를 불러오는 중" />
+        </SubjectLoadingWrap>
+      );
+    }
+
+    if (teacherDetailQuery.isError) {
+      return <SubjectPlaceholder role="alert">교사 정보를 불러오지 못했습니다.</SubjectPlaceholder>;
+    }
+
+    return <SubjectPlaceholder>선택한 교사에 연결된 분반이 없습니다.</SubjectPlaceholder>;
+  }
+
+  if (subjectsQuery.isLoading) {
+    return (
+      <SubjectLoadingWrap>
+        <LoadingSpinner label="과목 목록 불러오는 중" />
+      </SubjectLoadingWrap>
+    );
+  }
+
+  if (subjectsQuery.isError) {
+    return <SubjectPlaceholder role="alert">과목 목록을 불러오지 못했습니다.</SubjectPlaceholder>;
+  }
+
+  return (
+    <SubjectPicker
+      subjects={subjects}
+      selectedSubjectId={selectedSubjectId}
+      onSelectSubject={onSelectSubject}
+    />
   );
 }
 
@@ -167,7 +339,7 @@ export function AdminLessonCreateForm() {
   return (
     <>
       <SectionDescription>
-        과목, 담당 교사, 일자, 교시, 시간을 입력해 새 수업을 등록합니다.
+        담당 교사, 과목, 일자, 교시, 시간을 입력해 새 수업을 등록합니다.
       </SectionDescription>
 
       <LessonFormGrid
@@ -176,100 +348,88 @@ export function AdminLessonCreateForm() {
           submitLesson();
         }}
       >
-        <Label>
-          담당 교사
-          <DataState
-            isLoading={volunteersQuery.isLoading}
-            isError={volunteersQuery.isError}
-            isEmpty={volunteers.length === 0}
-            loadingLabel="교원 목록 불러오는 중"
-            errorLabel="교원 목록을 불러오지 못했습니다."
-            emptyLabel="등록된 교원이 없습니다."
-          >
-            <TeacherSelectWrap>
-              <TeacherSelect
-                value={selectedTeacherId ?? ""}
-                onChange={(event) => {
-                  clearSubmitError();
-                  const value = Number(event.target.value);
-                  selectTeacher(Number.isInteger(value) && value > 0 ? value : null);
-                }}
-              >
-                <option value="">교원 선택</option>
-                {volunteers.map((teacher) => (
-                  <option key={teacher.id} value={teacher.id}>
-                    {getTeacherLabel(teacher)}
-                  </option>
-                ))}
-              </TeacherSelect>
-              <TeacherSelectChevron aria-hidden="true" />
-            </TeacherSelectWrap>
-          </DataState>
-        </Label>
-
-        <Label>
-          과목
-          {!selectedTeacherId ? (
-            <StatePanel>담당 교사를 먼저 선택해 주세요.</StatePanel>
-          ) : classroomId == null ? (
-            teacherDetailQuery.isLoading ? (
-              <InlineStatus>교사 정보를 불러오는 중입니다.</InlineStatus>
-            ) : teacherDetailQuery.isError ? (
-              <StatePanel role="alert">교사 정보를 불러오지 못했습니다.</StatePanel>
+        <CreateTopRow>
+          <TeacherField>
+            담당 교사
+            {volunteersQuery.isLoading ? (
+              <TeacherSelectWrap>
+                <TeacherSelect disabled value="">
+                  <option value="">불러오는 중...</option>
+                </TeacherSelect>
+              </TeacherSelectWrap>
+            ) : volunteersQuery.isError ? (
+              <InlineStatus role="alert">교원 목록을 불러오지 못했습니다.</InlineStatus>
             ) : (
-              <StatePanel>선택한 교사에 연결된 분반이 없습니다.</StatePanel>
-            )
-          ) : (
-            <DataState
-              isLoading={subjectsQuery.isLoading}
-              isError={subjectsQuery.isError}
-              isEmpty={subjects.length === 0}
-              loadingLabel="과목 목록 불러오는 중"
-              errorLabel="과목 목록을 불러오지 못했습니다."
-              emptyLabel="해당 분반에 등록된 과목이 없습니다."
-            >
-              <SubjectPicker
-                subjects={subjects}
-                selectedSubjectId={selectedSubjectId}
-                onSelectSubject={(subjectId) => {
+              <TeacherSelectWrap>
+                <TeacherSelect
+                  value={selectedTeacherId ?? ""}
+                  onChange={(event) => {
+                    clearSubmitError();
+                    const value = Number(event.target.value);
+                    selectTeacher(Number.isInteger(value) && value > 0 ? value : null);
+                  }}
+                >
+                  <option value="">{volunteers.length === 0 ? "등록된 교원 없음" : "교원 선택"}</option>
+                  {volunteers.map((teacher) => (
+                    <option key={teacher.id} value={teacher.id}>
+                      {getTeacherLabel(teacher)}
+                    </option>
+                  ))}
+                </TeacherSelect>
+                <TeacherSelectChevron aria-hidden="true" />
+              </TeacherSelectWrap>
+            )}
+          </TeacherField>
+
+          <Label>
+            과목
+            <SubjectFieldBox>
+              {renderSubjectContent({
+                selectedTeacherId,
+                classroomId,
+                teacherDetailQuery,
+                subjectsQuery,
+                subjects,
+                selectedSubjectId,
+                onSelectSubject: (subjectId) => {
                   clearSubmitError();
                   setSelectedSubjectId(subjectId);
-                }}
-              />
-            </DataState>
-          )}
-        </Label>
+                },
+              })}
+            </SubjectFieldBox>
+          </Label>
+        </CreateTopRow>
 
-        <Label>
-          수업 일자
-          <TextInput
-            type="date"
-            value={date}
-            onChange={(event) => {
-              clearSubmitError();
-              setDate(event.target.value);
-            }}
-            required
-          />
-        </Label>
+        <CreateBottomRow>
+          <Label>
+            수업 일자
+            <TextInput
+              type="date"
+              value={date}
+              onChange={(event) => {
+                clearSubmitError();
+                setDate(event.target.value);
+              }}
+              required
+            />
+          </Label>
 
-        <Label>
-          교시
-          <TextInput
-            type="number"
-            min={1}
-            step={1}
-            value={period}
-            onChange={(event) => {
-              clearSubmitError();
-              setPeriod(event.target.value);
-            }}
-            required
-          />
-        </Label>
+          <Label>
+            교시
+            <TextInput
+              type="number"
+              min={1}
+              step={1}
+              value={period}
+              onChange={(event) => {
+                clearSubmitError();
+                setPeriod(event.target.value);
+              }}
+              required
+            />
+          </Label>
 
-        <TimeRow>
-          <TimeField>
+          <Label>
             시작 시간
             <TimeInput
               type="time"
@@ -283,9 +443,9 @@ export function AdminLessonCreateForm() {
               }}
               required
             />
-          </TimeField>
+          </Label>
 
-          <TimeField>
+          <Label>
             종료 시간
             <TimeInput
               type="time"
@@ -299,16 +459,16 @@ export function AdminLessonCreateForm() {
               }}
               required
             />
-          </TimeField>
-        </TimeRow>
+          </Label>
+
+          <SubmitField>
+            <PrimaryButton type="submit" disabled={!canSubmit}>
+              {isSubmitting ? "생성 중..." : "수업 생성"}
+            </PrimaryButton>
+          </SubmitField>
+        </CreateBottomRow>
 
         {submitError ? <InlineStatus role="alert">{submitError}</InlineStatus> : null}
-
-        <ButtonRow>
-          <PrimaryButton type="submit" disabled={!canSubmit}>
-            {isSubmitting ? "생성 중..." : "수업 생성"}
-          </PrimaryButton>
-        </ButtonRow>
       </LessonFormGrid>
     </>
   );

--- a/components/admin/lesson-management/AdminLessonCreateForm.tsx
+++ b/components/admin/lesson-management/AdminLessonCreateForm.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import styled from "styled-components";
+import { IconChevronDown } from "@tabler/icons-react";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import {
+  ActionCardButton,
+  ActionGrid,
+  ActionTitle,
+  ButtonRow,
+  DataState,
+  FormGrid,
+  InlineStatus,
+  Label,
+  PrimaryButton,
+  SectionDescription,
+  Select,
+  StatePanel,
+  TextInput,
+} from "@/components/admin/AdminDashboardSectionParts";
+import {
+  getSubjectId,
+  getTeacherLabel,
+  useLessonCreateOptions,
+} from "@/components/admin/lesson-management/useLessonCreateOptions";
+import { useLessonCreateSubmit } from "@/components/admin/lesson-management/useLessonCreateSubmit";
+import {
+  formatLessonTimeForDisplay,
+  snapLessonTimeToFiveMinutes,
+} from "@/components/admin/lesson-management/lessonCreateError";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+const SubjectGrid = styled(ActionGrid)`
+  margin-top: ${spacing.space4};
+`;
+
+const SubjectOption = styled(ActionCardButton)<{ $selected: boolean }>`
+  border-color: ${({ $selected }) => ($selected ? colors.point : "#e1e5e3")};
+  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : colors.white)};
+`;
+
+const SubjectMeta = styled.p`
+  margin: ${spacing.space4} 0 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;
+
+const TimeRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space12};
+`;
+
+const TimeField = styled(Label)`
+  justify-items: stretch;
+  text-align: left;
+`;
+
+const TimeInput = styled(TextInput)`
+  width: 100%;
+`;
+
+const TeacherSelectWrap = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const TeacherSelect = styled(Select)`
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 2.25rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: ${colors.point};
+  }
+`;
+
+const TeacherSelectChevron = styled(IconChevronDown)`
+  position: absolute;
+  top: 50%;
+  right: 0.875rem;
+  width: 1rem;
+  height: 1rem;
+  color: ${colors.muted};
+  pointer-events: none;
+  transform: translateY(-50%);
+`;
+
+function SubjectPicker({
+  subjects,
+  selectedSubjectId,
+  onSelectSubject,
+}: {
+  subjects: SubjectDetailResponseDto[];
+  selectedSubjectId: number | null;
+  onSelectSubject: (subjectId: number) => void;
+}) {
+  if (subjects.length === 0) {
+    return <StatePanel>등록된 과목이 없습니다.</StatePanel>;
+  }
+
+  return (
+    <SubjectGrid>
+      {subjects.map((subject) => {
+        const subjectId = getSubjectId(subject);
+        if (subjectId == null) return null;
+
+        const isSelected = selectedSubjectId === subjectId;
+        const isSingle = subjects.length === 1;
+
+        return (
+          <SubjectOption
+            key={subjectId}
+            type="button"
+            $selected={isSelected}
+            aria-pressed={isSelected}
+            disabled={isSingle}
+            onClick={() => onSelectSubject(subjectId)}
+          >
+            <ActionTitle $accent={isSelected}>{subject.name ?? "—"}</ActionTitle>
+            {subject.classroomName ? <SubjectMeta>{subject.classroomName}</SubjectMeta> : null}
+          </SubjectOption>
+        );
+      })}
+    </SubjectGrid>
+  );
+}
+
+export function AdminLessonCreateForm() {
+  const {
+    volunteers,
+    volunteersQuery,
+    selectedTeacherId,
+    selectTeacher,
+    teacherDetailQuery,
+    classroomId,
+    subjects,
+    subjectsQuery,
+    selectedSubjectId,
+    setSelectedSubjectId,
+  } = useLessonCreateOptions();
+
+  const {
+    date,
+    setDate,
+    period,
+    setPeriod,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    submitError,
+    canSubmit,
+    submitLesson,
+    clearSubmitError,
+    isSubmitting,
+  } = useLessonCreateSubmit({
+    teacherId: selectedTeacherId,
+    subjectId: selectedSubjectId,
+  });
+
+  return (
+    <>
+      <SectionDescription>
+        과목, 담당 교사, 일자, 교시, 시간을 입력해 새 수업을 등록합니다.
+      </SectionDescription>
+
+      <FormGrid
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitLesson();
+        }}
+      >
+        <Label>
+          담당 교사
+          <DataState
+            isLoading={volunteersQuery.isLoading}
+            isError={volunteersQuery.isError}
+            isEmpty={volunteers.length === 0}
+            loadingLabel="교원 목록 불러오는 중"
+            errorLabel="교원 목록을 불러오지 못했습니다."
+            emptyLabel="등록된 교원이 없습니다."
+          >
+            <TeacherSelectWrap>
+              <TeacherSelect
+                value={selectedTeacherId ?? ""}
+                onChange={(event) => {
+                  clearSubmitError();
+                  const value = Number(event.target.value);
+                  selectTeacher(Number.isInteger(value) && value > 0 ? value : null);
+                }}
+              >
+                <option value="">교원 선택</option>
+                {volunteers.map((teacher) => (
+                  <option key={teacher.id} value={teacher.id}>
+                    {getTeacherLabel(teacher)}
+                  </option>
+                ))}
+              </TeacherSelect>
+              <TeacherSelectChevron aria-hidden="true" />
+            </TeacherSelectWrap>
+          </DataState>
+        </Label>
+
+        <Label>
+          과목
+          {!selectedTeacherId ? (
+            <StatePanel>담당 교사를 먼저 선택해 주세요.</StatePanel>
+          ) : classroomId == null ? (
+            teacherDetailQuery.isLoading ? (
+              <InlineStatus>교사 정보를 불러오는 중입니다.</InlineStatus>
+            ) : teacherDetailQuery.isError ? (
+              <StatePanel role="alert">교사 정보를 불러오지 못했습니다.</StatePanel>
+            ) : (
+              <StatePanel>선택한 교사에 연결된 분반이 없습니다.</StatePanel>
+            )
+          ) : (
+            <DataState
+              isLoading={subjectsQuery.isLoading}
+              isError={subjectsQuery.isError}
+              isEmpty={subjects.length === 0}
+              loadingLabel="과목 목록 불러오는 중"
+              errorLabel="과목 목록을 불러오지 못했습니다."
+              emptyLabel="해당 분반에 등록된 과목이 없습니다."
+            >
+              <SubjectPicker
+                subjects={subjects}
+                selectedSubjectId={selectedSubjectId}
+                onSelectSubject={(subjectId) => {
+                  clearSubmitError();
+                  setSelectedSubjectId(subjectId);
+                }}
+              />
+            </DataState>
+          )}
+        </Label>
+
+        <Label>
+          수업 일자
+          <TextInput
+            type="date"
+            value={date}
+            onChange={(event) => {
+              clearSubmitError();
+              setDate(event.target.value);
+            }}
+            required
+          />
+        </Label>
+
+        <Label>
+          교시
+          <TextInput
+            type="number"
+            min={1}
+            step={1}
+            value={period}
+            onChange={(event) => {
+              clearSubmitError();
+              setPeriod(event.target.value);
+            }}
+            required
+          />
+        </Label>
+
+        <TimeRow>
+          <TimeField>
+            시작 시간
+            <TimeInput
+              type="time"
+              step={300}
+              value={startTime}
+              onChange={(event) => {
+                clearSubmitError();
+                setStartTime(
+                  snapLessonTimeToFiveMinutes(formatLessonTimeForDisplay(event.target.value)),
+                );
+              }}
+              required
+            />
+          </TimeField>
+
+          <TimeField>
+            종료 시간
+            <TimeInput
+              type="time"
+              step={300}
+              value={endTime}
+              onChange={(event) => {
+                clearSubmitError();
+                setEndTime(
+                  snapLessonTimeToFiveMinutes(formatLessonTimeForDisplay(event.target.value)),
+                );
+              }}
+              required
+            />
+          </TimeField>
+        </TimeRow>
+
+        {submitError ? <InlineStatus role="alert">{submitError}</InlineStatus> : null}
+
+        <ButtonRow>
+          <PrimaryButton type="submit" disabled={!canSubmit}>
+            {isSubmitting ? "생성 중..." : "수업 생성"}
+          </PrimaryButton>
+        </ButtonRow>
+      </FormGrid>
+    </>
+  );
+}

--- a/components/admin/lesson-management/AdminLessonDeleteConfirmModal.tsx
+++ b/components/admin/lesson-management/AdminLessonDeleteConfirmModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import styled from "styled-components";
+import {
+  ButtonRow,
+  DangerButton,
+  SmallButton,
+} from "@/components/admin/AdminDashboardSectionParts";
+import { colors, radii, spacing, typography } from "@/styles/tokens";
+
+type AdminLessonDeleteConfirmModalProps = {
+  open: boolean;
+  message: string;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function AdminLessonDeleteConfirmModal({
+  open,
+  message,
+  isPending,
+  onCancel,
+  onConfirm,
+}: AdminLessonDeleteConfirmModalProps) {
+  if (!open) return null;
+
+  return (
+    <Backdrop onClick={onCancel} role="presentation">
+      <Dialog
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="lesson-delete-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Title id="lesson-delete-title">수업 삭제</Title>
+        <Message>{message}</Message>
+        <ButtonRow>
+          <SmallButton type="button" disabled={isPending} onClick={onCancel}>
+            취소
+          </SmallButton>
+          <DangerButton type="button" disabled={isPending} onClick={onConfirm}>
+            {isPending ? "삭제 중..." : "삭제"}
+          </DangerButton>
+        </ButtonRow>
+      </Dialog>
+    </Backdrop>
+  );
+}
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space16};
+  background-color: rgb(0 0 0 / 35%);
+`;
+
+const Dialog = styled.div`
+  width: min(100%, 24rem);
+  padding: ${spacing.space20};
+  background-color: ${colors.white};
+  border-radius: ${radii.radius12};
+  box-shadow: 0 12px 32px rgb(0 0 0 / 12%);
+`;
+
+const Title = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const Message = styled.p`
+  margin: ${spacing.space12} 0 ${spacing.space20};
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/admin/lesson-management/AdminLessonDetailPanel.tsx
+++ b/components/admin/lesson-management/AdminLessonDetailPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getLessonDetail } from "@/api/lesson/lesson.api";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import { AdminLessonDeleteConfirmModal } from "@/components/admin/lesson-management/AdminLessonDeleteConfirmModal";
+import {
+  formatLessonStatusLabel,
+  formatLessonTimeRange,
+} from "@/components/admin/lesson-management/lessonCreateError";
+import { useLessonDelete } from "@/components/admin/lesson-management/useLessonDelete";
+import {
+  ButtonRow,
+  DangerButton,
+  DataState,
+  SectionDescription,
+  StatePanel,
+} from "@/components/admin/AdminDashboardSectionParts";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+type AdminLessonDetailPanelProps = {
+  selectedLessonId: number | null;
+  selectedLessonSummary: LessonSummaryResponseDto | null;
+  onClearSelection: () => void;
+};
+
+function buildDeleteConfirmMessage(lesson: LessonSummaryResponseDto) {
+  const dateLabel = formatUtcToKstShortDate(lesson.date);
+  const periodLabel = lesson.period != null ? `${lesson.period}교시` : "—";
+  const subjectLabel = lesson.subjectName ?? "—";
+  const teacherLabel = lesson.teacherName ?? "—";
+
+  return `${dateLabel} ${periodLabel} · ${subjectLabel} · ${teacherLabel} 수업을 삭제할까요?`;
+}
+
+export function AdminLessonDetailPanel({
+  selectedLessonId,
+  selectedLessonSummary,
+  onClearSelection,
+}: AdminLessonDetailPanelProps) {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    setIsConfirmOpen(false);
+  }, [selectedLessonId]);
+
+  const detailQuery = useQuery({
+    queryKey: ["admin", "lessons", "detail", selectedLessonId],
+    queryFn: () => getLessonDetail({ lessonId: selectedLessonId ?? 0 }),
+    enabled: selectedLessonId != null && selectedLessonId > 0,
+    retry: false,
+  });
+
+  const { deleteLessonById, isDeleting } = useLessonDelete({
+    onDeleted: () => {
+      setIsConfirmOpen(false);
+      onClearSelection();
+    },
+  });
+
+  const deleteMessage = useMemo(
+    () => (selectedLessonSummary ? buildDeleteConfirmMessage(selectedLessonSummary) : ""),
+    [selectedLessonSummary],
+  );
+
+  if (selectedLessonId == null) {
+    return (
+      <>
+        <SectionDescription>목록에서 수업을 선택하면 상세 정보를 확인할 수 있습니다.</SectionDescription>
+        <StatePanel>목록에서 수업을 선택해 주세요.</StatePanel>
+      </>
+    );
+  }
+
+  const lesson = detailQuery.data;
+
+  return (
+    <>
+      <SectionDescription>선택한 수업의 상세 정보를 확인하고 삭제할 수 있습니다.</SectionDescription>
+
+      <DataState
+        isLoading={detailQuery.isLoading}
+        isError={detailQuery.isError}
+        isEmpty={false}
+        loadingLabel="수업 상세 불러오는 중"
+        errorLabel="수업 상세를 불러오지 못했습니다."
+        emptyLabel=""
+      >
+        {lesson ? (
+          <>
+            <DetailGrid>
+              <DetailField>
+                <DetailLabel>일자</DetailLabel>
+                <DetailValue>{formatUtcToKstShortDate(lesson.date)}</DetailValue>
+              </DetailField>
+              <DetailField>
+                <DetailLabel>교시</DetailLabel>
+                <DetailValue>{lesson.period ?? "—"}</DetailValue>
+              </DetailField>
+              <DetailField>
+                <DetailLabel>시간</DetailLabel>
+                <DetailValue>{formatLessonTimeRange(lesson.startTime, lesson.endTime)}</DetailValue>
+              </DetailField>
+              <DetailField>
+                <DetailLabel>담당 교사</DetailLabel>
+                <DetailValue>{lesson.teacherName ?? "—"}</DetailValue>
+              </DetailField>
+              <DetailField>
+                <DetailLabel>과목</DetailLabel>
+                <DetailValue>{lesson.subjectName ?? "—"}</DetailValue>
+              </DetailField>
+              <DetailField>
+                <DetailLabel>상태</DetailLabel>
+                <DetailValue>{formatLessonStatusLabel(lesson.status)}</DetailValue>
+              </DetailField>
+            </DetailGrid>
+
+            <ButtonRow>
+              <DangerButton type="button" disabled={isDeleting} onClick={() => setIsConfirmOpen(true)}>
+                삭제
+              </DangerButton>
+            </ButtonRow>
+          </>
+        ) : null}
+      </DataState>
+
+      <AdminLessonDeleteConfirmModal
+        open={isConfirmOpen}
+        message={deleteMessage}
+        isPending={isDeleting}
+        onCancel={() => setIsConfirmOpen(false)}
+        onConfirm={() => {
+          if (selectedLessonId != null) deleteLessonById(selectedLessonId);
+        }}
+      />
+    </>
+  );
+}
+
+const DetailGrid = styled.dl`
+  display: grid;
+  gap: ${spacing.space12};
+  margin: 0 0 ${spacing.space16};
+`;
+
+const DetailField = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+`;
+
+const DetailLabel = styled.dt`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+`;
+
+const DetailValue = styled.dd`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/admin/lesson-management/AdminLessonManagementSection.tsx
+++ b/components/admin/lesson-management/AdminLessonManagementSection.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import dayjs from "dayjs";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { getLessons } from "@/api/lesson/lesson.api";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
 import { AdminLessonCreateForm } from "@/components/admin/lesson-management/AdminLessonCreateForm";
+import { AdminLessonDetailPanel } from "@/components/admin/lesson-management/AdminLessonDetailPanel";
+import { formatLessonTimeRange } from "@/components/admin/lesson-management/lessonCreateError";
+import {
+  getLessonMonthRange,
+  getLessonYearOptions,
+  LESSON_MONTH_OPTIONS,
+  parseLessonMonthFilter,
+} from "@/components/admin/lesson-management/lessonMonthFilter";
 import {
   ControlRow,
   DataState,
@@ -14,34 +22,28 @@ import {
   SectionCard,
   SectionHeaderRow,
   SectionTitle,
+  Select,
   StableListArea,
   Table,
-  TextInput,
   TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, spacing } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
-const LessonTable = styled(Table)`
-  tbody tr {
-    cursor: default;
-  }
-
-  tbody tr:hover {
-    background-color: transparent;
-  }
+const PageStack = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
 `;
 
-const DateFilterRow = styled(ControlRow)`
-  input {
+const LessonTableRow = styled.tr<{ $selected: boolean }>`
+  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : "transparent")};
+`;
+
+const MonthFilterRow = styled(ControlRow)`
+  select {
     font-weight: 500;
   }
 `;
-
-function formatLessonTimeRange(startTime?: string, endTime?: string) {
-  const start = startTime ? startTime.slice(0, 5) : "—";
-  const end = endTime ? endTime.slice(0, 5) : "—";
-  return `${start} - ${end}`;
-}
 
 function sortLessons(lessons: LessonSummaryResponseDto[]) {
   return [...lessons].sort((a, b) => {
@@ -56,15 +58,18 @@ function sortLessons(lessons: LessonSummaryResponseDto[]) {
 }
 
 export function AdminLessonManagementSection() {
-  const [from, setFrom] = useState(() => dayjs().startOf("month").format("YYYY-MM-DD"));
-  const [to, setTo] = useState(() => dayjs().endOf("month").format("YYYY-MM-DD"));
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { year, month } = parseLessonMonthFilter(searchParams);
+  const { from, to } = getLessonMonthRange(year, month);
 
-  const isValidRange = Boolean(from && to && from <= to);
+  const [selectedLessonId, setSelectedLessonId] = useState<number | null>(null);
+  const yearOptions = useMemo(() => getLessonYearOptions(), []);
 
   const lessonsQuery = useQuery({
     queryKey: ["admin", "lessons", from, to],
     queryFn: () => getLessons({ from, to }),
-    enabled: isValidRange,
     retry: false,
   });
 
@@ -73,31 +78,64 @@ export function AdminLessonManagementSection() {
     [lessonsQuery.data],
   );
 
+  const selectedLessonSummary = useMemo(
+    () => lessons.find((lesson) => lesson.lessonId === selectedLessonId) ?? null,
+    [lessons, selectedLessonId],
+  );
+
+  useEffect(() => {
+    setSelectedLessonId(null);
+  }, [year, month]);
+
+  const updateMonthFilter = (nextYear: number, nextMonth: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("year", String(nextYear));
+    params.set("month", String(nextMonth));
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
   return (
-    <TwoColumnGrid>
+    <PageStack>
       <SectionCard>
-        <SectionHeaderRow>
-          <SectionTitle>수업 목록</SectionTitle>
-        </SectionHeaderRow>
+        <SectionTitle>수업 생성</SectionTitle>
+        <AdminLessonCreateForm />
+      </SectionCard>
 
-        <DateFilterRow>
-          <Label>
-            시작일
-            <TextInput
-              type="date"
-              value={from}
-              onChange={(event) => setFrom(event.target.value)}
-            />
-          </Label>
-          <Label>
-            종료일
-            <TextInput type="date" value={to} onChange={(event) => setTo(event.target.value)} />
-          </Label>
-        </DateFilterRow>
+      <TwoColumnGrid>
+        <SectionCard>
+          <SectionHeaderRow>
+            <SectionTitle>수업 목록</SectionTitle>
+          </SectionHeaderRow>
 
-        {!isValidRange ? (
-          <StableListArea>시작일과 종료일을 올바르게 입력해 주세요.</StableListArea>
-        ) : (
+          <MonthFilterRow>
+            <Label>
+              년도
+              <Select
+                value={year}
+                onChange={(event) => updateMonthFilter(Number(event.target.value), month)}
+              >
+                {yearOptions.map((optionYear) => (
+                  <option key={optionYear} value={optionYear}>
+                    {optionYear}년
+                  </option>
+                ))}
+              </Select>
+            </Label>
+            <Label>
+              월
+              <Select
+                value={month}
+                onChange={(event) => updateMonthFilter(year, Number(event.target.value))}
+              >
+                {LESSON_MONTH_OPTIONS.map((optionMonth) => (
+                  <option key={optionMonth} value={optionMonth}>
+                    {optionMonth}월
+                  </option>
+                ))}
+              </Select>
+            </Label>
+          </MonthFilterRow>
+
           <StableListArea>
             <DataState
               isLoading={lessonsQuery.isLoading}
@@ -105,9 +143,9 @@ export function AdminLessonManagementSection() {
               isEmpty={lessons.length === 0}
               loadingLabel="수업 목록 불러오는 중"
               errorLabel="수업 목록을 불러오지 못했습니다."
-              emptyLabel="조회 기간에 해당하는 수업이 없습니다."
+              emptyLabel="해당 월에 등록된 수업이 없습니다."
             >
-              <LessonTable>
+              <Table>
                 <thead>
                   <tr>
                     <th>일자</th>
@@ -118,26 +156,42 @@ export function AdminLessonManagementSection() {
                   </tr>
                 </thead>
                 <tbody>
-                  {lessons.map((lesson, index) => (
-                    <tr key={lesson.lessonId ?? `${lesson.date}-${lesson.period}-${index}`}>
-                      <td>{formatUtcToKstShortDate(lesson.date)}</td>
-                      <td>{lesson.period ?? "—"}</td>
-                      <td>{formatLessonTimeRange(lesson.startTime, lesson.endTime)}</td>
-                      <td>{lesson.teacherName ?? "—"}</td>
-                      <td>{lesson.subjectName ?? "—"}</td>
-                    </tr>
-                  ))}
+                  {lessons.map((lesson, index) => {
+                    const lessonId = lesson.lessonId;
+                    const isSelected = lessonId != null && lessonId === selectedLessonId;
+
+                    return (
+                      <LessonTableRow
+                        key={lessonId ?? `${lesson.date}-${lesson.period}-${index}`}
+                        $selected={isSelected}
+                        onClick={() => {
+                          if (lessonId == null) return;
+                          setSelectedLessonId(lessonId);
+                        }}
+                      >
+                        <td>{formatUtcToKstShortDate(lesson.date)}</td>
+                        <td>{lesson.period ?? "—"}</td>
+                        <td>{formatLessonTimeRange(lesson.startTime, lesson.endTime)}</td>
+                        <td>{lesson.teacherName ?? "—"}</td>
+                        <td>{lesson.subjectName ?? "—"}</td>
+                      </LessonTableRow>
+                    );
+                  })}
                 </tbody>
-              </LessonTable>
+              </Table>
             </DataState>
           </StableListArea>
-        )}
-      </SectionCard>
+        </SectionCard>
 
-      <SectionCard>
-        <SectionTitle>수업 생성</SectionTitle>
-        <AdminLessonCreateForm />
-      </SectionCard>
-    </TwoColumnGrid>
+        <SectionCard>
+          <SectionTitle>수업 상세</SectionTitle>
+          <AdminLessonDetailPanel
+            selectedLessonId={selectedLessonId}
+            selectedLessonSummary={selectedLessonSummary}
+            onClearSelection={() => setSelectedLessonId(null)}
+          />
+        </SectionCard>
+      </TwoColumnGrid>
+    </PageStack>
   );
 }

--- a/components/admin/lesson-management/AdminLessonManagementSection.tsx
+++ b/components/admin/lesson-management/AdminLessonManagementSection.tsx
@@ -31,6 +31,12 @@ const LessonTable = styled(Table)`
   }
 `;
 
+const DateFilterRow = styled(ControlRow)`
+  input {
+    font-weight: 500;
+  }
+`;
+
 function formatLessonTimeRange(startTime?: string, endTime?: string) {
   const start = startTime ? startTime.slice(0, 5) : "—";
   const end = endTime ? endTime.slice(0, 5) : "—";
@@ -74,7 +80,7 @@ export function AdminLessonManagementSection() {
           <SectionTitle>수업 목록</SectionTitle>
         </SectionHeaderRow>
 
-        <ControlRow>
+        <DateFilterRow>
           <Label>
             시작일
             <TextInput
@@ -87,7 +93,7 @@ export function AdminLessonManagementSection() {
             종료일
             <TextInput type="date" value={to} onChange={(event) => setTo(event.target.value)} />
           </Label>
-        </ControlRow>
+        </DateFilterRow>
 
         {!isValidRange ? (
           <StableListArea>시작일과 종료일을 올바르게 입력해 주세요.</StableListArea>

--- a/components/admin/lesson-management/AdminLessonManagementSection.tsx
+++ b/components/admin/lesson-management/AdminLessonManagementSection.tsx
@@ -1,18 +1,137 @@
 "use client";
 
+import { useMemo, useState } from "react";
+import dayjs from "dayjs";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getLessons } from "@/api/lesson/lesson.api";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import { AdminLessonCreateForm } from "@/components/admin/lesson-management/AdminLessonCreateForm";
 import {
+  ControlRow,
+  DataState,
+  Label,
   SectionCard,
-  SectionDescription,
+  SectionHeaderRow,
   SectionTitle,
-  StatePanel,
+  StableListArea,
+  Table,
+  TextInput,
+  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+const LessonTable = styled(Table)`
+  tbody tr {
+    cursor: default;
+  }
+
+  tbody tr:hover {
+    background-color: transparent;
+  }
+`;
+
+function formatLessonTimeRange(startTime?: string, endTime?: string) {
+  const start = startTime ? startTime.slice(0, 5) : "—";
+  const end = endTime ? endTime.slice(0, 5) : "—";
+  return `${start} - ${end}`;
+}
+
+function sortLessons(lessons: LessonSummaryResponseDto[]) {
+  return [...lessons].sort((a, b) => {
+    const dateCompare = (a.date ?? "").localeCompare(b.date ?? "");
+    if (dateCompare !== 0) return dateCompare;
+
+    const periodCompare = (a.period ?? 0) - (b.period ?? 0);
+    if (periodCompare !== 0) return periodCompare;
+
+    return (a.startTime ?? "").localeCompare(b.startTime ?? "");
+  });
+}
 
 export function AdminLessonManagementSection() {
+  const [from, setFrom] = useState(() => dayjs().startOf("month").format("YYYY-MM-DD"));
+  const [to, setTo] = useState(() => dayjs().endOf("month").format("YYYY-MM-DD"));
+
+  const isValidRange = Boolean(from && to && from <= to);
+
+  const lessonsQuery = useQuery({
+    queryKey: ["admin", "lessons", from, to],
+    queryFn: () => getLessons({ from, to }),
+    enabled: isValidRange,
+    retry: false,
+  });
+
+  const lessons = useMemo(
+    () => sortLessons(Array.isArray(lessonsQuery.data) ? lessonsQuery.data : []),
+    [lessonsQuery.data],
+  );
+
   return (
-    <SectionCard>
-      <SectionTitle>수업 관리</SectionTitle>
-      <SectionDescription>수업 목록을 조회하고 새 수업을 생성합니다.</SectionDescription>
-      <StatePanel>수업 관리 화면을 준비 중입니다.</StatePanel>
-    </SectionCard>
+    <TwoColumnGrid>
+      <SectionCard>
+        <SectionHeaderRow>
+          <SectionTitle>수업 목록</SectionTitle>
+        </SectionHeaderRow>
+
+        <ControlRow>
+          <Label>
+            시작일
+            <TextInput
+              type="date"
+              value={from}
+              onChange={(event) => setFrom(event.target.value)}
+            />
+          </Label>
+          <Label>
+            종료일
+            <TextInput type="date" value={to} onChange={(event) => setTo(event.target.value)} />
+          </Label>
+        </ControlRow>
+
+        {!isValidRange ? (
+          <StableListArea>시작일과 종료일을 올바르게 입력해 주세요.</StableListArea>
+        ) : (
+          <StableListArea>
+            <DataState
+              isLoading={lessonsQuery.isLoading}
+              isError={lessonsQuery.isError}
+              isEmpty={lessons.length === 0}
+              loadingLabel="수업 목록 불러오는 중"
+              errorLabel="수업 목록을 불러오지 못했습니다."
+              emptyLabel="조회 기간에 해당하는 수업이 없습니다."
+            >
+              <LessonTable>
+                <thead>
+                  <tr>
+                    <th>일자</th>
+                    <th>교시</th>
+                    <th>시간</th>
+                    <th>담당 교사</th>
+                    <th>과목</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {lessons.map((lesson, index) => (
+                    <tr key={lesson.lessonId ?? `${lesson.date}-${lesson.period}-${index}`}>
+                      <td>{formatUtcToKstShortDate(lesson.date)}</td>
+                      <td>{lesson.period ?? "—"}</td>
+                      <td>{formatLessonTimeRange(lesson.startTime, lesson.endTime)}</td>
+                      <td>{lesson.teacherName ?? "—"}</td>
+                      <td>{lesson.subjectName ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </LessonTable>
+            </DataState>
+          </StableListArea>
+        )}
+      </SectionCard>
+
+      <SectionCard>
+        <SectionTitle>수업 생성</SectionTitle>
+        <AdminLessonCreateForm />
+      </SectionCard>
+    </TwoColumnGrid>
   );
 }

--- a/components/admin/lesson-management/AdminLessonManagementSection.tsx
+++ b/components/admin/lesson-management/AdminLessonManagementSection.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import {
+  SectionCard,
+  SectionDescription,
+  SectionTitle,
+  StatePanel,
+} from "@/components/admin/AdminDashboardSectionParts";
+
+export function AdminLessonManagementSection() {
+  return (
+    <SectionCard>
+      <SectionTitle>수업 관리</SectionTitle>
+      <SectionDescription>수업 목록을 조회하고 새 수업을 생성합니다.</SectionDescription>
+      <StatePanel>수업 관리 화면을 준비 중입니다.</StatePanel>
+    </SectionCard>
+  );
+}

--- a/components/admin/lesson-management/lessonCreateClassroomFallback.ts
+++ b/components/admin/lesson-management/lessonCreateClassroomFallback.ts
@@ -1,0 +1,15 @@
+import type { UserListItemDto } from "@/api/user/user.dto";
+
+// TODO(backend): 분반 DB 연동 후 이 파일 삭제하고 classroomId는 API 응답만 사용
+const TEACHER_CLASSROOM_FALLBACK: Record<string, number> = {
+  김철수: 2,
+  홍길동: 1,
+};
+
+export function resolveLessonCreateClassroomId(
+  teacher?: Pick<UserListItemDto, "name" | "classroom"> | null,
+) {
+  if (!teacher) return null;
+
+  return teacher.classroom?.id ?? TEACHER_CLASSROOM_FALLBACK[teacher.name?.trim() ?? ""] ?? null;
+}

--- a/components/admin/lesson-management/lessonCreateError.ts
+++ b/components/admin/lesson-management/lessonCreateError.ts
@@ -47,3 +47,30 @@ export function resolveLessonCreateErrorMessage(error: unknown) {
 
   return "수업 생성에 실패했습니다.";
 }
+
+export function formatLessonTimeRange(startTime?: string, endTime?: string) {
+  const start = startTime ? startTime.slice(0, 5) : "—";
+  const end = endTime ? endTime.slice(0, 5) : "—";
+  return `${start} - ${end}`;
+}
+
+export function formatLessonStatusLabel(status?: string) {
+  switch (status) {
+    case "SCHEDULED":
+      return "예정";
+    case "COMPLETED":
+      return "완료";
+    case "CANCELED":
+      return "취소";
+    default:
+      return status ?? "—";
+  }
+}
+
+export function resolveLessonDeleteErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return "수업 삭제에 실패했습니다.";
+}

--- a/components/admin/lesson-management/lessonCreateError.ts
+++ b/components/admin/lesson-management/lessonCreateError.ts
@@ -1,0 +1,49 @@
+import { isAxiosError } from "axios";
+
+const LESSON_TIME_OVERLAP_MESSAGE = "시간대가 겹치는 수업이 존재합니다";
+
+export function formatLessonTimeForDisplay(value: string) {
+  const trimmed = value.trim();
+  if (/^\d{2}:\d{2}:\d{2}$/.test(trimmed)) return trimmed.slice(0, 5);
+  if (/^\d{2}:\d{2}$/.test(trimmed)) return trimmed;
+  return trimmed;
+}
+
+export function snapLessonTimeToFiveMinutes(value: string) {
+  const normalized = formatLessonTimeForDisplay(value);
+  if (!/^\d{2}:\d{2}$/.test(normalized)) return normalized;
+
+  const [hourText, minuteText] = normalized.split(":");
+  let hour = Number(hourText);
+  let minute = Number(minuteText);
+
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return normalized;
+
+  let snappedMinute = Math.round(minute / 5) * 5;
+  if (snappedMinute === 60) {
+    hour = Math.min(hour + 1, 23);
+    snappedMinute = 0;
+  }
+
+  return `${String(hour).padStart(2, "0")}:${String(snappedMinute).padStart(2, "0")}`;
+}
+
+export function normalizeLessonTimeForApi(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  if (/^\d{2}:\d{2}:\d{2}$/.test(trimmed)) return trimmed;
+  if (/^\d{2}:\d{2}$/.test(trimmed)) return `${trimmed}:00`;
+  return trimmed;
+}
+
+export function resolveLessonCreateErrorMessage(error: unknown) {
+  if (isAxiosError(error) && error.response?.status === 409) {
+    return LESSON_TIME_OVERLAP_MESSAGE;
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return "수업 생성에 실패했습니다.";
+}

--- a/components/admin/lesson-management/lessonMonthFilter.ts
+++ b/components/admin/lesson-management/lessonMonthFilter.ts
@@ -1,0 +1,45 @@
+import dayjs from "dayjs";
+
+type SearchParamsLike = {
+  get: (key: string) => string | null;
+};
+
+export function getLessonMonthRange(year: number, month: number) {
+  const start = dayjs().year(year).month(month - 1).startOf("month");
+  const end = start.endOf("month");
+
+  return {
+    from: start.format("YYYY-MM-DD"),
+    to: end.format("YYYY-MM-DD"),
+  };
+}
+
+export function parseLessonMonthFilter(searchParams: SearchParamsLike) {
+  const now = dayjs();
+  const yearParam = Number(searchParams.get("year"));
+  const monthParam = Number(searchParams.get("month"));
+
+  const year =
+    Number.isInteger(yearParam) && yearParam >= 2000 && yearParam <= 2100
+      ? yearParam
+      : now.year();
+  const month =
+    Number.isInteger(monthParam) && monthParam >= 1 && monthParam <= 12
+      ? monthParam
+      : now.month() + 1;
+
+  return { year, month };
+}
+
+export function getLessonYearOptions() {
+  const currentYear = dayjs().year();
+  const years: number[] = [];
+
+  for (let year = currentYear - 2; year <= currentYear + 1; year += 1) {
+    years.push(year);
+  }
+
+  return years;
+}
+
+export const LESSON_MONTH_OPTIONS = Array.from({ length: 12 }, (_, index) => index + 1);

--- a/components/admin/lesson-management/useLessonCreateOptions.ts
+++ b/components/admin/lesson-management/useLessonCreateOptions.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getSubjects } from "@/api/subject/subject.api";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import { getUserDetail, getUsers } from "@/api/user/user.api";
+import type { UserListItemDto, UserListQueryParamsDto } from "@/api/user/user.dto";
+import { resolveLessonCreateClassroomId } from "@/components/admin/lesson-management/lessonCreateClassroomFallback";
+
+type VolunteerUsersQuery = UserListQueryParamsDto & { role?: "VOLUNTEER" };
+
+export type LessonCreateSelection = {
+  teacherId: number | null;
+  subjectId: number | null;
+};
+
+export function useLessonCreateOptions() {
+  const [selectedTeacherId, setSelectedTeacherId] = useState<number | null>(null);
+  const [selectedSubjectId, setSelectedSubjectId] = useState<number | null>(null);
+
+  const volunteersQuery = useQuery({
+    queryKey: ["admin", "lesson-create", "volunteers"],
+    queryFn: () =>
+      getUsers({
+        page: 0,
+        size: 100,
+        role: "VOLUNTEER",
+      } satisfies VolunteerUsersQuery),
+    retry: false,
+  });
+
+  const volunteers = useMemo(() => {
+    const items = volunteersQuery.data?.content ?? [];
+    return items.filter((user) => user.role === "VOLUNTEER" || user.role == null);
+  }, [volunteersQuery.data?.content]);
+
+  const teacherDetailQuery = useQuery({
+    queryKey: ["admin", "lesson-create", "teacher-detail", selectedTeacherId],
+    queryFn: () => getUserDetail({ userId: selectedTeacherId! }),
+    enabled: selectedTeacherId != null && selectedTeacherId > 0,
+    retry: false,
+  });
+
+  const classroomId = useMemo(() => {
+    const teacher =
+      teacherDetailQuery.data ?? volunteers.find((user) => user.id === selectedTeacherId);
+    return resolveLessonCreateClassroomId(teacher);
+  }, [teacherDetailQuery.data, volunteers, selectedTeacherId]);
+
+  const subjectsQuery = useQuery({
+    queryKey: ["admin", "lesson-create", "subjects", classroomId],
+    queryFn: () => getSubjects({ classroomId: classroomId! }),
+    enabled: classroomId != null && classroomId > 0,
+    retry: false,
+  });
+
+  const subjects = useMemo(
+    () => (Array.isArray(subjectsQuery.data) ? subjectsQuery.data : []),
+    [subjectsQuery.data],
+  );
+
+  useEffect(() => {
+    setSelectedSubjectId(subjects[0]?.id ?? null);
+  }, [subjects, selectedTeacherId]);
+
+  const selectTeacher = (teacherId: number | null) => {
+    setSelectedTeacherId(teacherId);
+    setSelectedSubjectId(null);
+  };
+
+  const selection: LessonCreateSelection = {
+    teacherId: selectedTeacherId,
+    subjectId: selectedSubjectId,
+  };
+
+  return {
+    volunteers,
+    volunteersQuery,
+    selectedTeacherId,
+    selectTeacher,
+    teacherDetailQuery,
+    classroomId,
+    subjects,
+    subjectsQuery,
+    selectedSubjectId,
+    setSelectedSubjectId,
+    selection,
+  };
+}
+
+export function getTeacherLabel(teacher: UserListItemDto) {
+  return teacher.name?.trim() || teacher.nickname?.trim() || teacher.email || `교원 #${teacher.id}`;
+}
+
+export function getSubjectId(subject: SubjectDetailResponseDto) {
+  return subject.id ?? null;
+}

--- a/components/admin/lesson-management/useLessonCreateSubmit.ts
+++ b/components/admin/lesson-management/useLessonCreateSubmit.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createLesson } from "@/api/lesson/lesson.api";
+import {
+  normalizeLessonTimeForApi,
+  resolveLessonCreateErrorMessage,
+} from "@/components/admin/lesson-management/lessonCreateError";
+
+type UseLessonCreateSubmitParams = {
+  teacherId: number | null;
+  subjectId: number | null;
+};
+
+export function useLessonCreateSubmit({ teacherId, subjectId }: UseLessonCreateSubmitParams) {
+  const queryClient = useQueryClient();
+  const [date, setDate] = useState("");
+  const [period, setPeriod] = useState("1");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const createLessonMutation = useMutation({
+    mutationFn: createLesson,
+    onSuccess: async () => {
+      setSubmitError(null);
+      setDate("");
+      setPeriod("1");
+      setStartTime("");
+      setEndTime("");
+      await queryClient.invalidateQueries({ queryKey: ["admin", "lessons"] });
+    },
+    onError: (error) => {
+      setSubmitError(resolveLessonCreateErrorMessage(error));
+    },
+  });
+
+  const parsedPeriod = Number(period);
+  const canSubmit =
+    teacherId != null &&
+    teacherId > 0 &&
+    subjectId != null &&
+    subjectId > 0 &&
+    date.trim().length > 0 &&
+    Number.isInteger(parsedPeriod) &&
+    parsedPeriod > 0 &&
+    startTime.trim().length > 0 &&
+    endTime.trim().length > 0 &&
+    !createLessonMutation.isPending;
+
+  const submitLesson = () => {
+    if (!canSubmit || teacherId == null || subjectId == null) return;
+
+    setSubmitError(null);
+    createLessonMutation.mutate({
+      subjectId,
+      teacherId,
+      date,
+      startTime: normalizeLessonTimeForApi(startTime),
+      endTime: normalizeLessonTimeForApi(endTime),
+      period: parsedPeriod,
+    });
+  };
+
+  const clearSubmitError = () => {
+    if (submitError) setSubmitError(null);
+  };
+
+  return {
+    date,
+    setDate,
+    period,
+    setPeriod,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    submitError,
+    canSubmit,
+    submitLesson,
+    clearSubmitError,
+    isSubmitting: createLessonMutation.isPending,
+  };
+}

--- a/components/admin/lesson-management/useLessonDelete.ts
+++ b/components/admin/lesson-management/useLessonDelete.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { deleteLesson } from "@/api/lesson/lesson.api";
+import { resolveLessonDeleteErrorMessage } from "@/components/admin/lesson-management/lessonCreateError";
+
+type UseLessonDeleteParams = {
+  onDeleted?: () => void;
+};
+
+export function useLessonDelete({ onDeleted }: UseLessonDeleteParams = {}) {
+  const queryClient = useQueryClient();
+
+  const deleteLessonMutation = useMutation({
+    mutationFn: (lessonId: number) => deleteLesson({ lessonId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["admin", "lessons"] });
+      toast.success("수업을 삭제했습니다.");
+      onDeleted?.();
+    },
+    onError: (error) => {
+      toast.error(resolveLessonDeleteErrorMessage(error));
+    },
+  });
+
+  return {
+    deleteLessonById: deleteLessonMutation.mutate,
+    isDeleting: deleteLessonMutation.isPending,
+  };
+}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

<img width="1228" height="816" alt="스크린샷 2026-05-27 오전 1 59 20" src="https://github.com/user-attachments/assets/c1b30e9a-4706-420d-acee-ad664dfc3992" />

1. 관리자 콘솔 수업 메뉴 연동
    - AdminDashboardPage 사이드바에 「수업」 메뉴 추가
    - AdminDashboardTypes에 lessons 메뉴 타입 추가
2. 수업 목록 조회 **GET /api/v1/lessons**
    - UI는 년/월 드롭다운으로 선택 URL `query: ?year=YYYY&month=M`
    - 선택한 월의 1일 ~ 말일을 from / to로 변환해 API 호출
    - 페이지네이션 없이 월 단위 조회
    - 테이블 컬럼: 일자 → 교시 → 시간 → 담당 교사 → 과목 순서 렌더링
3. 수업 생성 사전 세팅
    - 교원 목록 **GET /api/v1/users (role=VOLUNTEER 고정)** → 드롭다운 렌더링
    - 교원 선택 시 사용자 상세 **GET /api/v1/users/{userId}** → `classroom.id` 추출
    - 과목 목록 **GET /api/v1/subjects?classroomId=** → 블록 UI 렌더링
        - 과목 1개: 고정 블록(자동 선택)
        - 과목 여러 개: 블록 중 택 1
    - classroomId 미연동 교원 임시 처리: `lessonCreateClassroomFallback.ts` (백엔드 분반 연동 후 삭제 예정)
4. 수업 생성 **POST /api/v1/lessons**
    - request: subjectId, teacherId, date, period, startTime, endTime
    - 409 응답: "시간대가 겹치는 수업이 존재합니다" 인라인 에러 표시
    - 생성 성공 시 ["admin", "lessons"] query invalidate → 목록 자동 갱신
5. 수업 상세 조회 **GET /api/v1/lessons/{lessonId}**
    - 목록 행 클릭 → 우측 수업 상세 패널 표시
    - 일자, 교시, 시간, 담당 교사, 과목, 상태(예정/완료/취소) 조회
6. 수업 삭제 **DELETE /api/v1/lessons/{lessonId}**
    - 상세 패널 삭제 버튼 → confirm 모달
    - 확인 시 삭제 API 호출 → toast → 목록 갱신 → 선택 해제

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #89

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
