### PR TITLE
[FEAT] 연혁, 부서 정보, 반 정보 API 연동

### DIFF
--- a/api/auth/auth.api.test.ts
+++ b/api/auth/auth.api.test.ts
@@ -20,6 +20,7 @@ import {
 
 import { getAccessToken, getRefreshToken, setTokens } from "../client/tokenStorage";
 import {
+  adminLogin,
   connectLocalAccount,
   googleLogin,
   googleSignup,
@@ -82,6 +83,28 @@ describe("auth.api", () => {
       pathname: "/api/v1/auth/login",
       body: DEFAULT_LOGIN_REQUEST,
     });
+  });
+
+  it("returns and stores tokens for admin login", async () => {
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth/admin/login`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          accessToken: VALID_ACCESS_TOKEN,
+          refreshToken: VALID_REFRESH_TOKEN,
+          tokenType: "Bearer",
+        });
+      }),
+    );
+
+    const response = await adminLogin(DEFAULT_LOGIN_REQUEST);
+
+    expect(response.accessToken).toBe(VALID_ACCESS_TOKEN);
+    expect(observedBody).toEqual(DEFAULT_LOGIN_REQUEST);
+    expect(getAccessToken()).toBe(VALID_ACCESS_TOKEN);
+    expect(getRefreshToken()).toBe(VALID_REFRESH_TOKEN);
   });
 
   it("returns tokens for a successful signup", async () => {

--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -3,6 +3,7 @@ import publicClient from "../client/publicClient";
 import { clearTokens, setTokens } from "../client/tokenStorage";
 import type {
   AuthMessageResponseDto,
+  AdminLoginRequestDto,
   GoogleCallbackQueryParamsDto,
   GoogleLoginRequestDto,
   GoogleSignupRequestDto,
@@ -23,6 +24,16 @@ export async function signup(body: SignupRequestDto) {
 // 로그인 후 토큰을 발급받는 요청
 export async function login(body: LoginRequestDto) {
   const response = await publicClient.post<TokenResponseDto>("/api/v1/auth/login", body);
+  setTokens(response.data.accessToken, response.data.refreshToken);
+  return response.data;
+}
+
+// 관리자 로그인 후 토큰을 발급받는 요청
+export async function adminLogin(body: AdminLoginRequestDto) {
+  const response = await publicClient.post<TokenResponseDto>(
+    "/api/v1/auth/admin/login",
+    body,
+  );
   setTokens(response.data.accessToken, response.data.refreshToken);
   return response.data;
 }

--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -4,6 +4,7 @@ export interface SignupRequestDto {
   email: string;
   profileImageUrl?: string;
   phoneNumber?: string;
+  residentRegistrationNumberPrefix?: string;
 }
 
 export interface LoginRequestDto {
@@ -44,3 +45,5 @@ export interface GoogleSignupRequestDto {
 export interface GoogleLoginRequestDto {
   tempToken: string;
 }
+
+export type AdminLoginRequestDto = LoginRequestDto;

--- a/api/channel/channel.dto.ts
+++ b/api/channel/channel.dto.ts
@@ -1,4 +1,12 @@
-export type ChannelType = "NOTICE" | "CLASSROOM" | "DEPARTMENT" | "EVENT" | "CUSTOM" | string;
+export type ChannelType =
+  | "NOTICE"
+  | "EVENT"
+  | "RESOURCE"
+  | "CLASSROOM"
+  | "DEPARTMENT"
+  | "GUIDE"
+  | "CUSTOM"
+  | string;
 
 export type ChannelBindingType = "STANDALONE" | "DOMAIN_LINKED" | string;
 export type ChannelAccessLevel = "CLOSED" | "READ_ONLY" | "READ_COMMENT" | "READ_WRITE" | string;
@@ -17,6 +25,7 @@ export interface ChannelListQueryParamsDto {
 export interface CreateChannelRequestDto {
   name: string;
   description?: string;
+  channelType?: Extract<ChannelType, "NOTICE" | "EVENT" | "RESOURCE" | "GUIDE" | "CUSTOM">;
   accessLevel: ChannelAccessLevel;
   allowGuestRead?: boolean;
   isDefault?: boolean;

--- a/api/dailySchedule/dailySchedule.api.test.ts
+++ b/api/dailySchedule/dailySchedule.api.test.ts
@@ -1,0 +1,176 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import {
+  createJournal,
+  getDailyScheduleDetail,
+  getDailySchedules,
+  getVolunteerHours,
+  updateStudentAttendances,
+  updateTeacherAttendance,
+} from "./dailySchedule.api";
+
+const DAILY_SCHEDULE_DETAIL = {
+  dailyScheduleId: 1,
+  lessonDate: "2026-06-01",
+  classroomId: 2,
+  classroomName: "한글반",
+  teacherId: 3,
+  teacherName: "홍길동",
+  activityStartTime: "19:00:00",
+  activityEndTime: "22:00:00",
+  status: "SCHEDULED",
+  lessonCount: 1,
+  lessons: [{ lessonId: 10, period: 1, subjectName: "국어", note: null }],
+};
+
+describe("dailySchedule.api", () => {
+  it("returns daily schedules with auth header and list query params", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAuthorizationHeader: string | null = null;
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/daily-schedules`, ({ request }) => {
+        observedAuthorizationHeader = request.headers.get("authorization");
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          content: [DAILY_SCHEDULE_DETAIL],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const response = await getDailySchedules({ keyword: "한글", mine: true, page: 0, size: 10 });
+
+    expect(response.content[0]).toMatchObject({ dailyScheduleId: 1, classroomName: "한글반" });
+    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
+    expect(observedQueryString).toContain("keyword=");
+    expect(observedQueryString).toContain("mine=true");
+    expect(observedQueryString).toContain("page=0");
+    expect(observedQueryString).toContain("size=10");
+  });
+
+  it("returns detail and volunteer hours with expected query params", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedDetailQueryString = "";
+    let observedVolunteerQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/daily-schedules/detail`, ({ request }) => {
+        observedDetailQueryString = new URL(request.url).search;
+        return HttpResponse.json(DAILY_SCHEDULE_DETAIL);
+      }),
+      http.get(`${API_BASE_URL}/api/v1/daily-schedules/volunteer-hours`, ({ request }) => {
+        observedVolunteerQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          teacherId: 3,
+          from: "2026-06-01",
+          to: "2026-06-30",
+          totalVolunteerServiceMinutes: 180,
+          totalVolunteerServiceHours: 3,
+        });
+      }),
+    );
+
+    await expect(
+      getDailyScheduleDetail({ classroomId: 2, lessonDate: "2026-06-01" }),
+    ).resolves.toMatchObject({ dailyScheduleId: 1 });
+    await expect(
+      getVolunteerHours({ teacherId: 3, from: "2026-06-01", to: "2026-06-30" }),
+    ).resolves.toMatchObject({ totalVolunteerServiceHours: 3 });
+
+    expect(observedDetailQueryString).toContain("classroomId=2");
+    expect(observedDetailQueryString).toContain("lessonDate=2026-06-01");
+    expect(observedVolunteerQueryString).toContain("teacherId=3");
+    expect(observedVolunteerQueryString).toContain("from=2026-06-01");
+    expect(observedVolunteerQueryString).toContain("to=2026-06-30");
+  });
+
+  it("creates a journal with the expected request body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/daily-schedules/journal`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          ...DAILY_SCHEDULE_DETAIL,
+          personalInfoConsent: true,
+          residentRegistrationNumberPrefix: "900101",
+        });
+      }),
+    );
+
+    const body = {
+      lessonDate: "2026-06-01",
+      classroomId: 2,
+      personalInfoConsent: true,
+      residentRegistrationNumberPrefix: "900101",
+      lessonJournals: [{ lessonId: 10, note: "수업 내용" }],
+    };
+
+    const response = await createJournal(body);
+
+    expect(response).toMatchObject({ dailyScheduleId: 1, personalInfoConsent: true });
+    expect(observedBody).toEqual(body);
+  });
+
+  it("updates teacher and student attendance with expected bodies", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedTeacherBody: unknown;
+    let observedStudentBody: unknown;
+
+    server.use(
+      http.patch(
+        `${API_BASE_URL}/api/v1/daily-schedules/1/teacher-attendance`,
+        async ({ request }) => {
+          observedTeacherBody = await request.json();
+          return HttpResponse.json({
+            ...DAILY_SCHEDULE_DETAIL,
+            teacherAttendance: { attendanceId: 1, status: "PRESENT" },
+          });
+        },
+      ),
+      http.patch(
+        `${API_BASE_URL}/api/v1/daily-schedules/1/student-attendances`,
+        async ({ request }) => {
+          observedStudentBody = await request.json();
+          return HttpResponse.json({
+            ...DAILY_SCHEDULE_DETAIL,
+            studentAttendances: [{ attendanceId: 1, studentId: 5, status: "ABSENT" }],
+          });
+        },
+      ),
+    );
+
+    await updateTeacherAttendance(
+      { dailyScheduleId: 1 },
+      { status: "PRESENT", latitude: 35.2, longitude: 129.1 },
+    );
+    await updateStudentAttendances(
+      { dailyScheduleId: 1 },
+      { attendances: [{ studentId: 5, status: "ABSENT" }] },
+    );
+
+    expect(observedTeacherBody).toEqual({
+      status: "PRESENT",
+      latitude: 35.2,
+      longitude: 129.1,
+    });
+    expect(observedStudentBody).toEqual({ attendances: [{ studentId: 5, status: "ABSENT" }] });
+  });
+});

--- a/api/event/event.api.test.ts
+++ b/api/event/event.api.test.ts
@@ -1,0 +1,83 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import { createEvent, deleteEvent, getEvents, updateEvent } from "./event.api";
+
+describe("event.api", () => {
+  it("returns public events with date range query params", async () => {
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/events`, ({ request }) => {
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          content: [{ id: 1, title: "문학의 밤", eventDate: "2026-05-13" }],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const response = await getEvents({
+      startDate: "2026-05-01",
+      endDate: "2026-05-31",
+    });
+
+    expect(response.content?.[0]).toMatchObject({ id: 1, title: "문학의 밤" });
+    expect(observedQueryString).toContain("startDate=2026-05-01");
+    expect(observedQueryString).toContain("endDate=2026-05-31");
+  });
+
+  it("creates and updates events through admin endpoints", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedCreateBody: unknown;
+    let observedUpdateBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/admin/events`, async ({ request }) => {
+        observedCreateBody = await request.json();
+        return HttpResponse.json({ id: 2, title: "행사", eventDate: "2026-06-01" });
+      }),
+      http.patch(`${API_BASE_URL}/api/v1/admin/events/2`, async ({ request }) => {
+        observedUpdateBody = await request.json();
+        return HttpResponse.json({ id: 2, title: "수정 행사", eventDate: "2026-06-02" });
+      }),
+    );
+
+    await expect(
+      createEvent({ title: "행사", eventDate: "2026-06-01" }),
+    ).resolves.toMatchObject({ id: 2 });
+    await expect(updateEvent({ eventId: 2 }, { title: "수정 행사" })).resolves.toMatchObject({
+      title: "수정 행사",
+    });
+
+    expect(observedCreateBody).toEqual({ title: "행사", eventDate: "2026-06-01" });
+    expect(observedUpdateBody).toEqual({ title: "수정 행사" });
+  });
+
+  it("deletes an event through the admin endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+
+    server.use(
+      http.delete(`${API_BASE_URL}/api/v1/admin/events/2`, ({ request }) => {
+        observedPathname = new URL(request.url).pathname;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    await deleteEvent({ eventId: 2 });
+
+    expect(observedPathname).toBe("/api/v1/admin/events/2");
+  });
+});

