### PR TITLE
[FEAT] 기관 정보 - 행사 정보 페이지 UI 구현 및 API 연동

### DIFF
--- a/api/channel/channel.dto.ts
+++ b/api/channel/channel.dto.ts
@@ -1,4 +1,4 @@
-export type ChannelType = "NOTICE" | "CLASSROOM" | "DEPARTMENT" | "CUSTOM" | string;
+export type ChannelType = "NOTICE" | "CLASSROOM" | "DEPARTMENT" | "EVENT" | "CUSTOM" | string;
 
 export type ChannelBindingType = "STANDALONE" | "DOMAIN_LINKED" | string;
 export type ChannelAccessLevel = "CLOSED" | "READ_ONLY" | "READ_COMMENT" | "READ_WRITE" | string;

--- a/app/(public)/info/events/[postId]/page.tsx
+++ b/app/(public)/info/events/[postId]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import EventDetailPageClient from "@/components/info/events/EventDetailPageClient";
+
+type PageProps = {
+  params: Promise<{
+    postId: string;
+  }>;
+  searchParams?: Promise<{
+    channelId?: string;
+  }>;
+};
+
+export default async function Page({ params, searchParams }: PageProps) {
+  const { postId } = await params;
+  const resolvedSearchParams = await searchParams;
+  const parsedPostId = Number(postId);
+  const rawChannelId = resolvedSearchParams?.channelId;
+  const parsedChannelId = rawChannelId ? Number(rawChannelId) : undefined;
+
+  if (!Number.isInteger(parsedPostId) || parsedPostId < 1) {
+    notFound();
+  }
+
+  return (
+    <EventDetailPageClient
+      postId={parsedPostId}
+      channelId={
+        Number.isInteger(parsedChannelId) && parsedChannelId && parsedChannelId > 0
+          ? parsedChannelId
+          : undefined
+      }
+    />
+  );
+}

--- a/app/(public)/info/events/new/page.tsx
+++ b/app/(public)/info/events/new/page.tsx
@@ -1,0 +1,21 @@
+import EventFormPageClient from "@/components/info/events/EventFormPageClient";
+
+type PageProps = {
+  searchParams?: Promise<{
+    postId?: string;
+    channelId?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const postId = Number(resolvedSearchParams?.postId);
+  const channelId = Number(resolvedSearchParams?.channelId);
+
+  return (
+    <EventFormPageClient
+      editPostId={Number.isInteger(postId) && postId > 0 ? postId : undefined}
+      editChannelId={Number.isInteger(channelId) && channelId > 0 ? channelId : undefined}
+    />
+  );
+}

--- a/app/(public)/info/events/page.tsx
+++ b/app/(public)/info/events/page.tsx
@@ -1,0 +1,15 @@
+import EventListPageClient from "@/components/info/events/EventListPageClient";
+
+type PageProps = {
+  searchParams?: Promise<{
+    page?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const resolvedSearchParams = await searchParams;
+  const rawPage = resolvedSearchParams?.page;
+  const initialPage = rawPage ? Number(rawPage) : 1;
+
+  return <EventListPageClient initialPage={initialPage} />;
+}

--- a/app/(public)/info/events/page.tsx
+++ b/app/(public)/info/events/page.tsx
@@ -1,4 +1,13 @@
 import EventListPageClient from "@/components/info/events/EventListPageClient";
+import { getChannels } from "@/api/channel/channel.api";
+import { getPosts } from "@/api/post/post.api";
+import type { ChannelResponseDto } from "@/api/channel/channel.dto";
+import type { PostListResponseDto } from "@/api/post/post.dto";
+import {
+  EVENT_CHANNEL_TYPE,
+  EVENT_FETCH_SIZE,
+  findEventChannel,
+} from "@/components/info/events/eventUtils";
 
 type PageProps = {
   searchParams?: Promise<{
@@ -10,6 +19,32 @@ export default async function Page({ searchParams }: PageProps) {
   const resolvedSearchParams = await searchParams;
   const rawPage = resolvedSearchParams?.page;
   const initialPage = rawPage ? Number(rawPage) : 1;
+  let initialChannels: ChannelResponseDto[] | undefined;
+  let initialPosts: PostListResponseDto | undefined;
 
-  return <EventListPageClient initialPage={initialPage} />;
+  try {
+    initialChannels = await getChannels({ channelType: EVENT_CHANNEL_TYPE, isActive: true });
+    const eventChannel = findEventChannel(initialChannels);
+
+    if (typeof eventChannel?.id === "number") {
+      initialPosts = await getPosts({
+        channelType: EVENT_CHANNEL_TYPE,
+        channelId: eventChannel.id,
+        status: "PUBLISHED",
+        page: 0,
+        size: EVENT_FETCH_SIZE,
+      });
+    }
+  } catch {
+    initialChannels = undefined;
+    initialPosts = undefined;
+  }
+
+  return (
+    <EventListPageClient
+      initialPage={initialPage}
+      initialChannels={initialChannels}
+      initialPosts={initialPosts}
+    />
+  );
 }

--- a/components/home/EventPhotoCard.tsx
+++ b/components/home/EventPhotoCard.tsx
@@ -1,32 +1,102 @@
-import Image from "next/image";
+"use client";
+
+import { useMemo } from "react";
+import { IconPhoto } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import styled from "styled-components";
+import { getChannels } from "@/api/channel/channel.api";
+import { getPosts } from "@/api/post/post.api";
+import type { PostSummaryResponseDto } from "@/api/post/post.dto";
 import HomeCard from "@/components/home/HomeCard";
+import {
+  EVENT_CHANNEL_TYPE,
+  EVENT_FETCH_SIZE,
+  findEventChannel,
+  sortEventPosts,
+} from "@/components/info/events/eventUtils";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, spacing, typography } from "@/styles/tokens";
-import type { EventPhoto } from "@/types/home";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
-type EventPhotoCardProps = {
-  photos: EventPhoto[];
-};
+const HOME_EVENT_PHOTO_LIMIT = 3;
 
-export default function EventPhotoCard({ photos }: EventPhotoCardProps) {
+function buildEventHref(post: PostSummaryResponseDto, fallbackChannelId?: number) {
+  const postId = post.id;
+  if (typeof postId !== "number") return "/info/events";
+
+  const channelId = typeof post.channelId === "number" ? post.channelId : fallbackChannelId;
+  return typeof channelId === "number"
+    ? `/info/events/${postId}?channelId=${channelId}`
+    : `/info/events/${postId}`;
+}
+
+export default function EventPhotoCard() {
+  const channelsQuery = useQuery({
+    queryKey: queryKeys.posts.eventChannels(),
+    queryFn: () => getChannels({ channelType: EVENT_CHANNEL_TYPE, isActive: true }),
+    retry: false,
+  });
+
+  const eventChannel = findEventChannel(channelsQuery.data);
+
+  const postsQuery = useQuery({
+    queryKey: queryKeys.posts.eventHomePhotos(eventChannel?.id),
+    queryFn: () =>
+      getPosts({
+        channelType: EVENT_CHANNEL_TYPE,
+        channelId: eventChannel?.id,
+        status: "PUBLISHED",
+        page: 0,
+        size: EVENT_FETCH_SIZE,
+      }),
+    enabled: typeof eventChannel?.id === "number",
+    retry: false,
+  });
+
+  const photos = useMemo(
+    () => sortEventPosts(postsQuery.data?.content ?? []).slice(0, HOME_EVENT_PHOTO_LIMIT),
+    [postsQuery.data?.content],
+  );
+  const isLoading = channelsQuery.isLoading || postsQuery.isLoading;
+  const isError = channelsQuery.isError || postsQuery.isError;
+  const stateMessage = isLoading
+    ? "행사 사진을 불러오는 중입니다."
+    : isError
+      ? "행사 사진을 불러오지 못했습니다."
+      : "등록된 행사 사진이 없습니다.";
+
   return (
-    <Card title="행사 사진" actionLabel="더보기">
-      <PhotoGrid>
-        {photos.map((photo) => (
-          <PhotoItem key={photo.id}>
-            <Thumbnail>
-              <PhotoImage
-                src={photo.imageUrl}
-                alt={photo.title}
-                fill
-                sizes="(max-width: 768px) 100vw, 33vw"
-              />
-            </Thumbnail>
-            <PhotoTitle>{photo.title}</PhotoTitle>
-            <PhotoDate>{photo.date}</PhotoDate>
-          </PhotoItem>
-        ))}
-      </PhotoGrid>
+    <Card title="행사 사진" actionLabel="더보기" actionHref="/info/events">
+      {photos.length > 0 ? (
+        <PhotoGrid>
+          {photos.map((photo, index) => {
+            const title = photo.title ?? "제목 없음";
+            const date = formatUtcToKstShortDate(photo.createdAt ?? photo.updatedAt);
+
+            return (
+              <PhotoItem
+                key={`${photo.id ?? "event"}-${photo.channelId ?? "channel"}-${index}`}
+                href={buildEventHref(photo, eventChannel?.id)}
+              >
+                <Thumbnail>
+                  {photo.thumbnailUrl ? (
+                    <PhotoImage src={photo.thumbnailUrl} alt={title} />
+                  ) : (
+                    <ThumbnailPlaceholder aria-hidden="true">
+                      <IconPhoto size={28} stroke={1.8} />
+                    </ThumbnailPlaceholder>
+                  )}
+                </Thumbnail>
+                <PhotoTitle>{title}</PhotoTitle>
+                <PhotoDate>{date}</PhotoDate>
+              </PhotoItem>
+            );
+          })}
+        </PhotoGrid>
+      ) : (
+        <Fallback>{stateMessage}</Fallback>
+      )}
     </Card>
   );
 }
@@ -49,8 +119,15 @@ const PhotoGrid = styled.div`
   }
 `;
 
-const PhotoItem = styled.article`
+const PhotoItem = styled(Link)`
+  display: block;
   min-width: 0;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover h3 {
+    color: ${colors.point};
+  }
 `;
 
 const Thumbnail = styled.div`
@@ -67,8 +144,20 @@ const Thumbnail = styled.div`
   }
 `;
 
-const PhotoImage = styled(Image)`
+const PhotoImage = styled.img`
+  display: block;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+`;
+
+const ThumbnailPlaceholder = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: ${colors.placeholder};
 `;
 
 const PhotoTitle = styled.h3`
@@ -97,4 +186,11 @@ const PhotoDate = styled.time`
     margin-top: ${spacing.space8};
     font-size: ${typography.fontSize20};
   }
+`;
+
+const Fallback = styled.p`
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  padding: ${spacing.space8} 0;
 `;

--- a/components/home/HomePage.tsx
+++ b/components/home/HomePage.tsx
@@ -4,7 +4,7 @@ import LoginCard from "@/components/home/LoginCard";
 import MeetingRecordsCard from "@/components/home/MeetingRecordsCard";
 import NoticeCard from "@/components/home/NoticeCard";
 import WeeklySchedulePanel from "@/components/home/WeeklySchedulePanel";
-import { eventPhotos, meetingRecords } from "@/mocks/home";
+import { meetingRecords } from "@/mocks/home";
 import { colors, layout, spacing } from "@/styles/tokens";
 
 export default function HomePage() {
@@ -31,7 +31,7 @@ export default function HomePage() {
           </MeetingArea>
 
           <EventArea>
-            <EventPhotoCard photos={eventPhotos} />
+            <EventPhotoCard />
           </EventArea>
         </BottomGrid>
       </Content>

--- a/components/info/events/EventDetailPageClient.tsx
+++ b/components/info/events/EventDetailPageClient.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { IconDownload } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { deletePost, getPost } from "@/api/post/post.api";
+import ToastViewerField from "@/components/admin/posts/ToastViewerField";
+import EventDocumentLayout from "@/components/info/events/EventDocumentLayout";
+import { canManageEventPost } from "@/components/info/events/eventUtils";
+import {
+  ActionButton,
+  ActionLink,
+  ContentStack,
+  DocumentSection,
+  DownloadBadge,
+  FieldBox,
+  FileLink,
+  FileList,
+  Label,
+  MetaBar,
+  StateMessage,
+  Toolbar,
+  ToolbarRight,
+  ViewerBox,
+} from "@/components/staff/board/BoardDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+type EventDetailPageClientProps = {
+  postId: number;
+  channelId?: number;
+};
+
+export default function EventDetailPageClient({ postId, channelId }: EventDetailPageClientProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useAuthSession();
+  const hasChannelId = typeof channelId === "number" && Number.isFinite(channelId);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.posts.boardDetail(channelId ?? 0, postId),
+    queryFn: () => getPost({ channelId: channelId ?? 0, postId }),
+    enabled: hasChannelId,
+    retry: false,
+  });
+
+  const visiblePost = data;
+  const date = formatUtcToKstShortDate(visiblePost?.createdAt ?? visiblePost?.updatedAt);
+  const title = visiblePost?.title ?? "제목";
+  const author = visiblePost?.authorName ?? "홍길동";
+  const content = visiblePost?.contentHtml?.trim() || "내용";
+  const canManagePost = canManageEventPost(user, visiblePost);
+  const editHref =
+    hasChannelId && visiblePost?.id
+      ? `/info/events/new?postId=${visiblePost.id}&channelId=${channelId}`
+      : "/info/events/new";
+  const attachments = visiblePost?.attachments ?? [];
+
+  const deletePostMutation = useMutation({
+    mutationFn: () => deletePost({ channelId: channelId ?? 0, postId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["info", "events"] });
+      await queryClient.invalidateQueries({ queryKey: ["posts"] });
+      router.push("/info/events");
+    },
+  });
+
+  const stateMessage =
+    !visiblePost && !hasChannelId
+      ? "게시글 채널 정보가 없어 상세 내용을 불러오지 못했습니다."
+      : isLoading
+        ? "게시글을 불러오는 중입니다."
+        : isError && !visiblePost
+          ? "게시글을 불러오지 못했습니다."
+          : deletePostMutation.isError
+            ? "게시글 삭제에 실패했습니다."
+            : "";
+
+  return (
+    <EventDocumentLayout>
+      <DocumentSection>
+        <Toolbar>
+          <ActionLink href="/info/events" $variant="muted">
+            목록
+          </ActionLink>
+
+          {canManagePost ? (
+            <ToolbarRight>
+              <ActionButton
+                type="button"
+                $variant="danger"
+                disabled={!hasChannelId || deletePostMutation.isPending}
+                onClick={() => deletePostMutation.mutate()}
+              >
+                삭제
+              </ActionButton>
+              <ActionLink href={editHref} $variant="edit">
+                수정
+              </ActionLink>
+            </ToolbarRight>
+          ) : null}
+        </Toolbar>
+
+        {stateMessage ? <StateMessage>{stateMessage}</StateMessage> : null}
+
+        <ContentStack>
+          <MetaBar>
+            <span>행사 정보</span>
+            <span>{date}</span>
+          </MetaBar>
+
+          <Label>제목</Label>
+          <FieldBox>{title}</FieldBox>
+
+          <Label>작성자</Label>
+          <FieldBox>{author}</FieldBox>
+
+          <Label>내용</Label>
+          <ViewerBox>
+            <ToastViewerField value={content} />
+          </ViewerBox>
+
+          <Label>자료</Label>
+          <FileList>
+            {attachments.length > 0 ? (
+              attachments.map((file) => {
+                const href = file.downloadUrl ?? file.url ?? "#";
+                const label = file.originalName ?? file.fileId ?? "첨부파일";
+                return (
+                  <FileLink key={`${file.fileId ?? label}-${file.sortOrder ?? 0}`} href={href}>
+                    <span>{label}</span>
+                    <DownloadBadge aria-hidden="true">
+                      <IconDownload size={16} stroke={2.25} />
+                    </DownloadBadge>
+                  </FileLink>
+                );
+              })
+            ) : (
+              <StateMessage>등록된 자료가 없습니다.</StateMessage>
+            )}
+          </FileList>
+        </ContentStack>
+      </DocumentSection>
+    </EventDocumentLayout>
+  );
+}

--- a/components/info/events/EventDocumentLayout.tsx
+++ b/components/info/events/EventDocumentLayout.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { ReactNode } from "react";
+import styled from "styled-components";
+import { EventInfoSidebar } from "@/components/info/events/EventInfoLayout";
+import { colors, layout } from "@/styles/tokens";
+
+type EventDocumentLayoutProps = {
+  children: ReactNode;
+};
+
+export default function EventDocumentLayout({ children }: EventDocumentLayoutProps) {
+  return (
+    <Main>
+      <Stage>
+        <EventInfoSidebar />
+        <Content>{children}</Content>
+      </Stage>
+    </Main>
+  );
+}
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+  }
+`;
+
+const Stage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const Content = styled.section`
+  flex: 1;
+  min-width: 0;
+`;

--- a/components/info/events/EventFormPageClient.tsx
+++ b/components/info/events/EventFormPageClient.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { IconPaperclip } from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { getChannels } from "@/api/channel/channel.api";
+import { createPost, getPost, updatePost } from "@/api/post/post.api";
+import ToastEditorField from "@/components/admin/posts/ToastEditorField";
+import EventDocumentLayout from "@/components/info/events/EventDocumentLayout";
+import {
+  EVENT_CHANNEL_TYPE,
+  canManageEventPost,
+  extractFirstImageUrl,
+  findEventChannel,
+} from "@/components/info/events/eventUtils";
+import {
+  ActionButton,
+  DocumentSection,
+  FileSelectLabel,
+  FileUploadPanel,
+  Form,
+  HiddenFileInput,
+  Input,
+  Label,
+  PageTitle,
+  StateMessage,
+  Toolbar,
+} from "@/components/staff/board/BoardDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { boardFileToGoogleDrive } from "@/lib/googleDrive/boardFileToGoogleDrive";
+import { queryKeys } from "@/lib/queryKeys";
+
+type EventFormPageClientProps = {
+  editPostId?: number;
+  editChannelId?: number;
+};
+
+export default function EventFormPageClient({ editPostId, editChannelId }: EventFormPageClientProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { status, user } = useAuthSession();
+  const isEditMode = typeof editPostId === "number" && typeof editChannelId === "number";
+  const [title, setTitle] = useState<string | undefined>(undefined);
+  const [contentHtml, setContentHtml] = useState<string | undefined>(undefined);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
+  const channelsQuery = useQuery({
+    queryKey: ["info", "events", "channels"],
+    queryFn: () => getChannels({ channelType: EVENT_CHANNEL_TYPE, isActive: true }),
+    retry: false,
+  });
+  const postDetailQuery = useQuery({
+    queryKey: queryKeys.posts.boardDetail(editChannelId ?? 0, editPostId ?? 0),
+    queryFn: () => getPost({ channelId: editChannelId ?? 0, postId: editPostId ?? 0 }),
+    enabled: isEditMode,
+    retry: false,
+  });
+
+  const eventChannel = useMemo(() => findEventChannel(channelsQuery.data), [channelsQuery.data]);
+  const currentUserName = user?.name ?? user?.nickname ?? user?.email ?? "";
+  const visibleTitle = title ?? postDetailQuery.data?.title ?? "";
+  const visibleAuthor = postDetailQuery.data?.authorName ?? currentUserName;
+  const visibleContentHtml = contentHtml ?? postDetailQuery.data?.contentHtml ?? "";
+  const canManagePost =
+    !isEditMode ? status === "authenticated" : canManageEventPost(user, postDetailQuery.data);
+
+  const uploadEventFiles = async (files: File[]) => {
+    if (files.length === 0) return;
+
+    await Promise.all(files.map((file) => boardFileToGoogleDrive(file)));
+  };
+
+  const { mutate, isPending, isError } = useMutation({
+    mutationFn: async () => {
+      const channelId = isEditMode ? editChannelId : eventChannel?.id;
+
+      if (!channelId) {
+        throw new Error("행사 정보를 등록할 채널을 찾을 수 없습니다.");
+      }
+
+      if (!canManagePost) {
+        throw new Error("행사 정보를 저장할 권한이 없습니다.");
+      }
+
+      const thumbnailUrl = extractFirstImageUrl(visibleContentHtml);
+
+      if (isEditMode) {
+        const updated = await updatePost(
+          { channelId, postId: editPostId },
+          {
+            title: visibleTitle.trim(),
+            contentHtml: visibleContentHtml.trim(),
+            status: "PUBLISHED",
+            allowComment: true,
+            thumbnailUrl,
+          },
+        );
+
+        await uploadEventFiles(selectedFiles);
+
+        return updated;
+      }
+
+      const created = await createPost(
+        { channelId },
+        {
+          title: visibleTitle.trim(),
+          contentHtml: visibleContentHtml.trim(),
+          status: "PUBLISHED",
+          allowComment: true,
+          thumbnailUrl: thumbnailUrl || undefined,
+        },
+      );
+
+      await uploadEventFiles(selectedFiles);
+
+      return created;
+    },
+    onSuccess: async (post) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["info", "events"] }),
+        queryClient.invalidateQueries({ queryKey: ["posts"] }),
+        typeof post.channelId === "number" && typeof post.id === "number"
+          ? queryClient.invalidateQueries({
+              queryKey: queryKeys.posts.boardDetail(post.channelId, post.id),
+            })
+          : Promise.resolve(),
+      ]);
+
+      router.push(
+        typeof post.id === "number" && typeof post.channelId === "number"
+          ? `/info/events/${post.id}?channelId=${post.channelId}`
+          : "/info/events",
+      );
+    },
+  });
+
+  const canSubmit =
+    status === "authenticated" &&
+    visibleTitle.trim().length > 0 &&
+    visibleContentHtml.trim().length > 0 &&
+    Boolean(isEditMode ? editChannelId : eventChannel?.id) &&
+    canManagePost &&
+    !isPending;
+
+  return (
+    <EventDocumentLayout>
+      <DocumentSection>
+        <Toolbar>
+          <PageTitle>{isEditMode ? "행사 정보 수정" : "행사 정보 작성"}</PageTitle>
+          <ActionButton type="submit" form="event-form" disabled={!canSubmit}>
+            {isEditMode ? "수정 완료" : "작성 완료"}
+          </ActionButton>
+        </Toolbar>
+
+        <Form
+          id="event-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canSubmit) mutate();
+          }}
+        >
+          <Label as="label" htmlFor="event-title">
+            제목
+          </Label>
+          <Input
+            id="event-title"
+            name="title"
+            placeholder="제목"
+            value={visibleTitle}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+
+          <Label as="label" htmlFor="event-author">
+            작성자
+          </Label>
+          <Input id="event-author" name="author" value={visibleAuthor} readOnly />
+
+          <Label as="label" htmlFor="event-content">
+            내용
+          </Label>
+          <ToastEditorField initialValue={visibleContentHtml} onChange={setContentHtml} />
+
+          <Label>자료</Label>
+          <FileUploadPanel>
+            {selectedFiles.length > 0 ? (
+              selectedFiles.map((file, index) => (
+                <span key={`${file.name}-${index}`}>{file.name}</span>
+              ))
+            ) : (
+              <span>선택된 파일이 없습니다.</span>
+            )}
+            <FileSelectLabel>
+              <IconPaperclip aria-hidden="true" size={16} stroke={2.25} />
+              <span>파일 선택</span>
+              <HiddenFileInput
+                type="file"
+                name="files"
+                multiple
+                onChange={(event) => {
+                  setSelectedFiles(Array.from(event.target.files ?? []));
+                }}
+              />
+            </FileSelectLabel>
+          </FileUploadPanel>
+
+          {status === "unauthenticated" ? (
+            <StateMessage>로그인 후 행사 정보를 작성할 수 있습니다.</StateMessage>
+          ) : null}
+          {channelsQuery.isError ? (
+            <StateMessage>행사 정보 채널을 불러오지 못했습니다.</StateMessage>
+          ) : null}
+          {postDetailQuery.isError ? (
+            <StateMessage>수정할 행사 정보를 불러오지 못했습니다.</StateMessage>
+          ) : null}
+          {!canManagePost && status === "authenticated" ? (
+            <StateMessage>이 행사 정보를 수정할 권한이 없습니다.</StateMessage>
+          ) : null}
+          {isError ? (
+            <StateMessage>
+              {isEditMode ? "행사 정보 수정에 실패했습니다." : "행사 정보 작성에 실패했습니다."}
+            </StateMessage>
+          ) : null}
+        </Form>
+      </DocumentSection>
+    </EventDocumentLayout>
+  );
+}