--- a/api/event/event.api.ts
+++ b/api/event/event.api.ts
@@ -1,0 +1,49 @@
+import authClient from "../client/authClient";
+import publicClient from "../client/publicClient";
+import type {
+  CreateEventRequestDto,
+  EventListQueryParamsDto,
+  EventListResponseDto,
+  EventPathParamsDto,
+  EventResponseDto,
+  UpdateEventRequestDto,
+} from "./event.dto";
+
+// 공개 행사 목록을 조회하는 요청
+export async function getEvents(query?: EventListQueryParamsDto) {
+  const response = await publicClient.get<EventListResponseDto>("/api/v1/events", {
+    params: query,
+  });
+  return response.data;
+}
+
+// 공개 행사 상세를 조회하는 요청
+export async function getEvent(pathParams: EventPathParamsDto) {
+  const response = await publicClient.get<EventResponseDto>(
+    `/api/v1/events/${pathParams.eventId}`,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 행사를 생성하는 요청
+export async function createEvent(body: CreateEventRequestDto) {
+  const response = await authClient.post<EventResponseDto>("/api/v1/admin/events", body);
+  return response.data;
+}
+
+// 관리자 권한으로 행사를 수정하는 요청
+export async function updateEvent(
+  pathParams: EventPathParamsDto,
+  body: UpdateEventRequestDto,
+) {
+  const response = await authClient.patch<EventResponseDto>(
+    `/api/v1/admin/events/${pathParams.eventId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 행사를 삭제하는 요청
+export async function deleteEvent(pathParams: EventPathParamsDto) {
+  await authClient.delete(`/api/v1/admin/events/${pathParams.eventId}`);
+}

--- a/api/event/event.dto.ts
+++ b/api/event/event.dto.ts
@@ -1,0 +1,47 @@
+export interface EventListQueryParamsDto {
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface EventPathParamsDto {
+  eventId: number;
+}
+
+export interface EventResponseDto {
+  id?: number;
+  title?: string;
+  description?: string;
+  eventDate?: string;
+  startTime?: string;
+  endTime?: string;
+  lastModifiedById?: number;
+  lastModifiedByName?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface EventListResponseDto {
+  content?: EventResponseDto[];
+  page?: number;
+  size?: number;
+  totalElements?: number;
+  totalPages?: number;
+}
+
+export interface CreateEventRequestDto {
+  title: string;
+  description?: string;
+  eventDate: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface UpdateEventRequestDto {
+  title?: string;
+  description?: string;
+  eventDate?: string;
+  startTime?: string;
+  endTime?: string;
+}

--- a/api/file/file.api.test.ts
+++ b/api/file/file.api.test.ts
@@ -17,7 +17,9 @@ import { setAccessToken } from "../client/tokenStorage";
 import {
   deleteAttachment,
   getAttachmentDownloadUrl,
+  registerDriveFile,
   uploadPurchaseItemImage,
+  uploadSiteContentImage,
 } from "./file.api";
 
 describe("file.api", () => {
@@ -54,6 +56,55 @@ describe("file.api", () => {
     });
 
     expect(response).toEqual(ATTACHMENT_DOWNLOAD_URL_RESPONSE);
+  });
+
+  it("uploads a site content image through the expected endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+    let observedContentType = "";
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/files/images/site-contents`, ({ request }) => {
+        observedPathname = new URL(request.url).pathname;
+        observedContentType = request.headers.get("content-type") ?? "";
+        return HttpResponse.json(FILE_UPLOAD_RESPONSE);
+      }),
+    );
+
+    const response = await uploadSiteContentImage(
+      new File(["image"], "history.png", { type: "image/png" }),
+      "history.png",
+    );
+
+    expect(response).toEqual(FILE_UPLOAD_RESPONSE);
+    expect(observedPathname).toBe("/api/v1/files/images/site-contents");
+    expect(observedContentType).toContain("multipart/form-data");
+  });
+
+  it("registers Google Drive file metadata", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/files/drive`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json(FILE_UPLOAD_RESPONSE);
+      }),
+    );
+
+    const body = {
+      driveUrl: "https://drive.google.com/file/d/abc123/view",
+      originalName: "handover.pdf",
+      mimeType: "application/pdf",
+      fileSize: 1024,
+    };
+
+    const response = await registerDriveFile(body);
+
+    expect(response).toEqual(FILE_UPLOAD_RESPONSE);
+    expect(observedBody).toEqual(body);
   });
 
   it("deletes an attachment through the expected endpoint", async () => {

--- a/api/file/file.api.ts
+++ b/api/file/file.api.ts
@@ -3,6 +3,7 @@ import type {
   FileDownloadUrlResponseDto,
   FilePathParamsDto,
   FileUploadResponseDto,
+  RegisterDriveFileRequestDto,
 } from "./file.dto";
 
 function createMultipartFormData(file: Blob, filename?: string) {
@@ -17,11 +18,7 @@ function createMultipartFormData(file: Blob, filename?: string) {
   return formData;
 }
 
-async function uploadImage(
-  endpoint: string,
-  file: Blob,
-  filename?: string,
-) {
+async function uploadImage(endpoint: string, file: Blob, filename?: string) {
   const response = await authClient.post<FileUploadResponseDto>(
     endpoint,
     createMultipartFormData(file, filename),
@@ -48,6 +45,17 @@ export async function uploadProfileImage(file: Blob, filename?: string) {
 // 게시글 본문용 이미지를 업로드하는 요청
 export async function uploadPostImage(file: Blob, filename?: string) {
   return uploadImage("/api/v1/files/images/posts", file, filename);
+}
+
+// 사이트 콘텐츠 이미지를 업로드하는 요청
+export async function uploadSiteContentImage(file: Blob, filename?: string) {
+  return uploadImage("/api/v1/files/images/site-contents", file, filename);
+}
+
+// 프론트에서 Google Drive에 업로드한 파일 메타데이터를 등록하는 요청
+export async function registerDriveFile(body: RegisterDriveFileRequestDto) {
+  const response = await authClient.post<FileUploadResponseDto>("/api/v1/files/drive", body);
+  return response.data;
 }
 
 // 일반 첨부파일을 업로드하는 요청

--- a/api/file/file.dto.ts
+++ b/api/file/file.dto.ts
@@ -14,3 +14,10 @@ export interface FileDownloadUrlResponseDto {
 export interface FilePathParamsDto {
   fileId: string;
 }
+
+export interface RegisterDriveFileRequestDto {
+  driveUrl: string;
+  originalName: string;
+  mimeType?: string;
+  fileSize?: number;
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -40,3 +40,18 @@ export * as subjectDto from "./subject/subject.dto";
 
 export * as userApi from "./user/user.api";
 export * as userDto from "./user/user.dto";
+
+export * as eventApi from "./event/event.api";
+export * as eventDto from "./event/event.dto";
+
+export * as meetingRecordApi from "./meetingRecord/meetingRecord.api";
+export * as meetingRecordDto from "./meetingRecord/meetingRecord.dto";
+
+export * as siteContentApi from "./siteContent/siteContent.api";
+export * as siteContentDto from "./siteContent/siteContent.dto";
+
+export * as teacherApplicationApi from "./teacherApplication/teacherApplication.api";
+export * as teacherApplicationDto from "./teacherApplication/teacherApplication.dto";
+
+export * as vendorApi from "./vendor/vendor.api";
+export * as vendorDto from "./vendor/vendor.dto";

--- a/api/lessonExchange/lessonExchange.api.test.ts
+++ b/api/lessonExchange/lessonExchange.api.test.ts
@@ -1,0 +1,194 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import {
+  acceptLessonExchangeProposal,
+  approveLessonExchangeRequest,
+  createLessonExchangeProposal,
+  createLessonExchangeRequest,
+  getLessonExchangeProposals,
+  getLessonExchangeRequests,
+  rejectLessonExchangeRequest,
+  updateLessonExchangeProposal,
+  updateLessonExchangeRequest,
+  withdrawLessonExchangeProposal,
+} from "./lessonExchange.api";
+
+const LESSON_EXCHANGE_DETAIL = {
+  id: 1,
+  dailyScheduleId: 10,
+  classroomName: "한글반",
+  lessonDate: "2026-06-01",
+  requestedById: 3,
+  requestedByName: "홍길동",
+  title: "수업 교환 요청",
+  content: "교환이 필요합니다.",
+  status: "PENDING",
+  expiresAt: "2026-05-31T22:00:00",
+};
+
+const LESSON_EXCHANGE_PROPOSAL = {
+  id: 7,
+  requestId: 1,
+  proposedById: 4,
+  proposedByName: "김교사",
+  lessonDate: "2026-06-02",
+  content: "대체 가능합니다.",
+  status: "ACTIVE",
+};
+
+describe("lessonExchange.api", () => {
+  it("returns lesson exchange requests with filters and auth header", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAuthorizationHeader: string | null = null;
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/lesson-exchange-requests`, ({ request }) => {
+        observedAuthorizationHeader = request.headers.get("authorization");
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          content: [LESSON_EXCHANGE_DETAIL],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const response = await getLessonExchangeRequests({
+      status: "PENDING",
+      mine: true,
+      keyword: "교환",
+    });
+
+    expect(response.content[0]).toMatchObject({ id: 1, status: "PENDING" });
+    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
+    expect(observedQueryString).toContain("status=PENDING");
+    expect(observedQueryString).toContain("mine=true");
+    expect(observedQueryString).toContain("keyword=");
+  });
+
+  it("creates and updates a lesson exchange request with expected bodies", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedCreateBody: unknown;
+    let observedUpdateBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/lesson-exchange-requests`, async ({ request }) => {
+        observedCreateBody = await request.json();
+        return HttpResponse.json({ ...LESSON_EXCHANGE_DETAIL, id: 2 });
+      }),
+      http.patch(`${API_BASE_URL}/api/v1/lesson-exchange-requests/2`, async ({ request }) => {
+        observedUpdateBody = await request.json();
+        return HttpResponse.json({ ...LESSON_EXCHANGE_DETAIL, id: 2, title: "수정 요청" });
+      }),
+    );
+
+    await createLessonExchangeRequest({
+      lessonDate: "2026-06-01",
+      title: "수업 교환 요청",
+      content: "교환이 필요합니다.",
+      expiresAt: "2026-05-31T22:00:00",
+    });
+    await updateLessonExchangeRequest({ requestId: 2 }, { title: "수정 요청" });
+
+    expect(observedCreateBody).toEqual({
+      lessonDate: "2026-06-01",
+      title: "수업 교환 요청",
+      content: "교환이 필요합니다.",
+      expiresAt: "2026-05-31T22:00:00",
+    });
+    expect(observedUpdateBody).toEqual({ title: "수정 요청" });
+  });
+
+  it("approves and rejects a lesson exchange request with expected bodies", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedApproveBody: unknown;
+    let observedRejectBody: unknown;
+
+    server.use(
+      http.patch(`${API_BASE_URL}/api/v1/lesson-exchange-requests/1/approve`, async ({ request }) => {
+        observedApproveBody = await request.json();
+        return HttpResponse.json({ ...LESSON_EXCHANGE_DETAIL, status: "APPROVED" });
+      }),
+      http.patch(`${API_BASE_URL}/api/v1/lesson-exchange-requests/1/reject`, async ({ request }) => {
+        observedRejectBody = await request.json();
+        return HttpResponse.json({ ...LESSON_EXCHANGE_DETAIL, status: "REJECTED" });
+      }),
+    );
+
+    await approveLessonExchangeRequest({ requestId: 1 }, { proposalId: 7 });
+    await rejectLessonExchangeRequest({ requestId: 1 }, { note: "일정 불가" });
+
+    expect(observedApproveBody).toEqual({ proposalId: 7 });
+    expect(observedRejectBody).toEqual({ note: "일정 불가" });
+  });
+
+  it("handles proposal list, create, update, withdraw, and accept routes", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedCreateBody: unknown;
+    let observedUpdateBody: unknown;
+    const observedPaths: string[] = [];
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/lesson-exchange-requests/1/proposals`, ({ request }) => {
+        observedPaths.push(new URL(request.url).pathname);
+        return HttpResponse.json([LESSON_EXCHANGE_PROPOSAL]);
+      }),
+      http.post(
+        `${API_BASE_URL}/api/v1/lesson-exchange-requests/1/proposals`,
+        async ({ request }) => {
+          observedCreateBody = await request.json();
+          return HttpResponse.json({ ...LESSON_EXCHANGE_PROPOSAL, id: 8 });
+        },
+      ),
+      http.patch(
+        `${API_BASE_URL}/api/v1/lesson-exchange-requests/1/proposals/8`,
+        async ({ request }) => {
+          observedUpdateBody = await request.json();
+          return HttpResponse.json({ ...LESSON_EXCHANGE_PROPOSAL, id: 8, content: "수정" });
+        },
+      ),
+      http.patch(
+        `${API_BASE_URL}/api/v1/lesson-exchange-requests/1/proposals/8/withdraw`,
+        ({ request }) => {
+          observedPaths.push(new URL(request.url).pathname);
+          return HttpResponse.json({ ...LESSON_EXCHANGE_PROPOSAL, id: 8, status: "WITHDRAWN" });
+        },
+      ),
+      http.patch(
+        `${API_BASE_URL}/api/v1/lesson-exchange-requests/1/proposals/8/accept`,
+        ({ request }) => {
+          observedPaths.push(new URL(request.url).pathname);
+          return HttpResponse.json({ ...LESSON_EXCHANGE_PROPOSAL, id: 8, status: "ACCEPTED" });
+        },
+      ),
+    );
+
+    await expect(getLessonExchangeProposals({ requestId: 1 })).resolves.toEqual([
+      expect.objectContaining({ id: 7 }),
+    ]);
+    await createLessonExchangeProposal({ requestId: 1 }, { content: "대체 가능합니다." });
+    await updateLessonExchangeProposal({ requestId: 1, proposalId: 8 }, { content: "수정" });
+    await withdrawLessonExchangeProposal({ requestId: 1, proposalId: 8 });
+    await acceptLessonExchangeProposal({ requestId: 1, proposalId: 8 });
+
+    expect(observedCreateBody).toEqual({ content: "대체 가능합니다." });
+    expect(observedUpdateBody).toEqual({ content: "수정" });
+    expect(observedPaths).toContain("/api/v1/lesson-exchange-requests/1/proposals");
+    expect(observedPaths).toContain("/api/v1/lesson-exchange-requests/1/proposals/8/withdraw");
+    expect(observedPaths).toContain("/api/v1/lesson-exchange-requests/1/proposals/8/accept");
+  });
+});