--- a/components/info/events/EventInfoLayout.tsx
+++ b/components/info/events/EventInfoLayout.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import styled from "styled-components";
+import { colors, layout, typography } from "@/styles/tokens";
+
+const sidebarItems = [
+  { label: "연혁", href: "/info/history" },
+  { label: "부서 정보", href: "/info/departments" },
+  { label: "반 정보", href: "/info/classes" },
+  { label: "행사 정보", href: "/info/events" },
+];
+
+type EventInfoLayoutProps = {
+  children: ReactNode;
+};
+
+export default function EventInfoLayout({ children }: EventInfoLayoutProps) {
+  return (
+    <Shell>
+      <Stage>
+        <EventInfoSidebar />
+        {children}
+      </Stage>
+    </Shell>
+  );
+}
+
+export function EventInfoSidebar() {
+  return (
+    <InfoSidebar>
+      <SidebarHeader>기관 정보</SidebarHeader>
+      <SidebarContent>
+        <SidebarList>
+          {sidebarItems.map((item) => {
+            const isCurrent = item.href === "/info/events";
+            return (
+              <SidebarItem key={item.href}>
+                <SidebarLink
+                  href={item.href}
+                  $isCurrent={isCurrent}
+                  aria-current={isCurrent ? "page" : undefined}
+                >
+                  {item.label}
+                </SidebarLink>
+              </SidebarItem>
+            );
+          })}
+        </SidebarList>
+      </SidebarContent>
+    </InfoSidebar>
+  );
+}
+
+const Shell = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+  }
+`;
+
+const Stage = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  min-height: calc(100vh - ${layout.headerHeight});
+  margin: 0 auto;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    max-width: 120rem;
+    min-height: calc(100vh - 7.1875rem);
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-direction: column;
+  }
+`;
+
+const InfoSidebar = styled.aside`
+  width: 11.625rem;
+  flex-shrink: 0;
+  background-color: ${colors.background};
+  border-right: 1px solid ${colors.border};
+
+  @media (min-width: 120rem) {
+    width: 17.4375rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    width: 100%;
+  }
+`;
+
+const SidebarHeader = styled.h1`
+  display: flex;
+  align-items: center;
+  min-height: 3.625rem;
+  margin: 0;
+  padding: 0 1.625rem;
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    min-height: 5.5rem;
+    padding: 0 2.5rem;
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const SidebarContent = styled.nav`
+  padding: 1.75rem 0 2.5rem;
+
+  @media (min-width: 120rem) {
+    padding: 2.75rem 0 3.75rem;
+  }
+`;
+
+const SidebarList = styled.ul`
+  display: grid;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  @media (min-width: 120rem) {
+    gap: 0.625rem;
+  }
+`;
+
+const SidebarItem = styled.li`
+  display: block;
+`;
+
+const SidebarLink = styled(Link)<{ $isCurrent: boolean }>`
+  display: block;
+  padding: 0.25rem 1.625rem;
+  background-color: ${({ $isCurrent }) => ($isCurrent ? colors.point : "transparent")};
+  color: ${({ $isCurrent }) => ($isCurrent ? colors.white : colors.point)};
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    background-color: ${({ $isCurrent }) => ($isCurrent ? colors.point : "#eeeeee")};
+    color: ${({ $isCurrent }) => ($isCurrent ? colors.white : colors.text)};
+  }
+
+  @media (min-width: 120rem) {
+    padding: 0.3125rem 2.5rem;
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/info/events/EventListPageClient.tsx
+++ b/components/info/events/EventListPageClient.tsx
@@ -8,13 +8,13 @@ import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
 import { getPosts } from "@/api/post/post.api";
-import type { PostSummaryResponseDto } from "@/api/post/post.dto";
 import EventInfoLayout from "@/components/info/events/EventInfoLayout";
 import {
   EVENT_CHANNEL_TYPE,
   EVENT_FETCH_SIZE,
   EVENTS_PER_PAGE,
   findEventChannel,
+  sortEventPosts,
 } from "@/components/info/events/eventUtils";
 import { ActionLink } from "@/components/staff/board/BoardDocument.styles";
 import { useAuthSession } from "@/hooks/useAuthSession";
@@ -24,18 +24,6 @@ import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 type EventListPageClientProps = {
   initialPage: number;
 };
-
-function getPostTime(post: PostSummaryResponseDto) {
-  const dateValue = post.createdAt ?? post.updatedAt;
-  if (!dateValue) return 0;
-
-  const time = new Date(dateValue).getTime();
-  return Number.isNaN(time) ? 0 : time;
-}
-
-function sortEventPosts(posts: PostSummaryResponseDto[]) {
-  return [...posts].sort((a, b) => getPostTime(b) - getPostTime(a));
-}
 
 export default function EventListPageClient({ initialPage }: EventListPageClientProps) {
   const router = useRouter();

--- a/components/info/events/EventListPageClient.tsx
+++ b/components/info/events/EventListPageClient.tsx
@@ -1,0 +1,509 @@
+"use client";
+
+import { type FormEvent, useMemo, useState } from "react";
+import { IconEdit, IconPhoto, IconSearch } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+import { getChannels } from "@/api/channel/channel.api";
+import { getPosts } from "@/api/post/post.api";
+import type { PostSummaryResponseDto } from "@/api/post/post.dto";
+import EventInfoLayout from "@/components/info/events/EventInfoLayout";
+import {
+  EVENT_CHANNEL_TYPE,
+  EVENT_FETCH_SIZE,
+  EVENTS_PER_PAGE,
+  findEventChannel,
+} from "@/components/info/events/eventUtils";
+import { ActionLink } from "@/components/staff/board/BoardDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+type EventListPageClientProps = {
+  initialPage: number;
+};
+
+function getPostTime(post: PostSummaryResponseDto) {
+  const dateValue = post.createdAt ?? post.updatedAt;
+  if (!dateValue) return 0;
+
+  const time = new Date(dateValue).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function sortEventPosts(posts: PostSummaryResponseDto[]) {
+  return [...posts].sort((a, b) => getPostTime(b) - getPostTime(a));
+}
+
+export default function EventListPageClient({ initialPage }: EventListPageClientProps) {
+  const router = useRouter();
+  const { status } = useAuthSession();
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const requestedPage = Number.isInteger(initialPage) && initialPage >= 1 ? initialPage : 1;
+
+  const channelsQuery = useQuery({
+    queryKey: ["info", "events", "channels"],
+    queryFn: () => getChannels({ channelType: EVENT_CHANNEL_TYPE, isActive: true }),
+    retry: false,
+  });
+
+  const eventChannel = findEventChannel(channelsQuery.data);
+
+  const postsQuery = useQuery({
+    queryKey: ["info", "events", "posts", eventChannel?.id, searchKeyword],
+    queryFn: () =>
+      getPosts({
+        channelType: EVENT_CHANNEL_TYPE,
+        channelId: eventChannel?.id,
+        title: searchKeyword.trim() || undefined,
+        status: "PUBLISHED",
+        page: 0,
+        size: EVENT_FETCH_SIZE,
+      }),
+    enabled: typeof eventChannel?.id === "number",
+    retry: false,
+  });
+
+  const sortedPosts = useMemo(
+    () => sortEventPosts(postsQuery.data?.content ?? []),
+    [postsQuery.data?.content],
+  );
+  const totalPages = Math.max(1, Math.ceil(sortedPosts.length / EVENTS_PER_PAGE));
+  const currentPage = requestedPage > totalPages ? 1 : requestedPage;
+  const pagedPosts = sortedPosts.slice(
+    (currentPage - 1) * EVENTS_PER_PAGE,
+    currentPage * EVENTS_PER_PAGE,
+  );
+  const canWrite = status === "authenticated";
+  const isLoading = channelsQuery.isLoading || postsQuery.isLoading;
+  const isError = channelsQuery.isError || postsQuery.isError;
+  const emptyMessage = isLoading
+    ? "행사 정보를 불러오는 중입니다."
+    : isError
+      ? "행사 정보를 불러오지 못했습니다."
+      : "등록된 행사 정보가 없습니다.";
+
+  function moveToPage(page: number) {
+    if (page === currentPage) return;
+    router.push(`/info/events?page=${page}`);
+  }
+
+  function handleSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSearchKeyword(searchInput);
+    if (currentPage > 1) {
+      router.replace("/info/events", { scroll: false });
+    }
+  }
+
+  return (
+    <EventInfoLayout>
+      <Content>
+        <HeaderRow>
+          <Title>행사 정보</Title>
+          {canWrite ? (
+            <WriteLink href="/info/events/new" $variant="edit">
+              <span>행사 정보 추가하기</span>
+              <IconEdit aria-hidden="true" size={16} stroke={2} />
+            </WriteLink>
+          ) : null}
+        </HeaderRow>
+
+        <CardsSection>
+          {pagedPosts.length > 0 ? (
+            <EventGrid aria-label="행사 정보 목록">
+              {pagedPosts.map((post, index) => {
+                const postId = post.id ?? index;
+                const href = `/info/events/${postId}${
+                  typeof post.channelId === "number" ? `?channelId=${post.channelId}` : ""
+                }`;
+
+                return (
+                  <EventCard key={`${postId}-${post.channelId ?? "event"}`} href={href}>
+                    {post.thumbnailUrl ? (
+                      <ThumbnailImage src={post.thumbnailUrl} alt="" />
+                    ) : (
+                      <ThumbnailPlaceholder aria-hidden="true">
+                        <IconPhoto size={28} stroke={1.8} />
+                      </ThumbnailPlaceholder>
+                    )}
+                    <CardMeta>
+                      <CardTitle>{post.title ?? "제목 없음"}</CardTitle>
+                      <CardInfo>
+                        <Author>{post.authorName ?? "-"}</Author>
+                        <DateText>
+                          {formatUtcToKstShortDate(post.createdAt ?? post.updatedAt)}
+                        </DateText>
+                      </CardInfo>
+                    </CardMeta>
+                  </EventCard>
+                );
+              })}
+            </EventGrid>
+          ) : (
+            <EmptyState>{emptyMessage}</EmptyState>
+          )}
+        </CardsSection>
+
+        <FooterBar>
+          <Pagination aria-label="행사 정보 페이지">
+            <PageButton
+              type="button"
+              disabled={currentPage <= 1}
+              onClick={() => moveToPage(currentPage - 1)}
+              aria-label="이전 페이지"
+            >
+              ◀
+            </PageButton>
+            {Array.from({ length: totalPages }, (_, index) => index + 1)
+              .slice(0, 5)
+              .map((page) => (
+                <PageNumber
+                  key={page}
+                  type="button"
+                  $isCurrent={page === currentPage}
+                  onClick={() => moveToPage(page)}
+                  aria-current={page === currentPage ? "page" : undefined}
+                >
+                  {page}
+                </PageNumber>
+              ))}
+            <PageButton
+              type="button"
+              disabled={currentPage >= totalPages}
+              onClick={() => moveToPage(currentPage + 1)}
+              aria-label="다음 페이지"
+            >
+              ▶
+            </PageButton>
+          </Pagination>
+
+          <SearchForm role="search" onSubmit={handleSearch}>
+            <SearchInput
+              aria-label="행사 정보 검색"
+              placeholder="검색어를 입력해주세요"
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+            />
+            <SearchButton type="submit" aria-label="검색">
+              <IconSearch size={18} stroke={2.25} />
+            </SearchButton>
+          </SearchForm>
+        </FooterBar>
+      </Content>
+    </EventInfoLayout>
+  );
+}
+
+const Content = styled.section`
+  flex: 1;
+  min-width: 0;
+  padding: 2.1875rem 3.125rem 4rem;
+
+  @media (min-width: 120rem) {
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: 2.75rem;
+
+  @media (min-width: 120rem) {
+    margin-bottom: 3.5rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: 2.5rem;
+  }
+`;
+
+const WriteLink = styled(ActionLink)`
+  gap: ${spacing.space8};
+`;
+
+const CardsSection = styled.section`
+  width: 100%;
+  min-height: 25rem;
+
+  @media (min-width: 120rem) {
+    min-height: 39.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    min-height: 32rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    min-height: 42rem;
+  }
+`;
+
+const EventGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem 2.75rem;
+
+  @media (min-width: 120rem) {
+    gap: 3.75rem 3.875rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const EventCard = styled(Link)`
+  display: grid;
+  gap: 0.875rem;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover h3 {
+    color: ${colors.point};
+  }
+`;
+
+const ThumbnailImage = styled.img`
+  display: block;
+  width: 100%;
+  aspect-ratio: 160 / 90;
+  object-fit: cover;
+  background-color: #d9d9d9;
+`;
+
+const ThumbnailPlaceholder = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 160 / 90;
+  background-color: #d9d9d9;
+  color: ${colors.placeholder};
+`;
+
+const CardMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  min-width: 0;
+`;
+
+const CardTitle = styled.h3`
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: #000000;
+  font-size: ${typography.fontSize16};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const CardInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  flex: 0 0 auto;
+  min-width: 0;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const Author = styled.span`
+  color: #000000;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const DateText = styled.span`
+  color: ${colors.muted};
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const EmptyState = styled.p`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  min-height: 25rem;
+  color: ${colors.placeholder};
+  font-size: ${typography.fontSize16};
+  line-height: ${typography.lineHeight150};
+  text-align: center;
+
+  @media (min-width: 120rem) {
+    min-height: 39.75rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const FooterBar = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: ${spacing.space24};
+  margin-top: 2.75rem;
+
+  @media (min-width: 120rem) {
+    margin-top: 4rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+`;
+
+const Pagination = styled.nav`
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space8};
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-column: auto;
+  }
+`;
+
+const PageButton = styled.button`
+  border: 0;
+  background: transparent;
+  color: ${colors.muted};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight100};
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const PageNumber = styled.button<{ $isCurrent: boolean }>`
+  border: 0;
+  background: transparent;
+  color: ${({ $isCurrent }) => ($isCurrent ? "#000000" : colors.muted)};
+  font-family: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isCurrent }) => ($isCurrent ? 600 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
+  }
+`;
+
+const SearchForm = styled.form`
+  grid-column: 3;
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-column: auto;
+    justify-self: stretch;
+    width: 100%;
+  }
+`;
+
+const SearchInput = styled.input`
+  width: 13.75rem;
+  min-height: 2.25rem;
+  border: 0;
+  border-bottom: 1px solid ${colors.muted};
+  background: ${colors.white};
+  padding: 0.5rem 0;
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+
+  &::placeholder {
+    color: ${colors.muted};
+  }
+
+  @media (min-width: 120rem) {
+    width: 20.625rem;
+    min-height: 3rem;
+    font-size: ${typography.fontSize20};
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+`;
+
+const SearchButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: ${radii.radius30};
+  background: ${colors.text};
+  color: ${colors.white};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3.25rem;
+    height: 3.25rem;
+  }
+`;

--- a/components/info/events/EventListPageClient.tsx
+++ b/components/info/events/EventListPageClient.tsx
@@ -7,7 +7,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
+import type { ChannelResponseDto } from "@/api/channel/channel.dto";
 import { getPosts } from "@/api/post/post.api";
+import type { PostListResponseDto } from "@/api/post/post.dto";
 import EventInfoLayout from "@/components/info/events/EventInfoLayout";
 import {
   EVENT_CHANNEL_TYPE,
@@ -23,9 +25,15 @@ import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type EventListPageClientProps = {
   initialPage: number;
+  initialChannels?: ChannelResponseDto[];
+  initialPosts?: PostListResponseDto;
 };
 
-export default function EventListPageClient({ initialPage }: EventListPageClientProps) {
+export default function EventListPageClient({
+  initialPage,
+  initialChannels,
+  initialPosts,
+}: EventListPageClientProps) {
   const router = useRouter();
   const { status } = useAuthSession();
   const [searchInput, setSearchInput] = useState("");
@@ -35,6 +43,7 @@ export default function EventListPageClient({ initialPage }: EventListPageClient
   const channelsQuery = useQuery({
     queryKey: ["info", "events", "channels"],
     queryFn: () => getChannels({ channelType: EVENT_CHANNEL_TYPE, isActive: true }),
+    initialData: initialChannels,
     retry: false,
   });
 
@@ -52,6 +61,8 @@ export default function EventListPageClient({ initialPage }: EventListPageClient
         size: EVENT_FETCH_SIZE,
       }),
     enabled: typeof eventChannel?.id === "number",
+    initialData: searchKeyword ? undefined : initialPosts,
+    placeholderData: (previousData) => previousData,
     retry: false,
   });
 
@@ -66,7 +77,8 @@ export default function EventListPageClient({ initialPage }: EventListPageClient
     currentPage * EVENTS_PER_PAGE,
   );
   const canWrite = status === "authenticated";
-  const isLoading = channelsQuery.isLoading || postsQuery.isLoading;
+  const hasLoadedPosts = typeof postsQuery.data !== "undefined";
+  const isLoading = channelsQuery.isLoading || (postsQuery.isLoading && !hasLoadedPosts);
   const isError = channelsQuery.isError || postsQuery.isError;
   const emptyMessage = isLoading
     ? "행사 정보를 불러오는 중입니다."
@@ -205,9 +217,11 @@ const HeaderRow = styled.div`
   align-items: flex-start;
   justify-content: space-between;
   gap: ${spacing.space24};
+  min-height: 2.9rem;
   margin-bottom: 2.75rem;
 
   @media (min-width: 120rem) {
+    min-height: 4.5rem;
     margin-bottom: 3.5rem;
   }
 

--- a/components/info/events/eventUtils.ts
+++ b/components/info/events/eventUtils.ts
@@ -1,0 +1,42 @@
+import type { ChannelResponseDto } from "@/api/channel/channel.dto";
+import type { PostDetailResponseDto, PostSummaryResponseDto } from "@/api/post/post.dto";
+
+export const EVENT_CHANNEL_TYPE = "EVENT";
+export const EVENTS_PER_PAGE = 6;
+export const EVENT_FETCH_SIZE = 100;
+
+export function findEventChannel(channels?: ChannelResponseDto[]) {
+  return channels?.find((channel) => channel.channelType === EVENT_CHANNEL_TYPE && channel.isDefault)
+    ?? channels?.find((channel) => channel.channelType === EVENT_CHANNEL_TYPE)
+    ?? channels?.find((channel) => channel.name === "행사 정보");
+}
+
+export function canManageEventPost(
+  user: {
+    id?: number;
+    role?: string;
+    name?: string;
+    nickname?: string;
+    email?: string;
+  } | null | undefined,
+  post: Pick<PostDetailResponseDto | PostSummaryResponseDto, "authorId" | "authorName"> | null | undefined,
+) {
+  if (!user || !post) return false;
+  if (user.role === "ADMIN") return true;
+  if (typeof user.id === "number" && post.authorId === user.id) return true;
+
+  return Boolean(
+    post.authorName &&
+      (post.authorName === user.name ||
+        post.authorName === user.nickname ||
+        post.authorName === user.email),
+  );
+}
+
+export function extractFirstImageUrl(contentHtml: string) {
+  if (!contentHtml.trim() || typeof window === "undefined") return "";
+
+  const document = new DOMParser().parseFromString(contentHtml, "text/html");
+  const image = document.querySelector("img[src]");
+  return image?.getAttribute("src")?.trim() ?? "";
+}

--- a/components/info/events/eventUtils.ts
+++ b/components/info/events/eventUtils.ts
@@ -5,6 +5,18 @@ export const EVENT_CHANNEL_TYPE = "EVENT";
 export const EVENTS_PER_PAGE = 6;
 export const EVENT_FETCH_SIZE = 100;
 
+export function getEventPostTime(post: PostSummaryResponseDto) {
+  const dateValue = post.createdAt ?? post.updatedAt;
+  if (!dateValue) return 0;
+
+  const time = new Date(dateValue).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+export function sortEventPosts(posts: PostSummaryResponseDto[]) {
+  return [...posts].sort((a, b) => getEventPostTime(b) - getEventPostTime(a));
+}
+
 export function findEventChannel(channels?: ChannelResponseDto[]) {
   return channels?.find((channel) => channel.channelType === EVENT_CHANNEL_TYPE && channel.isDefault)
     ?? channels?.find((channel) => channel.channelType === EVENT_CHANNEL_TYPE)

--- a/components/staff/board/BoardListPageClient.tsx
+++ b/components/staff/board/BoardListPageClient.tsx
@@ -40,6 +40,10 @@ function isNoticePost(post: PostSummaryResponseDto) {
   return post.channelType === "NOTICE" || post.postType === "NOTICE";
 }
 
+function isEventPost(post: PostSummaryResponseDto) {
+  return post.channelType === "EVENT" || post.postType === "EVENT";
+}
+
 function isPinnedPost(post: PostSummaryResponseDto) {
   return Boolean(post.isPinned);
 }
@@ -192,7 +196,9 @@ export default function BoardListPageClient({
     retry: false,
   });
 
-  const rawPosts = (data?.content ?? []).filter((post) => !isArchiveDocumentPost(post));
+  const rawPosts = (data?.content ?? []).filter(
+    (post) => !isArchiveDocumentPost(post) && !isEventPost(post),
+  );
   const posts = rawPosts.filter((post) => {
     if (!mineOnly) return true;
     if (typeof user?.id === "number" && post.authorId === user.id) return true;

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,6 +1,8 @@
 export const queryKeys = {
   posts: {
     noticeTop12: () => ["posts", "notice", "top12"] as const,
+    eventChannels: () => ["posts", "event", "channels"] as const,
+    eventHomePhotos: (channelId?: number) => ["posts", "event", "homePhotos", channelId] as const,
     boardList: (filters: {
       page: number;
       channelType: string;

--- a/mocks/handlers/channel.handlers.ts
+++ b/mocks/handlers/channel.handlers.ts
@@ -45,15 +45,15 @@ function hasValidAuthorization(request: Request) {
 
 export const channelHandlers: RequestHandler[] = [
   http.get(`${API_BASE_URL}/api/v1/channels`, ({ request }) => {
-    if (!hasValidAuthorization(request)) {
-      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
     const url = new URL(request.url);
     const channelType = url.searchParams.get("channelType");
 
     if (channelType === "EVENT") {
       return HttpResponse.json([EVENT_CHANNEL_RESPONSE]);
+    }
+
+    if (!hasValidAuthorization(request)) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
     return HttpResponse.json([...CHANNEL_LIST_RESPONSE, EVENT_CHANNEL_RESPONSE]);

--- a/mocks/handlers/channel.handlers.ts
+++ b/mocks/handlers/channel.handlers.ts
@@ -21,6 +21,19 @@ export const CHANNEL_RESPONSE = {
 };
 
 export const CHANNEL_LIST_RESPONSE = [CHANNEL_RESPONSE];
+export const EVENT_CHANNEL_RESPONSE = {
+  ...CHANNEL_RESPONSE,
+  id: 4,
+  name: "행사 정보",
+  description: "행사 정보 기본 채널",
+  channelType: "EVENT",
+  bindingType: "STANDALONE",
+  refId: null,
+  accessLevel: "READ_WRITE",
+  allowGuestRead: true,
+  isDefault: true,
+  isActive: true,
+};
 
 function hasValidAuthorization(request: Request) {
   const authorizationHeader = request.headers.get("authorization");
@@ -36,7 +49,14 @@ export const channelHandlers: RequestHandler[] = [
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
-    return HttpResponse.json(CHANNEL_LIST_RESPONSE);
+    const url = new URL(request.url);
+    const channelType = url.searchParams.get("channelType");
+
+    if (channelType === "EVENT") {
+      return HttpResponse.json([EVENT_CHANNEL_RESPONSE]);
+    }
+
+    return HttpResponse.json([...CHANNEL_LIST_RESPONSE, EVENT_CHANNEL_RESPONSE]);
   }),
   http.post(`${API_BASE_URL}/api/v1/channels`, async ({ request }) => {
     if (!hasValidAuthorization(request)) {

--- a/mocks/handlers/post.handlers.ts
+++ b/mocks/handlers/post.handlers.ts
@@ -33,6 +33,37 @@ export const POST_LIST_RESPONSE = {
   totalPages: 1,
 };
 
+export const EVENT_POSTS_RESPONSE = [
+  {
+    id: 10,
+    channelId: 4,
+    channelName: "행사 정보",
+    channelType: "EVENT",
+    title: "문학의 밤",
+    postType: "EVENT",
+    status: "PUBLISHED",
+    authorId: 1,
+    authorName: "최양진",
+    thumbnailUrl: "/home/event-photo-1.svg",
+    createdAt: "2026-04-10T19:30:00",
+    updatedAt: "2026-04-10T19:30:00",
+  },
+  {
+    id: 11,
+    channelId: 4,
+    channelName: "행사 정보",
+    channelType: "EVENT",
+    title: "봄 소풍",
+    postType: "EVENT",
+    status: "PUBLISHED",
+    authorId: 2,
+    authorName: "관리자",
+    thumbnailUrl: "/home/event-photo-2.svg",
+    createdAt: "2026-04-08T19:30:00",
+    updatedAt: "2026-04-08T19:30:00",
+  },
+];
+
 function hasValidAuthorization(request: Request) {
   const authorizationHeader = request.headers.get("authorization");
   return (
@@ -45,6 +76,18 @@ export const postHandlers: RequestHandler[] = [
   http.get(`${API_BASE_URL}/api/v1/posts`, ({ request }) => {
     if (!hasValidAuthorization(request)) {
       return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const channelType = url.searchParams.get("channelType");
+
+    if (channelType === "EVENT") {
+      return HttpResponse.json({
+        ...POST_LIST_RESPONSE,
+        content: EVENT_POSTS_RESPONSE,
+        totalElements: EVENT_POSTS_RESPONSE.length,
+        totalPages: 1,
+      });
     }
 
     return HttpResponse.json({
@@ -94,6 +137,17 @@ export const postHandlers: RequestHandler[] = [
 
     if (channelId === 1 && postId === 1) {
       return HttpResponse.json(POST_DETAIL_RESPONSE);
+    }
+
+    if (channelId === 4) {
+      const eventPost = EVENT_POSTS_RESPONSE.find((post) => post.id === postId);
+      return HttpResponse.json({
+        ...(eventPost ?? EVENT_POSTS_RESPONSE[0]),
+        id: postId,
+        channelId,
+        contentHtml: "<p>행사 사진과 설명입니다.</p><p><img src=\"/home/event-photo-1.svg\" alt=\"행사\" /></p>",
+        allowComment: true,
+      });
     }
 
     return HttpResponse.json({

--- a/mocks/handlers/post.handlers.ts
+++ b/mocks/handlers/post.handlers.ts
@@ -35,6 +35,20 @@ export const POST_LIST_RESPONSE = {
 
 export const EVENT_POSTS_RESPONSE = [
   {
+    id: 12,
+    channelId: 4,
+    channelName: "행사 정보",
+    channelType: "EVENT",
+    title: "신입생 환영회",
+    postType: "EVENT",
+    status: "PUBLISHED",
+    authorId: 3,
+    authorName: "박지은",
+    thumbnailUrl: "/home/event-photo-3.svg",
+    createdAt: "2026-04-12T19:30:00",
+    updatedAt: "2026-04-12T19:30:00",
+  },
+  {
     id: 10,
     channelId: 4,
     channelName: "행사 정보",
@@ -74,10 +88,6 @@ function hasValidAuthorization(request: Request) {
 
 export const postHandlers: RequestHandler[] = [
   http.get(`${API_BASE_URL}/api/v1/posts`, ({ request }) => {
-    if (!hasValidAuthorization(request)) {
-      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
     const url = new URL(request.url);
     const channelType = url.searchParams.get("channelType");
 
@@ -88,6 +98,10 @@ export const postHandlers: RequestHandler[] = [
         totalElements: EVENT_POSTS_RESPONSE.length,
         totalPages: 1,
       });
+    }
+
+    if (!hasValidAuthorization(request)) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
     return HttpResponse.json({
@@ -128,16 +142,8 @@ export const postHandlers: RequestHandler[] = [
     });
   }),
   http.get(`${API_BASE_URL}/api/v1/channels/:channelId/posts/:postId`, ({ request, params }) => {
-    if (!hasValidAuthorization(request)) {
-      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
-    }
-
     const postId = Number(params.postId);
     const channelId = Number(params.channelId);
-
-    if (channelId === 1 && postId === 1) {
-      return HttpResponse.json(POST_DETAIL_RESPONSE);
-    }
 
     if (channelId === 4) {
       const eventPost = EVENT_POSTS_RESPONSE.find((post) => post.id === postId);
@@ -148,6 +154,14 @@ export const postHandlers: RequestHandler[] = [
         contentHtml: "<p>행사 사진과 설명입니다.</p><p><img src=\"/home/event-photo-1.svg\" alt=\"행사\" /></p>",
         allowComment: true,
       });
+    }
+
+    if (!hasValidAuthorization(request)) {
+      return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    if (channelId === 1 && postId === 1) {
+      return HttpResponse.json(POST_DETAIL_RESPONSE);
     }
 
     return HttpResponse.json({


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 기관 정보 > 행사 정보 페이지 구현
   \- Figma 디자인 시안을 기반으로 `/info/events`, `/info/events/new`, `/info/events/[postId]` 페이지를 구현하였습니다. 
   \- 기본 `EVENT` 채널을 통해 행사 게시글 목록/상세/등록/수정/삭제가 가능하도록 API를 연동하였습니다.
   \- 게시글 작성/수정 시, Toast UI 본문 첫 번째 이미지 URL을 `thumbnailUrl`로 추출해 행사 카드 썸네일로 사용하도록 처리하였습니다.
   \- 관리자는 모든 행사 글을 수정/삭제할 수 있고, 그 외 사용자는 본인 글만 수정/삭제할 수 있도록 처리하였습니다.

   <img width="1898" height="863" alt="스크린샷 2026-05-28 210726" src="https://github.com/user-attachments/assets/e0651a31-6800-4067-b6ca-e4cc3245a935" />

   <img width="1899" height="867" alt="스크린샷 2026-05-28 210826" src="https://github.com/user-attachments/assets/355cc8a3-2b7c-4326-bac4-963825739170" />

2. 홈 페이지의 행사 사진 섹션과 행사 정보 게시판을 연결하였습니다.
   \- 행사 사진 섹션의 `더보기` 버튼 클릭 시, 행사 정보 목록 페이지로 이동합니다.
   \- 행사 사진 항목 클릭 시, 해당 행사 정보 게시글의 상세 페이지로 이동합니다.

   <img width="1899" height="866" alt="스크린샷 2026-05-28 212655" src="https://github.com/user-attachments/assets/7f3aab64-5bf4-4ec9-b88c-50f7ae7ac1c0" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #98 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