--- a/api/meetingRecord/meetingRecord.api.test.ts
+++ b/api/meetingRecord/meetingRecord.api.test.ts
@@ -1,0 +1,90 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import {
+  createAbsenceReport,
+  createMeetingRecord,
+  getMeetingRecords,
+  updateMeetingRecord,
+} from "./meetingRecord.api";
+
+describe("meetingRecord.api", () => {
+  it("returns meeting records with query params", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/meeting-records`, ({ request }) => {
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          content: [{ id: 1, title: "교학 회의", status: "BEFORE_MEETING" }],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const response = await getMeetingRecords({ keyword: "교학", mineOnly: true });
+
+    expect(response.content?.[0]).toMatchObject({ id: 1 });
+    expect(observedQueryString).toContain("keyword=");
+    expect(observedQueryString).toContain("mineOnly=true");
+  });
+
+  it("creates and updates meeting records with expected bodies", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedCreateBody: unknown;
+    let observedUpdateBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/meeting-records`, async ({ request }) => {
+        observedCreateBody = await request.json();
+        return HttpResponse.json({ id: 1, title: "회의", agenda: "안건" });
+      }),
+      http.patch(`${API_BASE_URL}/api/v1/meeting-records/1`, async ({ request }) => {
+        observedUpdateBody = await request.json();
+        return HttpResponse.json({ id: 1, title: "회의", discussion: "논의" });
+      }),
+    );
+
+    await createMeetingRecord({ title: "회의", agenda: "안건" });
+    await updateMeetingRecord({ recordId: 1 }, { discussion: "논의" });
+
+    expect(observedCreateBody).toEqual({ title: "회의", agenda: "안건" });
+    expect(observedUpdateBody).toEqual({ discussion: "논의" });
+  });
+
+  it("creates an absence report for a meeting record", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(
+        `${API_BASE_URL}/api/v1/meeting-records/1/absence-reports`,
+        async ({ request }) => {
+          observedBody = await request.json();
+          return HttpResponse.json({ id: 10, reason: "수업", opinion: "의견" });
+        },
+      ),
+    );
+
+    const response = await createAbsenceReport(
+      { recordId: 1 },
+      { reason: "수업", opinion: "의견" },
+    );
+
+    expect(response).toMatchObject({ id: 10, reason: "수업" });
+    expect(observedBody).toEqual({ reason: "수업", opinion: "의견" });
+  });
+});

--- a/api/meetingRecord/meetingRecord.api.ts
+++ b/api/meetingRecord/meetingRecord.api.ts
@@ -1,0 +1,86 @@
+import authClient from "../client/authClient";
+import type {
+  CreateMeetingRecordRequestDto,
+  MeetingAbsenceReportPathParamsDto,
+  MeetingAbsenceReportResponseDto,
+  MeetingRecordDetailResponseDto,
+  MeetingRecordListQueryParamsDto,
+  MeetingRecordListResponseDto,
+  MeetingRecordPathParamsDto,
+  UpdateMeetingRecordRequestDto,
+  UpsertMeetingAbsenceReportRequestDto,
+} from "./meetingRecord.dto";
+
+// 교학 회의록 목록을 조회하는 요청
+export async function getMeetingRecords(query: MeetingRecordListQueryParamsDto) {
+  const response = await authClient.get<MeetingRecordListResponseDto>(
+    "/api/v1/meeting-records",
+    { params: query },
+  );
+  return response.data;
+}
+
+// 교학 회의록을 생성하는 요청
+export async function createMeetingRecord(body: CreateMeetingRecordRequestDto) {
+  const response = await authClient.post<MeetingRecordDetailResponseDto>(
+    "/api/v1/meeting-records",
+    body,
+  );
+  return response.data;
+}
+
+// 교학 회의록 상세를 조회하는 요청
+export async function getMeetingRecord(pathParams: MeetingRecordPathParamsDto) {
+  const response = await authClient.get<MeetingRecordDetailResponseDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}`,
+  );
+  return response.data;
+}
+
+// 교학 회의록을 수정하는 요청
+export async function updateMeetingRecord(
+  pathParams: MeetingRecordPathParamsDto,
+  body: UpdateMeetingRecordRequestDto,
+) {
+  const response = await authClient.patch<MeetingRecordDetailResponseDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 교학 회의록을 삭제하는 요청
+export async function deleteMeetingRecord(pathParams: MeetingRecordPathParamsDto) {
+  await authClient.delete(`/api/v1/meeting-records/${pathParams.recordId}`);
+}
+
+// 교학 회의록에 불참 사유서를 추가하는 요청
+export async function createAbsenceReport(
+  pathParams: MeetingRecordPathParamsDto,
+  body: UpsertMeetingAbsenceReportRequestDto,
+) {
+  const response = await authClient.post<MeetingAbsenceReportResponseDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}/absence-reports`,
+    body,
+  );
+  return response.data;
+}
+
+// 교학 회의록의 불참 사유서를 수정하는 요청
+export async function updateAbsenceReport(
+  pathParams: MeetingAbsenceReportPathParamsDto,
+  body: UpsertMeetingAbsenceReportRequestDto,
+) {
+  const response = await authClient.patch<MeetingAbsenceReportResponseDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}/absence-reports/${pathParams.absenceReportId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 교학 회의록의 불참 사유서를 삭제하는 요청
+export async function deleteAbsenceReport(pathParams: MeetingAbsenceReportPathParamsDto) {
+  await authClient.delete(
+    `/api/v1/meeting-records/${pathParams.recordId}/absence-reports/${pathParams.absenceReportId}`,
+  );
+}

--- a/api/meetingRecord/meetingRecord.dto.ts
+++ b/api/meetingRecord/meetingRecord.dto.ts
@@ -1,0 +1,69 @@
+export type MeetingRecordStatus = "BEFORE_MEETING" | "AFTER_MEETING";
+
+export interface MeetingRecordListQueryParamsDto {
+  page?: number;
+  size?: number;
+  keyword?: string;
+  mineOnly?: boolean;
+  status?: MeetingRecordStatus;
+}
+
+export interface MeetingRecordPathParamsDto {
+  recordId: number;
+}
+
+export interface MeetingAbsenceReportPathParamsDto extends MeetingRecordPathParamsDto {
+  absenceReportId: number;
+}
+
+export interface MeetingRecordSummaryResponseDto {
+  id?: number;
+  title?: string;
+  authorId?: number;
+  author?: string;
+  createdAt?: string;
+  status?: MeetingRecordStatus;
+  viewCount?: number;
+}
+
+export interface MeetingAbsenceReportResponseDto {
+  id?: number;
+  authorId?: number;
+  author?: string;
+  reason?: string;
+  opinion?: string;
+  createdAt?: string;
+}
+
+export interface MeetingRecordDetailResponseDto extends MeetingRecordSummaryResponseDto {
+  agenda?: string;
+  discussion?: string;
+  suggestion?: string;
+  absenceReports?: MeetingAbsenceReportResponseDto[];
+}
+
+export interface MeetingRecordListResponseDto {
+  content?: MeetingRecordSummaryResponseDto[];
+  page?: number;
+  size?: number;
+  totalElements?: number;
+  totalPages?: number;
+}
+
+export interface CreateMeetingRecordRequestDto {
+  title: string;
+  agenda: string;
+}
+
+export interface UpdateMeetingRecordRequestDto {
+  title?: string;
+  agenda?: string;
+  discussion?: string;
+  suggestion?: string;
+  status?: MeetingRecordStatus;
+}
+
+export interface UpsertMeetingAbsenceReportRequestDto {
+  reason: string;
+  opinion?: string;
+}

--- a/api/push/push.api.test.ts
+++ b/api/push/push.api.test.ts
@@ -1,0 +1,62 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import { subscribePush, unsubscribePush } from "./push.api";
+
+describe("push.api", () => {
+  it("subscribes push notifications with expected body and auth header", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAuthorizationHeader: string | null = null;
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/push/subscriptions`, async ({ request }) => {
+        observedAuthorizationHeader = request.headers.get("authorization");
+        observedBody = await request.json();
+        return HttpResponse.json({
+          id: 1,
+          endpoint: "https://push.example.com/subscription",
+          createdAt: "2026-06-01T10:00:00",
+        });
+      }),
+    );
+
+    const body = {
+      endpoint: "https://push.example.com/subscription",
+      keys: {
+        p256dh: "p256dh-key",
+        auth: "auth-key",
+      },
+    };
+
+    const response = await subscribePush(body);
+
+    expect(response).toMatchObject({ id: 1, endpoint: body.endpoint });
+    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
+    expect(observedBody).toEqual(body);
+  });
+
+  it("unsubscribes push notifications through the expected endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+
+    server.use(
+      http.delete(`${API_BASE_URL}/api/v1/push/subscriptions/1`, ({ request }) => {
+        observedPathname = new URL(request.url).pathname;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    await unsubscribePush({ subscriptionId: 1 });
+
+    expect(observedPathname).toBe("/api/v1/push/subscriptions/1");
+  });
+});

--- a/api/siteContent/siteContent.api.test.ts
+++ b/api/siteContent/siteContent.api.test.ts
@@ -1,0 +1,93 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import {
+  createClassInfo,
+  createDepartmentInfo,
+  getClassInfos,
+  getDepartmentInfos,
+  getHistories,
+  updateHistory,
+} from "./siteContent.api";
+
+describe("siteContent.api", () => {
+  it("returns public site content sections", async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/site-contents/history`, () => {
+        return HttpResponse.json({ history: [{ id: 1, title: "개교" }] });
+      }),
+      http.get(`${API_BASE_URL}/api/v1/site-contents/departments`, () => {
+        return HttpResponse.json({
+          principal: { id: 1, title: "교장", name: "홍길동" },
+          departments: [],
+        });
+      }),
+      http.get(`${API_BASE_URL}/api/v1/site-contents/classes`, () => {
+        return HttpResponse.json({
+          weekday: [{ id: 1, name: "주중반", description: ["설명"] }],
+          weekendMorning: [],
+          weekendAfternoon: [],
+        });
+      }),
+    );
+
+    await expect(getHistories()).resolves.toMatchObject({ history: [{ id: 1 }] });
+    await expect(getDepartmentInfos()).resolves.toMatchObject({
+      principal: { title: "교장" },
+    });
+    await expect(getClassInfos()).resolves.toMatchObject({ weekday: [{ id: 1 }] });
+  });
+
+  it("creates and updates site content with the expected body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedDepartmentBody: unknown;
+    let observedClassBody: unknown;
+    let observedHistoryBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/site-contents/departments`, async ({ request }) => {
+        observedDepartmentBody = await request.json();
+        return HttpResponse.json({ id: 2, title: "교무부", name: "김교사" });
+      }),
+      http.post(`${API_BASE_URL}/api/v1/site-contents/classes`, async ({ request }) => {
+        observedClassBody = await request.json();
+        return HttpResponse.json({ id: 3, name: "주말반", description: ["오전"] });
+      }),
+      http.put(`${API_BASE_URL}/api/v1/site-contents/history/1`, async ({ request }) => {
+        observedHistoryBody = await request.json();
+        return HttpResponse.json({ id: 1, title: "수정 연혁" });
+      }),
+    );
+
+    await createDepartmentInfo({
+      title: "교무부",
+      name: "김교사",
+      responsibilities: ["학사"],
+    });
+    await createClassInfo({
+      name: "주말반",
+      groupId: "weekendMorning",
+      description: ["오전"],
+    });
+    await updateHistory({ historyId: 1 }, { title: "수정 연혁" });
+
+    expect(observedDepartmentBody).toEqual({
+      title: "교무부",
+      name: "김교사",
+      responsibilities: ["학사"],
+    });
+    expect(observedClassBody).toEqual({
+      name: "주말반",
+      groupId: "weekendMorning",
+      description: ["오전"],
+    });
+    expect(observedHistoryBody).toEqual({ title: "수정 연혁" });
+  });
+});

--- a/api/siteContent/siteContent.api.ts
+++ b/api/siteContent/siteContent.api.ts
@@ -1,0 +1,120 @@
+import authClient from "../client/authClient";
+import publicClient from "../client/publicClient";
+import type {
+  SiteContentClassPathParamsDto,
+  SiteContentClassesResponseDto,
+  SiteContentClassResponseDto,
+  SiteContentDepartmentPathParamsDto,
+  SiteContentDepartmentResponseDto,
+  SiteContentDepartmentsResponseDto,
+  SiteHistoriesResponseDto,
+  SiteHistoryPathParamsDto,
+  SiteHistoryResponseDto,
+  UpsertSiteContentClassRequestDto,
+  UpsertSiteContentDepartmentRequestDto,
+  UpsertSiteHistoryRequestDto,
+} from "./siteContent.dto";
+
+// 공개 연혁 콘텐츠를 조회하는 요청
+export async function getHistories() {
+  const response = await publicClient.get<SiteHistoriesResponseDto>(
+    "/api/v1/site-contents/history",
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 연혁 항목을 생성하는 요청
+export async function createHistory(body: UpsertSiteHistoryRequestDto) {
+  const response = await authClient.post<SiteHistoryResponseDto>(
+    "/api/v1/site-contents/history",
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 연혁 항목을 수정하는 요청
+export async function updateHistory(
+  pathParams: SiteHistoryPathParamsDto,
+  body: UpsertSiteHistoryRequestDto,
+) {
+  const response = await authClient.put<SiteHistoryResponseDto>(
+    `/api/v1/site-contents/history/${pathParams.historyId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 연혁 항목을 삭제하는 요청
+export async function deleteHistory(pathParams: SiteHistoryPathParamsDto) {
+  await authClient.delete(`/api/v1/site-contents/history/${pathParams.historyId}`);
+}
+
+// 공개 부서 소개 콘텐츠를 조회하는 요청
+export async function getDepartmentInfos() {
+  const response = await publicClient.get<SiteContentDepartmentsResponseDto>(
+    "/api/v1/site-contents/departments",
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 부서 소개 항목을 생성하는 요청
+export async function createDepartmentInfo(body: UpsertSiteContentDepartmentRequestDto) {
+  const response = await authClient.post<SiteContentDepartmentResponseDto>(
+    "/api/v1/site-contents/departments",
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 부서 소개 항목을 수정하는 요청
+export async function updateDepartmentInfo(
+  pathParams: SiteContentDepartmentPathParamsDto,
+  body: UpsertSiteContentDepartmentRequestDto,
+) {
+  const response = await authClient.put<SiteContentDepartmentResponseDto>(
+    `/api/v1/site-contents/departments/${pathParams.departmentInfoId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 부서 소개 항목을 삭제하는 요청
+export async function deleteDepartmentInfo(pathParams: SiteContentDepartmentPathParamsDto) {
+  await authClient.delete(
+    `/api/v1/site-contents/departments/${pathParams.departmentInfoId}`,
+  );
+}
+
+// 공개 반 소개 콘텐츠를 조회하는 요청
+export async function getClassInfos() {
+  const response = await publicClient.get<SiteContentClassesResponseDto>(
+    "/api/v1/site-contents/classes",
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 반 소개 항목을 생성하는 요청
+export async function createClassInfo(body: UpsertSiteContentClassRequestDto) {
+  const response = await authClient.post<SiteContentClassResponseDto>(
+    "/api/v1/site-contents/classes",
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 반 소개 항목을 수정하는 요청
+export async function updateClassInfo(
+  pathParams: SiteContentClassPathParamsDto,
+  body: UpsertSiteContentClassRequestDto,
+) {
+  const response = await authClient.put<SiteContentClassResponseDto>(
+    `/api/v1/site-contents/classes/${pathParams.classInfoId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 반 소개 항목을 삭제하는 요청
+export async function deleteClassInfo(pathParams: SiteContentClassPathParamsDto) {
+  await authClient.delete(`/api/v1/site-contents/classes/${pathParams.classInfoId}`);
+}

--- a/api/siteContent/siteContent.dto.ts
+++ b/api/siteContent/siteContent.dto.ts
@@ -1,0 +1,79 @@
+export interface SiteHistoryPhotoRequestDto {
+  url: string;
+  alt?: string;
+}
+
+export interface SiteHistoryPhotoResponseDto {
+  id?: number;
+  url?: string;
+  alt?: string;
+}
+
+export interface SiteHistoryResponseDto {
+  id?: number;
+  title?: string;
+  detail?: string;
+  linkLabel?: string;
+  linkHref?: string;
+  photos?: SiteHistoryPhotoResponseDto[];
+}
+
+export interface SiteHistoriesResponseDto {
+  history?: SiteHistoryResponseDto[];
+}
+
+export interface UpsertSiteHistoryRequestDto {
+  title: string;
+  detail?: string;
+  linkLabel?: string;
+  linkHref?: string;
+  photos?: SiteHistoryPhotoRequestDto[];
+}
+
+export interface SiteContentDepartmentResponseDto {
+  id?: number;
+  title?: string;
+  name?: string;
+  responsibilities?: string[];
+}
+
+export interface SiteContentDepartmentsResponseDto {
+  principal?: SiteContentDepartmentResponseDto | null;
+  departments?: SiteContentDepartmentResponseDto[];
+}
+
+export interface UpsertSiteContentDepartmentRequestDto {
+  title: string;
+  name?: string;
+  responsibilities?: string[];
+}
+
+export interface SiteContentClassResponseDto {
+  id?: number;
+  name?: string;
+  description?: string[];
+}
+
+export interface SiteContentClassesResponseDto {
+  weekday?: SiteContentClassResponseDto[];
+  weekendMorning?: SiteContentClassResponseDto[];
+  weekendAfternoon?: SiteContentClassResponseDto[];
+}
+
+export interface UpsertSiteContentClassRequestDto {
+  name: string;
+  groupId: string;
+  description?: string[];
+}
+
+export interface SiteHistoryPathParamsDto {
+  historyId: number;
+}
+
+export interface SiteContentDepartmentPathParamsDto {
+  departmentInfoId: number;
+}
+
+export interface SiteContentClassPathParamsDto {
+  classInfoId: number;
+}

--- a/api/subject/subject.api.test.ts
+++ b/api/subject/subject.api.test.ts
@@ -16,6 +16,7 @@ import {
   assignSubjectTeacher,
   createSubject,
   getSubjects,
+  getUnassignedSubjects,
   updateSubject,
   updateSubjectSchedule,
 } from "./subject.api";
@@ -84,6 +85,24 @@ describe("subject.api", () => {
       period: 2,
       description: "Writing practice",
     });
+  });
+
+  it("returns unassigned subjects from the dedicated endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/subjects/unassigned`, ({ request }) => {
+        observedPathname = new URL(request.url).pathname;
+        return HttpResponse.json(SUBJECT_LIST_RESPONSE);
+      }),
+    );
+
+    const response = await getUnassignedSubjects();
+
+    expect(response).toEqual(SUBJECT_LIST_RESPONSE);
+    expect(observedPathname).toBe("/api/v1/subjects/unassigned");
   });
 
   it("updates subject teacher and schedule through dedicated Swagger routes", async () => {

--- a/api/subject/subject.api.ts
+++ b/api/subject/subject.api.ts
@@ -17,6 +17,14 @@ export async function getSubjects(query?: SubjectListQueryParamsDto) {
   return response.data;
 }
 
+// 담당 교사가 배정되지 않은 과목 목록을 조회하는 요청
+export async function getUnassignedSubjects() {
+  const response = await authClient.get<SubjectDetailResponseDto[]>(
+    "/api/v1/subjects/unassigned",
+  );
+  return response.data;
+}
+
 // 새 과목을 생성하는 요청
 export async function createSubject(body: CreateSubjectRequestDto) {
   const response = await authClient.post<SubjectDetailResponseDto>("/api/v1/subjects", body);

--- a/api/teacherApplication/teacherApplication.api.test.ts
+++ b/api/teacherApplication/teacherApplication.api.test.ts
@@ -1,0 +1,116 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import {
+  approveTeacherApplication,
+  createTeacherApplication,
+  getTeacherApplications,
+  rejectTeacherApplication,
+} from "./teacherApplication.api";
+import type { CreateTeacherApplicationRequestDto } from "./teacherApplication.dto";
+
+const APPLICATION_BODY: CreateTeacherApplicationRequestDto = {
+  birthDate: "1999-03-15",
+  phoneNumber: "010-0000-0000",
+  email: "hong@example.com",
+  address: "부산광역시 금정구",
+  educationAndMajor: "부산대학교 국어국문학과",
+  preferredSubjectId: 3,
+  motivation: "지원 동기",
+  desiredTeacherImage: "희망 교사상",
+  meaningOfSharing: "나눔의 의미",
+};
+
+describe("teacherApplication.api", () => {
+  it("submits a teacher application with the expected body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/teacher-applications`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ id: 1, status: "PENDING", ...APPLICATION_BODY });
+      }),
+    );
+
+    const response = await createTeacherApplication(APPLICATION_BODY);
+
+    expect(response).toMatchObject({ id: 1, status: "PENDING" });
+    expect(observedBody).toEqual(APPLICATION_BODY);
+  });
+
+  it("returns admin teacher applications with filters", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/admin/teacher-applications`, ({ request }) => {
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          content: [{ id: 1, applicantName: "홍길동", status: "PENDING" }],
+          page: 0,
+          size: 10,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const response = await getTeacherApplications({ keyword: "홍길동", status: "PENDING" });
+
+    expect(response.content?.[0]).toMatchObject({ applicantName: "홍길동" });
+    expect(observedQueryString).toContain("keyword=");
+    expect(observedQueryString).toContain("status=PENDING");
+  });
+
+  it("approves and rejects teacher applications through admin endpoints", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedApproveBody: unknown;
+    let observedRejectBody: unknown;
+
+    server.use(
+      http.patch(
+        `${API_BASE_URL}/api/v1/admin/teacher-applications/1/approve`,
+        async ({ request }) => {
+          observedApproveBody = await request.json();
+          return HttpResponse.json({ id: 1, status: "APPROVED" });
+        },
+      ),
+      http.patch(
+        `${API_BASE_URL}/api/v1/admin/teacher-applications/2/reject`,
+        async ({ request }) => {
+          observedRejectBody = await request.json();
+          return HttpResponse.json({ id: 2, status: "REJECTED" });
+        },
+      ),
+    );
+
+    await approveTeacherApplication(
+      { applicationId: 1 },
+      {
+        classroomId: 1,
+        teacherStartAt: "2026-06-01",
+        teacherEndAt: "2026-12-31",
+        note: "승인",
+      },
+    );
+    await rejectTeacherApplication({ applicationId: 2 }, { note: "반려" });
+
+    expect(observedApproveBody).toEqual({
+      classroomId: 1,
+      teacherStartAt: "2026-06-01",
+      teacherEndAt: "2026-12-31",
+      note: "승인",
+    });
+    expect(observedRejectBody).toEqual({ note: "반려" });
+  });
+});

--- a/api/teacherApplication/teacherApplication.api.ts
+++ b/api/teacherApplication/teacherApplication.api.ts
@@ -1,0 +1,87 @@
+import authClient from "../client/authClient";
+import type {
+  ApproveTeacherApplicationRequestDto,
+  CreateTeacherApplicationRequestDto,
+  MyTeacherApplicationResponseDto,
+  RejectTeacherApplicationRequestDto,
+  TeacherApplicationListQueryParamsDto,
+  TeacherApplicationListResponseDto,
+  TeacherApplicationPathParamsDto,
+  TeacherApplicationResponseDto,
+  UpdateTeacherApplicationRequestDto,
+} from "./teacherApplication.dto";
+
+// 교원 신청서를 제출하는 요청
+export async function createTeacherApplication(body: CreateTeacherApplicationRequestDto) {
+  const response = await authClient.post<TeacherApplicationResponseDto>(
+    "/api/v1/teacher-applications",
+    body,
+  );
+  return response.data;
+}
+
+// 현재 사용자의 교원 신청 상태를 조회하는 요청
+export async function getMyTeacherApplication() {
+  const response = await authClient.get<MyTeacherApplicationResponseDto>(
+    "/api/v1/teacher-applications/me",
+  );
+  return response.data;
+}
+
+// 현재 사용자의 교원 신청서를 수정하는 요청
+export async function updateTeacherApplication(
+  pathParams: TeacherApplicationPathParamsDto,
+  body: UpdateTeacherApplicationRequestDto,
+) {
+  const response = await authClient.patch<TeacherApplicationResponseDto>(
+    `/api/v1/teacher-applications/${pathParams.applicationId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 현재 사용자의 교원 신청을 취소하는 요청
+export async function cancelTeacherApplication(pathParams: TeacherApplicationPathParamsDto) {
+  await authClient.delete(`/api/v1/teacher-applications/${pathParams.applicationId}`);
+}
+
+// 관리자 권한으로 교원 신청 목록을 조회하는 요청
+export async function getTeacherApplications(query?: TeacherApplicationListQueryParamsDto) {
+  const response = await authClient.get<TeacherApplicationListResponseDto>(
+    "/api/v1/admin/teacher-applications",
+    { params: query },
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 교원 신청 상세를 조회하는 요청
+export async function getTeacherApplication(pathParams: TeacherApplicationPathParamsDto) {
+  const response = await authClient.get<TeacherApplicationResponseDto>(
+    `/api/v1/admin/teacher-applications/${pathParams.applicationId}`,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 교원 신청을 승인하는 요청
+export async function approveTeacherApplication(
+  pathParams: TeacherApplicationPathParamsDto,
+  body: ApproveTeacherApplicationRequestDto,
+) {
+  const response = await authClient.patch<TeacherApplicationResponseDto>(
+    `/api/v1/admin/teacher-applications/${pathParams.applicationId}/approve`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 교원 신청을 반려하는 요청
+export async function rejectTeacherApplication(
+  pathParams: TeacherApplicationPathParamsDto,
+  body: RejectTeacherApplicationRequestDto,
+) {
+  const response = await authClient.patch<TeacherApplicationResponseDto>(
+    `/api/v1/admin/teacher-applications/${pathParams.applicationId}/reject`,
+    body,
+  );
+  return response.data;
+}

--- a/api/teacherApplication/teacherApplication.dto.ts
+++ b/api/teacherApplication/teacherApplication.dto.ts
@@ -1,0 +1,79 @@
+import type { SubjectDayOfWeek } from "../subject/subject.dto";
+
+export type TeacherApplicationStatus = "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
+
+export interface TeacherApplicationPathParamsDto {
+  applicationId: number;
+}
+
+export interface TeacherApplicationListQueryParamsDto {
+  keyword?: string;
+  page?: number;
+  size?: number;
+  status?: TeacherApplicationStatus;
+}
+
+export interface TeacherApplicationRequestDto {
+  birthDate: string;
+  phoneNumber: string;
+  email: string;
+  address: string;
+  educationAndMajor: string;
+  preferredSubjectId: number;
+  motivation: string;
+  desiredTeacherImage: string;
+  meaningOfSharing: string;
+}
+
+export type CreateTeacherApplicationRequestDto = TeacherApplicationRequestDto;
+export type UpdateTeacherApplicationRequestDto = TeacherApplicationRequestDto;
+
+export interface TeacherApplicationResponseDto {
+  id?: number;
+  applicantId?: number;
+  applicantName?: string;
+  applicantPhoneNumber?: string;
+  applicantEmail?: string;
+  birthDate?: string;
+  address?: string;
+  educationAndMajor?: string;
+  preferredSubjectId?: number;
+  preferredSubjectName?: string;
+  preferredClassroomName?: string;
+  preferredDayOfWeek?: SubjectDayOfWeek;
+  preferredStartTime?: string;
+  preferredEndTime?: string;
+  motivation?: string;
+  desiredTeacherImage?: string;
+  meaningOfSharing?: string;
+  status?: TeacherApplicationStatus;
+  reviewedAt?: string;
+  reviewedByName?: string;
+  reviewNote?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface MyTeacherApplicationResponseDto {
+  exists?: boolean;
+  application?: TeacherApplicationResponseDto | null;
+}
+
+export interface TeacherApplicationListResponseDto {
+  content?: TeacherApplicationResponseDto[];
+  page?: number;
+  size?: number;
+  totalElements?: number;
+  totalPages?: number;
+}
+
+export interface ApproveTeacherApplicationRequestDto {
+  classroomId: number;
+  teacherStartAt: string;
+  teacherEndAt: string;
+  note?: string;
+}
+
+export interface RejectTeacherApplicationRequestDto {
+  note: string;
+}

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -14,6 +14,7 @@ import { setAccessToken } from "../client/tokenStorage";
 
 import {
   getAssignablePermissions,
+  getTeacherContacts,
   getUsers,
   removeUserPermission,
   updateCurrentUser,
@@ -127,5 +128,35 @@ describe("user.api", () => {
     await expect(getAssignablePermissions()).resolves.toEqual([
       expect.objectContaining({ permissionCode: "post:manage:*" }),
     ]);
+  });
+
+  it("returns teacher contacts with authorization header", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAuthorizationHeader: string | null = null;
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/teachers/contact-list`, ({ request }) => {
+        observedAuthorizationHeader = request.headers.get("authorization");
+        return HttpResponse.json([
+          {
+            id: 1,
+            name: "Teacher",
+            classroomName: "국화반",
+            phoneNumber: "010-1234-5678",
+          },
+        ]);
+      }),
+    );
+
+    const response = await getTeacherContacts();
+
+    expect(response).toEqual([
+      expect.objectContaining({
+        id: 1,
+        name: "Teacher",
+      }),
+    ]);
+    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
   });
 });

--- a/api/user/user.api.ts
+++ b/api/user/user.api.ts
@@ -10,6 +10,7 @@ import type {
   UserListResponseDto,
   UserPathParamsDto,
   UserResponseDto,
+  TeacherContactResponseDto,
 } from "./user.dto";
 
 // 사용자 목록을 조회하는 요청
@@ -96,6 +97,14 @@ export async function removeUserPermission(
 export async function getAssignablePermissions() {
   const response = await authClient.get<PermissionDefinitionDto[]>(
     "/api/v1/permission-registry",
+  );
+  return response.data;
+}
+
+// 현재 활동 중인 교사 연락망을 조회하는 요청
+export async function getTeacherContacts() {
+  const response = await authClient.get<TeacherContactResponseDto[]>(
+    "/api/v1/teachers/contact-list",
   );
   return response.data;
 }

--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -55,6 +55,13 @@ export interface UserResponseDto {
   updatedAt?: string;
 }
 
+export interface TeacherContactResponseDto {
+  id?: number;
+  name?: string;
+  classroomName?: string | null;
+  phoneNumber?: string;
+}
+
 export type UserListItemDto = UserResponseDto;
 
 export interface UserListResponseDto {

--- a/api/vendor/vendor.api.test.ts
+++ b/api/vendor/vendor.api.test.ts
@@ -1,0 +1,71 @@
+import "../../test/setup";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { API_BASE_URL, VALID_ACCESS_TOKEN } from "../../mocks/handlers/auth.handlers";
+import { server } from "../../mocks/server";
+import { setAccessToken } from "../client/tokenStorage";
+
+import { chargeVendor, createVendor, getVendorHistories, getVendors } from "./vendor.api";
+
+describe("vendor.api", () => {
+  it("returns vendors with keyword query and authorization header", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAuthorizationHeader: string | null = null;
+    let observedQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/admin/vendors`, ({ request }) => {
+        observedAuthorizationHeader = request.headers.get("authorization");
+        observedQueryString = new URL(request.url).search;
+        return HttpResponse.json([{ id: 1, name: "금정문구", balance: 10000 }]);
+      }),
+    );
+
+    const response = await getVendors({ keyword: "문구" });
+
+    expect(response).toEqual([expect.objectContaining({ id: 1, name: "금정문구" })]);
+    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
+    expect(observedQueryString).toContain("keyword=");
+  });
+
+  it("creates a vendor and charges its balance with expected bodies", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedCreateBody: unknown;
+    let observedChargeBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/admin/vendors`, async ({ request }) => {
+        observedCreateBody = await request.json();
+        return HttpResponse.json({ id: 2, name: "금정문구", balance: 0 });
+      }),
+      http.post(`${API_BASE_URL}/api/v1/admin/vendors/2/charges`, async ({ request }) => {
+        observedChargeBody = await request.json();
+        return HttpResponse.json({ id: 2, name: "금정문구", balance: 50000 });
+      }),
+    );
+
+    await createVendor({ name: "금정문구", description: "문구류" });
+    await chargeVendor({ vendorId: 2 }, { amount: 50000, memo: "충전" });
+
+    expect(observedCreateBody).toEqual({ name: "금정문구", description: "문구류" });
+    expect(observedChargeBody).toEqual({ amount: 50000, memo: "충전" });
+  });
+
+  it("returns vendor balance histories", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/admin/vendors/2/histories`, () => {
+        return HttpResponse.json([{ id: 1, type: "CHARGE", amount: 50000 }]);
+      }),
+    );
+
+    await expect(getVendorHistories({ vendorId: 2 })).resolves.toEqual([
+      expect.objectContaining({ type: "CHARGE", amount: 50000 }),
+    ]);
+  });
+});

--- a/api/vendor/vendor.api.ts
+++ b/api/vendor/vendor.api.ts
@@ -1,0 +1,69 @@
+import authClient from "../client/authClient";
+import type {
+  ChargeVendorRequestDto,
+  CreateVendorRequestDto,
+  UpdateVendorRequestDto,
+  VendorBalanceHistoryResponseDto,
+  VendorListQueryParamsDto,
+  VendorPathParamsDto,
+  VendorResponseDto,
+} from "./vendor.dto";
+
+// 관리자 권한으로 거래처 목록을 조회하는 요청
+export async function getVendors(query?: VendorListQueryParamsDto) {
+  const response = await authClient.get<VendorResponseDto[]>("/api/v1/admin/vendors", {
+    params: query,
+  });
+  return response.data;
+}
+
+// 관리자 권한으로 거래처를 생성하는 요청
+export async function createVendor(body: CreateVendorRequestDto) {
+  const response = await authClient.post<VendorResponseDto>("/api/v1/admin/vendors", body);
+  return response.data;
+}
+
+// 관리자 권한으로 거래처 상세를 조회하는 요청
+export async function getVendor(pathParams: VendorPathParamsDto) {
+  const response = await authClient.get<VendorResponseDto>(
+    `/api/v1/admin/vendors/${pathParams.vendorId}`,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 거래처를 수정하는 요청
+export async function updateVendor(
+  pathParams: VendorPathParamsDto,
+  body: UpdateVendorRequestDto,
+) {
+  const response = await authClient.patch<VendorResponseDto>(
+    `/api/v1/admin/vendors/${pathParams.vendorId}`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 거래처를 삭제하는 요청
+export async function deleteVendor(pathParams: VendorPathParamsDto) {
+  await authClient.delete(`/api/v1/admin/vendors/${pathParams.vendorId}`);
+}
+
+// 관리자 권한으로 거래처 잔액을 충전하는 요청
+export async function chargeVendor(
+  pathParams: VendorPathParamsDto,
+  body: ChargeVendorRequestDto,
+) {
+  const response = await authClient.post<VendorResponseDto>(
+    `/api/v1/admin/vendors/${pathParams.vendorId}/charges`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 권한으로 거래처 잔액 이력을 조회하는 요청
+export async function getVendorHistories(pathParams: VendorPathParamsDto) {
+  const response = await authClient.get<VendorBalanceHistoryResponseDto[]>(
+    `/api/v1/admin/vendors/${pathParams.vendorId}/histories`,
+  );
+  return response.data;
+}

--- a/api/vendor/vendor.dto.ts
+++ b/api/vendor/vendor.dto.ts
@@ -1,0 +1,48 @@
+export interface VendorListQueryParamsDto {
+  keyword?: string;
+}
+
+export interface VendorPathParamsDto {
+  vendorId: number;
+}
+
+export interface VendorResponseDto {
+  id?: number;
+  name?: string;
+  description?: string;
+  balance?: number;
+  isActive?: boolean;
+  createdAt?: string;
+}
+
+export interface CreateVendorRequestDto {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateVendorRequestDto {
+  name?: string;
+  description?: string;
+  isActive?: boolean;
+}
+
+export interface ChargeVendorRequestDto {
+  amount: number;
+  memo?: string;
+  receiptFileId?: string;
+}
+
+export type VendorBalanceHistoryType = "CHARGE" | "DEDUCT";
+
+export interface VendorBalanceHistoryResponseDto {
+  id?: number;
+  type?: VendorBalanceHistoryType;
+  amount?: number;
+  balanceAfter?: number;
+  memo?: string;
+  receiptFileId?: string;
+  receiptFileUrl?: string;
+  purchaseRequestId?: number;
+  createdByName?: string;
+  occurredAt?: string;
+}

--- a/components/info/classes/ClassesPage.tsx
+++ b/components/info/classes/ClassesPage.tsx
@@ -2,15 +2,24 @@
 
 import { type FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { IconEdit, IconPlus, IconX } from "@tabler/icons-react";
 import styled from "styled-components";
+import {
+  createClassInfo,
+  deleteClassInfo,
+  getClassInfos,
+  updateClassInfo,
+} from "@/api/siteContent/siteContent.api";
+import type { SiteContentClassResponseDto } from "@/api/siteContent/siteContent.dto";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 type ClassGroupId = "weekday" | "weekendMorning" | "weekendAfternoon";
 
 type ClassItem = {
-  id: string;
+  id: number;
   groupId: ClassGroupId;
   name: string;
   description: string;
@@ -53,84 +62,11 @@ const classGroups: ClassGroup[] = [
   },
 ];
 
-const initialClasses: ClassItem[] = [
-  {
-    id: "weekday-cherry",
-    groupId: "weekday",
-    name: "벚꽃반",
-    description: "한글 기초 학습 (자모, 받침, 기본 낱말)",
-  },
-  {
-    id: "weekday-forsythia",
-    groupId: "weekday",
-    name: "개나리반",
-    description: "짧은 기본 문장 읽기·쓰기 학습 (초등 1단계 국어)",
-  },
-  {
-    id: "weekday-dandelion",
-    groupId: "weekday",
-    name: "민들레반",
-    description: "생활 문장 읽기·이해 및 기초 수학 학습 (초등 2단계 국어·수학)",
-  },
-  {
-    id: "weekday-camellia",
-    groupId: "weekday",
-    name: "동백반",
-    description: "초등 고학년 수준의 교과 학습 (초등 3단계 국어·수학·영어)",
-  },
-  {
-    id: "weekday-sunflower",
-    groupId: "weekday",
-    name: "해바라기반",
-    description: "초졸 검정고시 대비 학습 (국어·영어·수학·사회·과학)",
-  },
-  {
-    id: "weekday-chrysanthemum",
-    groupId: "weekday",
-    name: "국화반",
-    description: "중졸 검정고시 대비 학습 (국어·영어·수학·사회·과학)",
-  },
-  {
-    id: "weekend-sprout",
-    groupId: "weekendMorning",
-    name: "새싹반",
-    description: "영어 기초 학습 (알파벳, 파닉스, 기본 단어)",
-  },
-  {
-    id: "weekend-tree",
-    groupId: "weekendMorning",
-    name: "나무반",
-    description: "초등 영어 문장 읽기 학습 (초등 영어 과정, 문장 읽기)",
-  },
-  {
-    id: "weekend-fruit",
-    groupId: "weekendMorning",
-    name: "열매반",
-    description: "중등 영어 문법·독해 학습 (중등 영어 과정, 문법)",
-  },
-  {
-    id: "weekend-seed",
-    groupId: "weekendAfternoon",
-    name: "씨앗반",
-    description: "영어 기초 과정 학습 (기초 영어)",
-  },
-  {
-    id: "weekend-moon",
-    groupId: "weekendAfternoon",
-    name: "상현/하현/초승반",
-    description: "디지털 기초 활용 학습 (스마트폰 기능, 생활 앱 사용법)",
-  },
-];
-
 const emptyForm: ClassFormState = {
   groupId: "weekday",
   name: "",
   description: "",
 };
-
-function makeId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.round(Math.random() * 100000)}`;
-}
 
 function toForm(item: ClassItem): ClassFormState {
   return {
@@ -147,19 +83,71 @@ function toDescriptionItems(value: string) {
     .filter(Boolean);
 }
 
+function mapClassItems(
+  groupId: ClassGroupId,
+  items: SiteContentClassResponseDto[] | undefined,
+) {
+  return (
+    items
+      ?.map((item) => {
+        if (typeof item.id !== "number" || !item.name) return null;
+
+        return {
+          id: item.id,
+          groupId,
+          name: item.name,
+          description: item.description?.join("\n") ?? "",
+        };
+      })
+      .filter((item): item is ClassItem => item !== null) ?? []
+  );
+}
+
 export default function ClassesPage() {
+  const queryClient = useQueryClient();
   const { status, user } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
-  const [classes, setClasses] = useState(initialClasses);
+  const classesQuery = useQuery({
+    queryKey: queryKeys.siteContent.classes(),
+    queryFn: getClassInfos,
+  });
   const [isEditMode, setIsEditMode] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
   const [form, setForm] = useState<ClassFormState>(emptyForm);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
+
+  const classes = useMemo(
+    () => [
+      ...mapClassItems("weekday", classesQuery.data?.weekday),
+      ...mapClassItems("weekendMorning", classesQuery.data?.weekendMorning),
+      ...mapClassItems("weekendAfternoon", classesQuery.data?.weekendAfternoon),
+    ],
+    [classesQuery.data],
+  );
 
   const editingItem = useMemo(
     () => classes.find((item) => item.id === editingId) ?? null,
     [classes, editingId],
   );
+
+  const refreshClasses = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.siteContent.classes() });
+
+  const createMutation = useMutation({
+    mutationFn: createClassInfo,
+    onSuccess: refreshClasses,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Parameters<typeof updateClassInfo>[1] }) =>
+      updateClassInfo({ classInfoId: id }, body),
+    onSuccess: refreshClasses,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteClassInfo({ classInfoId: id }),
+    onSuccess: refreshClasses,
+  });
 
   function openCreateEditor() {
     setEditingId(null);
@@ -188,31 +176,30 @@ export default function ClassesPage() {
     setForm((current) => ({ ...current, [name]: value }));
   }
 
-  function handleDeleteItem() {
+  async function handleDeleteItem() {
     if (!editingId) return;
-    setClasses((current) => current.filter((item) => item.id !== editingId));
+    await deleteMutation.mutateAsync(editingId);
     closeEditor();
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const name = form.name.trim();
     const descriptionItems = toDescriptionItems(form.description);
     if (!name || descriptionItems.length === 0) return;
 
-    const nextItem: ClassItem = {
-      id: editingId ?? makeId("class"),
+    const body = {
       groupId: form.groupId,
       name,
-      description: descriptionItems.join("\n"),
+      description: descriptionItems,
     };
 
-    setClasses((current) =>
-      editingId
-        ? current.map((item) => (item.id === editingId ? nextItem : item))
-        : [...current, nextItem],
-    );
+    if (editingId) {
+      await updateMutation.mutateAsync({ id: editingId, body });
+    } else {
+      await createMutation.mutateAsync(body);
+    }
     closeEditor();
   }
 
@@ -265,31 +252,37 @@ export default function ClassesPage() {
             ) : null}
           </HeaderRow>
 
-          <ClassLayout aria-label="금정열린배움터 반 정보">
-            <ClassColumn>
-              <ClassSection
-                group={classGroups[0]}
-                items={classes.filter((item) => item.groupId === "weekday")}
-                isEditMode={isAdmin && isEditMode}
-                onEdit={openEditEditor}
-              />
-            </ClassColumn>
-            <ColumnDivider aria-hidden="true" />
-            <ClassColumn>
-              <ClassSection
-                group={classGroups[1]}
-                items={classes.filter((item) => item.groupId === "weekendMorning")}
-                isEditMode={isAdmin && isEditMode}
-                onEdit={openEditEditor}
-              />
-              <ClassSection
-                group={classGroups[2]}
-                items={classes.filter((item) => item.groupId === "weekendAfternoon")}
-                isEditMode={isAdmin && isEditMode}
-                onEdit={openEditEditor}
-              />
-            </ClassColumn>
-          </ClassLayout>
+          {classesQuery.isLoading ? (
+            <EmptyState>반 정보를 불러오는 중입니다.</EmptyState>
+          ) : classesQuery.isError ? (
+            <EmptyState>반 정보를 불러오지 못했습니다.</EmptyState>
+          ) : (
+            <ClassLayout aria-label="금정열린배움터 반 정보">
+              <ClassColumn>
+                <ClassSection
+                  group={classGroups[0]}
+                  items={classes.filter((item) => item.groupId === "weekday")}
+                  isEditMode={isAdmin && isEditMode}
+                  onEdit={openEditEditor}
+                />
+              </ClassColumn>
+              <ColumnDivider aria-hidden="true" />
+              <ClassColumn>
+                <ClassSection
+                  group={classGroups[1]}
+                  items={classes.filter((item) => item.groupId === "weekendMorning")}
+                  isEditMode={isAdmin && isEditMode}
+                  onEdit={openEditEditor}
+                />
+                <ClassSection
+                  group={classGroups[2]}
+                  items={classes.filter((item) => item.groupId === "weekendAfternoon")}
+                  isEditMode={isAdmin && isEditMode}
+                  onEdit={openEditEditor}
+                />
+              </ClassColumn>
+            </ClassLayout>
+          )}
         </Content>
       </Stage>
 

--- a/components/info/departments/DepartmentsPage.tsx
+++ b/components/info/departments/DepartmentsPage.tsx
@@ -2,16 +2,26 @@
 
 import { type CSSProperties, type FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { IconEdit, IconPlus, IconX } from "@tabler/icons-react";
 import styled from "styled-components";
+import {
+  createDepartmentInfo,
+  deleteDepartmentInfo,
+  getDepartmentInfos,
+  updateDepartmentInfo,
+} from "@/api/siteContent/siteContent.api";
+import type { SiteContentDepartmentResponseDto } from "@/api/siteContent/siteContent.dto";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 type OrganizationMember = {
-  id: string;
+  id: number;
   name: string;
   title: string;
   responsibilities: string[];
+  isPrincipal?: boolean;
 };
 
 type DepartmentFormState = {
@@ -27,55 +37,11 @@ const sidebarItems = [
   { label: "행사 정보", href: "/info/events" },
 ];
 
-const initialPrincipal: OrganizationMember = {
-  id: "principal",
-  title: "교장",
-  name: "정해웅",
-  responsibilities: ["금정열린배움터의 전반적인 운영을 총괄"],
-};
-
-const initialDepartments: OrganizationMember[] = [
-  {
-    id: "academic-planning",
-    title: "교무기획부",
-    name: "",
-    responsibilities: ["야학 행사 계획 및 교무 선생님 보조"],
-  },
-  {
-    id: "education-research",
-    title: "교육연구부",
-    name: "",
-    responsibilities: ["신입 선생님 면접", "생일 및 참관, 연구 수업 관리", "각종 일지 관리"],
-  },
-  {
-    id: "general-affairs",
-    title: "총무부",
-    name: "",
-    responsibilities: ["야학 재정 관리"],
-  },
-  {
-    id: "life-safety",
-    title: "생활안전부",
-    name: "",
-    responsibilities: ["시설 안전 점검 및 수리", "비품 관리"],
-  },
-  {
-    id: "public-relations",
-    title: "홍보부",
-    name: "",
-    responsibilities: ["야학 홍보 및 학생, 교사 모집"],
-  },
-];
-
 const emptyDepartmentForm: DepartmentFormState = {
   title: "",
   name: "",
   responsibilities: "",
 };
-
-function makeId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.round(Math.random() * 100000)}`;
-}
 
 function toForm(item: OrganizationMember): DepartmentFormState {
   return {
@@ -92,20 +58,70 @@ function toResponsibilities(value: string) {
     .filter(Boolean);
 }
 
+function mapOrganizationMember(
+  item: SiteContentDepartmentResponseDto | null | undefined,
+  isPrincipal = false,
+): OrganizationMember | null {
+  if (!item || typeof item.id !== "number" || !item.title) return null;
+
+  return {
+    id: item.id,
+    title: item.title,
+    name: item.name ?? "",
+    responsibilities: item.responsibilities ?? [],
+    isPrincipal,
+  };
+}
+
 export default function DepartmentsPage() {
+  const queryClient = useQueryClient();
   const { status, user } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
-  const [principal, setPrincipal] = useState(initialPrincipal);
-  const [departments, setDepartments] = useState(initialDepartments);
+  const departmentsQuery = useQuery({
+    queryKey: queryKeys.siteContent.departments(),
+    queryFn: getDepartmentInfos,
+  });
   const [isEditMode, setIsEditMode] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
   const [form, setForm] = useState(emptyDepartmentForm);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
 
+  const principal = useMemo(
+    () => mapOrganizationMember(departmentsQuery.data?.principal, true),
+    [departmentsQuery.data],
+  );
+
+  const departments = useMemo(
+    () =>
+      departmentsQuery.data?.departments
+        ?.map((item) => mapOrganizationMember(item))
+        .filter((item): item is OrganizationMember => item !== null) ?? [],
+    [departmentsQuery.data],
+  );
+
   const editingItem = useMemo(() => {
-    if (editingId === principal.id) return principal;
+    if (editingId === principal?.id) return principal;
     return departments.find((item) => item.id === editingId) ?? null;
   }, [departments, editingId, principal]);
+
+  const refreshDepartments = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.siteContent.departments() });
+
+  const createMutation = useMutation({
+    mutationFn: createDepartmentInfo,
+    onSuccess: refreshDepartments,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Parameters<typeof updateDepartmentInfo>[1] }) =>
+      updateDepartmentInfo({ departmentInfoId: id }, body),
+    onSuccess: refreshDepartments,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteDepartmentInfo({ departmentInfoId: id }),
+    onSuccess: refreshDepartments,
+  });
 
   function openCreateEditor() {
     setEditingId(null);
@@ -134,31 +150,28 @@ export default function DepartmentsPage() {
     setForm((current) => ({ ...current, [name]: value }));
   }
 
-  function handleDeleteItem() {
-    if (!editingId || editingId === principal.id) return;
-    setDepartments((current) => current.filter((item) => item.id !== editingId));
+  async function handleDeleteItem() {
+    if (!editingId || editingId === principal?.id) return;
+    await deleteMutation.mutateAsync(editingId);
     closeEditor();
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const title = form.title.trim();
     if (!title) return;
 
-    const nextItem: OrganizationMember = {
-      id: editingId ?? makeId("department"),
+    const body = {
       title,
       name: form.name.trim(),
       responsibilities: toResponsibilities(form.responsibilities),
     };
 
-    if (editingId === principal.id) {
-      setPrincipal(nextItem);
-    } else if (editingId) {
-      setDepartments((current) => current.map((item) => (item.id === editingId ? nextItem : item)));
+    if (editingId) {
+      await updateMutation.mutateAsync({ id: editingId, body });
     } else {
-      setDepartments((current) => [...current, nextItem]);
+      await createMutation.mutateAsync(body);
     }
 
     closeEditor();
@@ -213,12 +226,19 @@ export default function DepartmentsPage() {
             ) : null}
           </HeaderRow>
 
-          <OrganizationChart aria-label="금정열린배움터 조직 구성도">
-            <PrincipalGroup>
-              <MemberCard item={principal} isEditMode={isAdmin && isEditMode} onEdit={openEditEditor} />
-            </PrincipalGroup>
+          {departmentsQuery.isLoading ? (
+            <EmptyState>부서 정보를 불러오는 중입니다.</EmptyState>
+          ) : departmentsQuery.isError ? (
+            <EmptyState>부서 정보를 불러오지 못했습니다.</EmptyState>
+          ) : (
+            <OrganizationChart aria-label="금정열린배움터 조직 구성도">
+              {principal ? (
+                <PrincipalGroup>
+                  <MemberCard item={principal} isEditMode={isAdmin && isEditMode} onEdit={openEditEditor} />
+                </PrincipalGroup>
+              ) : null}
 
-            {departments.length > 0 ? (
+              {departments.length > 0 ? (
               <>
                 <ConnectorRow
                   aria-hidden="true"
@@ -239,10 +259,11 @@ export default function DepartmentsPage() {
                   ))}
                 </DepartmentGrid>
               </>
-            ) : (
-              <EmptyState>등록된 부서가 없습니다.</EmptyState>
-            )}
-          </OrganizationChart>
+              ) : (
+                <EmptyState>등록된 부서가 없습니다.</EmptyState>
+              )}
+            </OrganizationChart>
+          )}
         </Content>
       </Stage>
 
@@ -299,7 +320,7 @@ export default function DepartmentsPage() {
                 <SecondaryButton type="button" onClick={closeEditor}>
                   취소
                 </SecondaryButton>
-                {editingId && editingId !== principal.id ? (
+                {editingId && editingId !== principal?.id ? (
                   <DeleteButton type="button" onClick={handleDeleteItem}>
                     삭제
                   </DeleteButton>

--- a/components/info/history/HistoryPage.tsx
+++ b/components/info/history/HistoryPage.tsx
@@ -2,6 +2,7 @@
 
 import { type ChangeEvent, type FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   IconEdit,
   IconExternalLink,
@@ -12,7 +13,16 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import styled from "styled-components";
+import {
+  createHistory,
+  deleteHistory,
+  getHistories,
+  updateHistory,
+} from "@/api/siteContent/siteContent.api";
+import type { SiteHistoryResponseDto } from "@/api/siteContent/siteContent.dto";
+import { uploadSiteContentImage } from "@/api/file/file.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 type HistoryLink = {
@@ -28,7 +38,7 @@ type HistoryPhoto = {
 };
 
 type HistoryItem = {
-  id: string;
+  id: number;
   title: string;
   detail?: string;
   links?: HistoryLink[];
@@ -50,108 +60,6 @@ const sidebarItems = [
   { label: "행사 정보", href: "/info/events" },
 ];
 
-const initialHistoryItems: HistoryItem[] = [
-  {
-    id: "history-1994-open",
-    title: "1994년 5월 2일 개교",
-    detail: "부산 성화야학에서 분리 개교",
-  },
-  { id: "history-1996-knn", title: "1996년 4월 PSB (현 KNN) 방송국 취재 및 방송" },
-  {
-    id: "history-2009-channel-pnu",
-    title: "2009년 9월 21일 채널 PNU 소개",
-    links: [{ id: "link-2009-channel-pnu", label: "영상 보기", href: "#" }],
-  },
-  {
-    id: "history-2014-interview",
-    title: "2014년 6월 9일 채널 PNU 조정환 교장 인터뷰",
-    links: [{ id: "link-2014-interview", label: "인터뷰 보기", href: "#" }],
-  },
-  {
-    id: "history-2017-lecture",
-    title: "2017년 3월 학생 1명과 교사 1명이 각각 일반인 대상으로 강연 (조해진 교무)",
-    detail: "부산문화재단 불쏘시개",
-  },
-  { id: "history-2017-award", title: "2017년 12월 금정구자원봉사센터 우수 수요처 감사패 수상" },
-  {
-    id: "history-2018-051",
-    title: "2018년 5월 11일 051초대석 18회 김수연 선생님, 이재빈 선생님 출연 (박혁서 교무)",
-    photos: [{ id: "photo-2018-051", alt: "051초대석 출연 사진", src: "" }],
-  },
-  {
-    id: "history-2018-logo",
-    title: "2018년 9월 21일 금정열린배움터 공식 로고 제작 (박혁서 교무)",
-    detail: "by 예소 디자인",
-  },
-  {
-    id: "history-2018-goldenbell",
-    title: "2018년 9월 23일 전국방영 성인 문해 KBS 골든벨 두명 출전 및 전국 2위 배출 (박혁서 교무)",
-    photos: [{ id: "photo-2018-goldenbell", alt: "KBS 골든벨 출전 사진", src: "" }],
-  },
-  {
-    id: "history-2021-radio",
-    title: "2021년 10월 10일 공오일 에프엠 뉴스 201회 깜짝 초대석 소개 이영주 선생님, 김현 선생님 출연 (김우찬 교무)",
-    photos: [{ id: "photo-2021-radio", alt: "공오일 에프엠 뉴스 출연 사진", src: "" }],
-  },
-  {
-    id: "history-2022-mbc",
-    title: "2022년 8월 23일 MBC 라디오 정해웅 교장 출연",
-    detail: "금정열린배움터 '배움에 나이가 있나요'",
-    photos: [{ id: "photo-2022-mbc", alt: "MBC 라디오 출연 사진", src: "" }],
-  },
-  {
-    id: "history-2022-kbs",
-    title: "2022년 10월 13일 KBS 생생투데이 방송 (안기재 교무)",
-    detail: "배움엔 나이가 없다! 공부하는 즐거움이 가득한 금정열린배움터",
-  },
-  {
-    id: "history-2022-poem",
-    title: "2022년 10월 17일 금정열린배움터 출신 학생 시집 출간 (박여진 교무)",
-    detail: "엄마의 꽁단보리밥, 손정화",
-    links: [{ id: "link-2022-poem", label: "관련 자료", href: "#" }],
-  },
-  { id: "history-2022-pnu-news", title: "2022년 11월 10일 채널 PNU 영상뉴스 취재 및 방송" },
-  { id: "history-2022-award", title: "2022년 12월 평생학습 활성화 평생학습도시 조성 표창 수상 (금정구청)" },
-  {
-    id: "history-2023-kbs",
-    title: "2023년 3월 20일 KBS 대담한K 정해웅 교장 출연",
-    detail: "'배움 전하는 야학' 금정열린배움터",
-    photos: [{ id: "photo-2023-kbs", alt: "KBS 대담한K 출연 사진", src: "" }],
-  },
-  {
-    id: "history-2023-forum",
-    title: "2023년 12월 7일 부산대 사회공헌포럼 정해웅 교장 금정열린배움터 소개 강연",
-    links: [{ id: "link-2023-forum", label: "강연 자료", href: "#" }],
-  },
-  {
-    id: "history-2023-song",
-    title: "2023년 12월 18일 금정열린배움터 교가 완성",
-    detail: "곡명 : 정성을 다하여",
-    links: [{ id: "link-2023-song", label: "교가 듣기", href: "#" }],
-  },
-  {
-    id: "history-2024-ktv",
-    title: "2024년 2월 19일 KTV 국민방송 국민 리포트 소개 (배건희 교무)",
-    links: [{ id: "link-2024-ktv", label: "방송 보기", href: "#" }],
-  },
-  { id: "history-2024-tbn", title: "2024년 2월 26일 부산시청자미디어센터 TBN 시민 리포트 소개" },
-  { id: "history-2024-kbs-radio", title: "2024년 5월 30일 KBS 라디오 시사 포커스 정해웅 교장 출연" },
-  {
-    id: "history-2025-song",
-    title: "2025년 1월 10일 교가 편곡 (빠른 ver)",
-    links: [{ id: "link-2025-song", label: "편곡 듣기", href: "#" }],
-  },
-  {
-    id: "history-2025-daedong",
-    title: "2025년 8월 22일 대동대학교와 산학협력 협약",
-    links: [{ id: "link-2025-daedong", label: "협약 자료", href: "#" }],
-  },
-  {
-    id: "history-2025-hackathon",
-    title: "2025년 8월 25일 야학어플개발팀 '손길모아' 창의융합SW해커톤 대상 수상 (부산대학교)",
-  },
-];
-
 const emptyForm: HistoryFormState = {
   title: "",
   detail: "",
@@ -160,15 +68,36 @@ const emptyForm: HistoryFormState = {
   photos: [],
 };
 
-function makeId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.round(Math.random() * 100000)}`;
-}
-
 function normalizeHref(href: string) {
   const trimmed = href.trim();
   if (!trimmed) return "";
   if (/^(https?:\/\/|mailto:|tel:|\/|#)/.test(trimmed)) return trimmed;
   return `https://${trimmed}`;
+}
+
+function mapHistoryItem(item: SiteHistoryResponseDto): HistoryItem | null {
+  if (typeof item.id !== "number" || !item.title) return null;
+  const linkHref = normalizeHref(item.linkHref ?? "");
+
+  return {
+    id: item.id,
+    title: item.title,
+    detail: item.detail || undefined,
+    links: linkHref
+      ? [
+          {
+            id: `link-${item.id}`,
+            label: item.linkLabel ?? "",
+            href: linkHref,
+          },
+        ]
+      : undefined,
+    photos: item.photos?.map((photo, index) => ({
+      id: String(photo.id ?? `${item.id}-${index}`),
+      alt: photo.alt ?? item.title ?? "연혁 사진",
+      src: photo.url ?? "",
+    })),
+  };
 }
 
 function itemToForm(item: HistoryItem): HistoryFormState {
@@ -197,19 +126,46 @@ function readFileAsDataUrl(file: File) {
 }
 
 export default function HistoryPage() {
+  const queryClient = useQueryClient();
   const { status, user } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
-  const [items, setItems] = useState<HistoryItem[]>(initialHistoryItems);
+  const historiesQuery = useQuery({
+    queryKey: queryKeys.siteContent.history(),
+    queryFn: getHistories,
+  });
   const [isEditMode, setIsEditMode] = useState(false);
-  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [editingItemId, setEditingItemId] = useState<number | null>(null);
   const [form, setForm] = useState<HistoryFormState>(emptyForm);
   const [photoFileNames, setPhotoFileNames] = useState<string[]>([]);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
+
+  const items = useMemo(
+    () => historiesQuery.data?.history?.map(mapHistoryItem).filter((item): item is HistoryItem => item !== null) ?? [],
+    [historiesQuery.data],
+  );
 
   const editingItem = useMemo(
     () => items.find((item) => item.id === editingItemId) ?? null,
     [editingItemId, items],
   );
+
+  const refreshHistory = () => queryClient.invalidateQueries({ queryKey: queryKeys.siteContent.history() });
+
+  const createMutation = useMutation({
+    mutationFn: createHistory,
+    onSuccess: refreshHistory,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: Parameters<typeof updateHistory>[1] }) =>
+      updateHistory({ historyId: id }, body),
+    onSuccess: refreshHistory,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteHistory({ historyId: id }),
+    onSuccess: refreshHistory,
+  });
 
   function openCreateEditor() {
     setEditingItemId(null);
@@ -246,11 +202,18 @@ export default function HistoryPage() {
     if (files.length === 0) return;
 
     const nextPhotos = await Promise.all(
-      files.map(async (file) => ({
-        id: makeId("photo"),
-        alt: file.name,
-        src: await readFileAsDataUrl(file),
-      })),
+      files.map(async (file) => {
+        const [previewSrc, uploaded] = await Promise.all([
+          readFileAsDataUrl(file),
+          uploadSiteContentImage(file, file.name),
+        ]);
+
+        return {
+          id: uploaded.fileId ?? `${file.name}-${Date.now()}`,
+          alt: file.name,
+          src: uploaded.url ?? previewSrc,
+        };
+      }),
     );
 
     setPhotoFileNames(files.map((file) => file.name));
@@ -268,41 +231,37 @@ export default function HistoryPage() {
     }));
   }
 
-  function handleDeleteItem() {
+  async function handleDeleteItem() {
     if (!editingItemId) return;
 
-    setItems((current) => current.filter((item) => item.id !== editingItemId));
+    await deleteMutation.mutateAsync(editingItemId);
     closeEditor();
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const title = form.title.trim();
     if (!title) return;
 
     const linkHref = normalizeHref(form.linkHref);
-    const nextItem: HistoryItem = {
-      id: editingItemId ?? makeId("history"),
+    const body = {
       title,
       detail: form.detail.trim() || undefined,
-      links: linkHref
-        ? [
-            {
-              id: editingItem?.links?.[0]?.id ?? makeId("link"),
-              label: form.linkLabel.trim(),
-              href: linkHref,
-            },
-          ]
+      linkLabel: linkHref ? form.linkLabel.trim() : undefined,
+      linkHref: linkHref || undefined,
+      photos: form.photos.length > 0
+        ? form.photos
+            .filter((photo) => photo.src)
+            .map((photo) => ({ url: photo.src, alt: photo.alt || title }))
         : undefined,
-      photos: form.photos.length > 0 ? form.photos.map((photo) => ({ ...photo, alt: photo.alt || title })) : undefined,
     };
 
-    setItems((current) =>
-      editingItemId
-        ? current.map((item) => (item.id === editingItemId ? nextItem : item))
-        : [...current, nextItem],
-    );
+    if (editingItemId) {
+      await updateMutation.mutateAsync({ id: editingItemId, body });
+    } else {
+      await createMutation.mutateAsync(body);
+    }
     closeEditor();
   }
 
@@ -355,8 +314,15 @@ export default function HistoryPage() {
             ) : null}
           </HeaderRow>
 
-          <TimelineList>
-            {items.map((item) => (
+          {historiesQuery.isLoading ? (
+            <EmptyState>연혁 정보를 불러오는 중입니다.</EmptyState>
+          ) : historiesQuery.isError ? (
+            <EmptyState>연혁 정보를 불러오지 못했습니다.</EmptyState>
+          ) : items.length === 0 ? (
+            <EmptyState>등록된 연혁이 없습니다.</EmptyState>
+          ) : (
+            <TimelineList>
+              {items.map((item) => (
               <TimelineItem key={item.id}>
                 <TimelineMarker aria-hidden="true" />
                 <TimelineBody>
@@ -405,8 +371,9 @@ export default function HistoryPage() {
                   ) : null}
                 </TimelineBody>
               </TimelineItem>
-            ))}
-          </TimelineList>
+              ))}
+            </TimelineList>
+          )}
         </Content>
       </Stage>
 
@@ -853,6 +820,17 @@ const DetailText = styled.p`
 
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const EmptyState = styled.p`
+  margin: 0;
+  color: ${colors.placeholder};
+  font-size: ${typography.fontSize16};
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize24};
   }
 `;
 

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -38,6 +38,11 @@ export const queryKeys = {
     purchaseList: () => ["purchase-requests"] as const,
     purchaseDetail: (requestId: number) => ["purchase-request", requestId] as const,
   },
+  siteContent: {
+    history: () => ["site-content", "history"] as const,
+    departments: () => ["site-content", "departments"] as const,
+    classes: () => ["site-content", "classes"] as const,
+  },
   admin: {
     users: (page = 0, size = 20) => ["admin", "users", { page, size }] as const,
     userDetail: (userId: number) => ["admin", "users", "detail", userId] as const,


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

기관 정보 섹션의 연혁, 부서 정보, 반 정보에 대한 CRUD API를 연동하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #102 

## 💬 기타 사항

[추가 보완 사항]

1. 기관의 연혁을 날짜를 기준으로 자동 정렬하여 조회 및 수정할 수 있게 해야 합니다.
2. 관련 링크를 여러 개 등록 가능하게 해야 합니다.

## 📂 참고 자료

> N/A
