### PR TITLE
feat: 결제 신청 플로우 개선 및 관련 API 연동

### DIFF
--- a/api/file/file.dto.ts
+++ b/api/file/file.dto.ts
@@ -4,6 +4,7 @@ export interface FileUploadResponseDto {
   contentType?: string;
   fileSize?: number;
   ext?: string;
+  isGoogleDrive?: boolean;
   url?: string;
 }
 

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -17,8 +17,12 @@ import { setAccessToken } from "../client/tokenStorage";
 
 import {
   approvePurchaseRequest,
+  createPurchaseRequest,
   createLessonExchangeRequest,
   getAbsenceRequests,
+  reportPurchase,
+  updateAdminPurchaseItemReceipts,
+  updatePurchaseItemReceipts,
 } from "./request.api";
 
 describe("request.api", () => {
@@ -115,6 +119,155 @@ describe("request.api", () => {
     expect(response.status).toBe("APPROVED");
     expect(observedPathname).toBe("/api/v1/admin/purchase-requests/4/approve");
     expect(observedBody).toEqual({ note: "승인합니다." });
+  });
+
+  it("creates a purchase request with payment type and without expected price", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/purchase-requests`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ id: 21, status: "PENDING" });
+      }),
+    );
+
+    await createPurchaseRequest({
+      title: "교재 결제 신청",
+      content: "신청자: 홍길동",
+      classroomId: 1,
+      items: [
+        {
+          name: "국어 교재",
+          quantity: 3,
+          reason: "수업 교재",
+          paymentType: "PREPAID",
+        },
+      ],
+    });
+
+    expect(observedBody).toEqual({
+      title: "교재 결제 신청",
+      content: "신청자: 홍길동",
+      classroomId: 1,
+      items: [
+        {
+          name: "국어 교재",
+          quantity: 3,
+          reason: "수업 교재",
+          paymentType: "PREPAID",
+        },
+      ],
+    });
+  });
+
+  it("reports purchase completion with vendor, item names, amount, and optional receipt ids", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/purchase-requests/4/report`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ id: 4, status: "PURCHASED" });
+      }),
+    );
+
+    await reportPurchase(
+      { requestId: 4 },
+      {
+        transactions: [
+          {
+            vendorId: 2,
+            itemNames: ["국어 교재", "수학 교재"],
+            amount: 45000,
+            receiptFileId: "11111111-1111-1111-1111-111111111111",
+          },
+        ],
+      },
+    );
+
+    expect(observedBody).toEqual({
+      transactions: [
+        {
+          vendorId: 2,
+          itemNames: ["국어 교재", "수학 교재"],
+          amount: 45000,
+          receiptFileId: "11111111-1111-1111-1111-111111111111",
+        },
+      ],
+    });
+  });
+
+  it("updates purchase item receipts through the requester endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+    let observedBody: unknown;
+
+    server.use(
+      http.post(
+        `${API_BASE_URL}/api/v1/purchase-requests/4/item-receipts`,
+        async ({ request }) => {
+          observedPathname = new URL(request.url).pathname;
+          observedBody = await request.json();
+          return HttpResponse.json({ id: 4, status: "PURCHASED" });
+        },
+      ),
+    );
+
+    await updatePurchaseItemReceipts(
+      { requestId: 4 },
+      {
+        transactions: [
+          {
+            vendorId: 2,
+            itemNames: ["국어 교재"],
+            amount: 15000,
+          },
+        ],
+      },
+    );
+
+    expect(observedPathname).toBe("/api/v1/purchase-requests/4/item-receipts");
+    expect(observedBody).toEqual({
+      transactions: [
+        {
+          vendorId: 2,
+          itemNames: ["국어 교재"],
+          amount: 15000,
+        },
+      ],
+    });
+  });
+
+  it("updates purchase item receipts through the admin endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+
+    server.use(
+      http.patch(`${API_BASE_URL}/api/v1/admin/purchase-requests/4/item-receipts`, ({ request }) => {
+        observedPathname = new URL(request.url).pathname;
+        return HttpResponse.json({ id: 4, status: "PURCHASED" });
+      }),
+    );
+
+    await updateAdminPurchaseItemReceipts(
+      { requestId: 4 },
+      {
+        transactions: [
+          {
+            vendorId: 2,
+            itemNames: ["국어 교재"],
+            amount: 15000,
+          },
+        ],
+      },
+    );
+
+    expect(observedPathname).toBe("/api/v1/admin/purchase-requests/4/item-receipts");
   });
 
   it("throws when purchase approval fails", async () => {

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -101,14 +101,11 @@ export async function createPurchaseRequest(body: CreatePurchaseRequestDto) {
     title: body.title,
     content: body.content,
     classroomId: body.classroomId,
-    ...(typeof body.advancePaymentRequestedAmount === "number"
-      ? { advancePaymentRequestedAmount: body.advancePaymentRequestedAmount }
-      : {}),
-    ...(body.receiptFileIds?.length ? { receiptFileIds: body.receiptFileIds } : {}),
     items: body.items.map((item) => ({
       name: item.name,
+      quantity: item.quantity,
       ...(item.reason ? { reason: item.reason } : {}),
-      ...(typeof item.expectedPrice === "number" ? { expectedPrice: item.expectedPrice } : {}),
+      paymentType: item.paymentType,
     })),
   };
 
@@ -219,6 +216,30 @@ export async function reportPurchase(
 ) {
   const response = await authClient.post<PurchaseRequestResponseDto>(
     `/api/v1/purchase-requests/${pathParams.requestId}/report`,
+    body,
+  );
+  return response.data;
+}
+
+// 구매 완료 거래를 수정하는 요청
+export async function updatePurchaseItemReceipts(
+  pathParams: RequestPathParamsDto,
+  body: ReportPurchaseRequestDto,
+) {
+  const response = await authClient.post<PurchaseRequestResponseDto>(
+    `/api/v1/purchase-requests/${pathParams.requestId}/item-receipts`,
+    body,
+  );
+  return response.data;
+}
+
+// 관리자 기준 구매 완료 거래를 수정하는 요청
+export async function updateAdminPurchaseItemReceipts(
+  pathParams: RequestPathParamsDto,
+  body: ReportPurchaseRequestDto,
+) {
+  const response = await authClient.patch<PurchaseRequestResponseDto>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/item-receipts`,
     body,
   );
   return response.data;

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -6,6 +6,7 @@ export type PurchaseRequestStatus =
   | "PURCHASED"
   | "CONFIRMED"
   | "REJECTED";
+export type PaymentType = "PREPAID" | "ACTUAL";
 
 export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
@@ -66,30 +67,29 @@ export interface CreatePurchaseRequestDto {
   title: string;
   content: string;
   classroomId: number;
-  advancePaymentRequestedAmount?: number;
-  receiptFileIds?: string[];
   items: PurchaseRequestItemDto[];
 }
 
 export interface PurchaseRequestItemDto {
   name: string;
+  quantity: number;
   reason?: string;
-  expectedPrice?: number;
+  paymentType: PaymentType;
 }
 
-export interface PurchaseRequestItemReportDto {
-  itemId: number;
-  price: number;
+export interface PurchaseTransactionReportDto {
+  vendorId: number;
+  itemNames: string[];
+  amount: number;
+  receiptFileId?: string;
 }
 
 export interface ReportPurchaseRequestDto {
-  items: PurchaseRequestItemReportDto[];
-  receiptFileIds?: string[];
+  transactions: PurchaseTransactionReportDto[];
 }
 
 export interface ReviewPurchaseRequestDto {
   note: string;
-  advancePaymentApprovedAmount?: number;
 }
 
 export interface RequestReconfirmationResponseDto {
@@ -99,19 +99,19 @@ export interface RequestReconfirmationResponseDto {
 export interface PurchaseRequestItemResponseDto {
   id?: number;
   name?: string;
+  quantity?: number;
   reason?: string;
-  expectedPrice?: number;
-  actualPrice?: number;
+  paymentType?: PaymentType;
 }
 
-export interface PurchaseRequestReceiptResponseDto {
+export interface PurchaseTransactionResponseDto {
   id?: number;
-  fileId?: string;
-  fileName?: string;
-  originalName?: string;
-  ext?: string;
-  fileUrl?: string;
-  url?: string;
+  vendorId?: number;
+  vendorName?: string;
+  itemNames?: string[];
+  amount?: number;
+  receiptFileId?: string;
+  receiptFileUrl?: string;
 }
 
 export interface PurchaseRequestSummaryResponseDto {
@@ -120,8 +120,6 @@ export interface PurchaseRequestSummaryResponseDto {
   requestedByName?: string;
   title?: string;
   totalPrice?: number;
-  advancePaymentRequestedAmount?: number;
-  advancePaymentApprovedAmount?: number;
   status?: PurchaseRequestStatus;
   createdAt?: string;
 }
@@ -130,12 +128,18 @@ export interface PurchaseRequestResponseDto extends PurchaseRequestSummaryRespon
   classroomId?: number;
   requestedById?: number;
   content?: string;
+  vendorName?: string;
+  vendorBalances?: {
+    vendorId?: number;
+    vendorName?: string;
+    balance?: number;
+  }[];
   approvalAt?: string;
   approvalByName?: string;
   purchasedAt?: string;
   note?: string;
   items?: PurchaseRequestItemResponseDto[];
-  receipts?: PurchaseRequestReceiptResponseDto[];
+  transactions?: PurchaseTransactionResponseDto[];
 }
 
 export type PurchaseRequestListItemDto = PurchaseRequestResponseDto;

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -66,7 +66,11 @@ import {
   getAllPurchaseRequests,
   rejectAdminPurchaseRequest,
 } from "@/api/request/request.api";
-import type { PurchaseRequestStatus } from "@/api/request/request.dto";
+import type {
+  PurchaseRequestResponseDto,
+  PurchaseRequestStatus,
+  PurchaseTransactionResponseDto,
+} from "@/api/request/request.dto";
 import {
   addUserPermission,
   createUser,
@@ -79,6 +83,8 @@ import {
   updateUser,
 } from "@/api/user/user.api";
 import type { PermissionDefinitionDto } from "@/api/user/user.dto";
+import { chargeVendor, getVendors } from "@/api/vendor/vendor.api";
+import type { VendorResponseDto } from "@/api/vendor/vendor.dto";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
@@ -208,10 +214,10 @@ const emptyPurchaseCreate: PurchaseCreateState = {
   title: "",
   content: "",
   classroomId: "",
-  advancePaymentRequestedAmount: "",
   itemName: "",
+  itemQuantity: "1",
   itemReason: "",
-  itemExpectedPrice: "",
+  itemPaymentType: "ACTUAL",
 };
 
 const emptyPermissionForm: PermissionFormState = {
@@ -302,6 +308,45 @@ function mapPostToEditState(post?: {
   };
 }
 
+function findPurchaseItemForTransaction(
+  transaction: PurchaseTransactionResponseDto,
+  purchase?: PurchaseRequestResponseDto,
+) {
+  return purchase?.items?.find((item) => {
+    if (!item.name) {
+      return false;
+    }
+
+    return transaction.itemNames?.some((name) => name.trim() === item.name);
+  });
+}
+
+function getPrepaidTransactions(purchase?: PurchaseRequestResponseDto) {
+  return (purchase?.transactions ?? []).filter((transaction) => {
+    const item = findPurchaseItemForTransaction(transaction, purchase);
+    return item?.paymentType === "PREPAID";
+  });
+}
+
+function applyVendorChargeToCache(
+  vendors: VendorResponseDto[] | undefined,
+  vendorId: number,
+  amount: number,
+) {
+  return vendors?.map((vendor) =>
+    vendor.id === vendorId
+      ? {
+          ...vendor,
+          balance: (vendor.balance ?? 0) + amount,
+        }
+      : vendor,
+  );
+}
+
+function getVendorBalance(vendors: VendorResponseDto[] | undefined, vendorId: number) {
+  return vendors?.find((vendor) => vendor.id === vendorId)?.balance ?? 0;
+}
+
 export default function AdminDashboardPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -331,7 +376,6 @@ export default function AdminDashboardPage() {
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
   const [reviewNote, setReviewNote] = useState("");
-  const [approvedAmount, setApprovedAmount] = useState("");
 
   useEffect(() => {
     if (status === "unauthenticated" || (status === "authenticated" && user?.role !== "ADMIN")) {
@@ -821,18 +865,12 @@ export default function AdminDashboardPage() {
         title: purchaseCreate.title.trim(),
         content: purchaseCreate.content.trim(),
         classroomId: toNumber(purchaseCreate.classroomId) ?? 0,
-        ...(purchaseCreate.advancePaymentRequestedAmount
-          ? {
-              advancePaymentRequestedAmount: toNumber(purchaseCreate.advancePaymentRequestedAmount),
-            }
-          : {}),
         items: [
           {
             name: purchaseCreate.itemName.trim(),
+            quantity: Math.max(1, Math.trunc(toNumber(purchaseCreate.itemQuantity) ?? 1)),
             reason: purchaseCreate.itemReason.trim() || undefined,
-            ...(purchaseCreate.itemExpectedPrice
-              ? { expectedPrice: toNumber(purchaseCreate.itemExpectedPrice) }
-              : {}),
+            paymentType: purchaseCreate.itemPaymentType,
           },
         ],
       }),
@@ -849,8 +887,7 @@ export default function AdminDashboardPage() {
       approveAdminPurchaseRequest(
         { requestId: selectedPurchaseId ?? 0 },
         {
-          note: reviewNote || "승인합니다.",
-          ...(approvedAmount ? { advancePaymentApprovedAmount: toNumber(approvedAmount) } : {}),
+          note: reviewNote.trim() || "승인합니다.",
         },
       ),
     onSuccess: () => {
@@ -863,7 +900,7 @@ export default function AdminDashboardPage() {
     mutationFn: () =>
       rejectAdminPurchaseRequest(
         { requestId: selectedPurchaseId ?? 0 },
-        { note: reviewNote || "반려합니다." },
+        { note: reviewNote.trim() || "반려합니다." },
       ),
     onSuccess: () => {
       notifySuccess("구매 요청을 반려했습니다.");
@@ -872,10 +909,85 @@ export default function AdminDashboardPage() {
     onError: (error) => notifyError(getErrorMessage(error, "구매 요청 반려에 실패했습니다.")),
   });
   const confirmPurchaseMutation = useMutation({
-    mutationFn: () => confirmPurchase({ requestId: selectedPurchaseId ?? 0 }),
+    mutationFn: async () => {
+      const purchase = purchaseDetailQuery.data;
+      const prepaidTransactions = getPrepaidTransactions(purchase).filter(
+        (transaction) =>
+          typeof transaction.vendorId === "number" &&
+          typeof transaction.amount === "number" &&
+          transaction.amount > 0,
+      );
+      const prepaidTargetBalances = new Map<number, number>();
+
+      if (prepaidTransactions.length > 0) {
+        await Promise.all(
+          prepaidTransactions.map(async (transaction) => {
+            const vendorId = transaction.vendorId as number;
+            const amount = transaction.amount as number;
+            const chargedVendor = await chargeVendor(
+              { vendorId: transaction.vendorId as number },
+              {
+                amount: transaction.amount as number,
+                memo: `${purchase?.title ?? "구매 요청"} 선금 결제 충전`,
+                ...(transaction.receiptFileId
+                  ? { receiptFileId: transaction.receiptFileId }
+                  : {}),
+              },
+            );
+            prepaidTargetBalances.set(vendorId, chargedVendor.balance ?? 0);
+
+            queryClient.setQueryData<VendorResponseDto[] | undefined>(
+              queryKeys.vendors.list(),
+              (current) =>
+                current?.some((vendor) => vendor.id === chargedVendor.id)
+                  ? current.map((vendor) =>
+                      vendor.id === chargedVendor.id ? { ...vendor, ...chargedVendor } : vendor,
+                    )
+                  : applyVendorChargeToCache(current, vendorId, amount),
+            );
+          }),
+        );
+      }
+
+      const confirmedPurchase = await confirmPurchase({ requestId: selectedPurchaseId ?? 0 });
+
+      if (prepaidTargetBalances.size > 0) {
+        const vendorsAfterConfirm = await getVendors();
+
+        await Promise.all(
+          Array.from(prepaidTargetBalances.entries()).map(async ([vendorId, targetBalance]) => {
+            const currentBalance = getVendorBalance(vendorsAfterConfirm, vendorId);
+            const compensationAmount = targetBalance - currentBalance;
+
+            if (compensationAmount <= 0) {
+              return null;
+            }
+
+            return chargeVendor(
+              { vendorId },
+              {
+                amount: compensationAmount,
+                memo: `${purchase?.title ?? "구매 요청"} 선금 결제 잔액 보정`,
+              },
+            );
+          }),
+        );
+
+        const refreshedVendors = await getVendors();
+        queryClient.setQueryData(queryKeys.vendors.list(), refreshedVendors);
+      }
+
+      return confirmedPurchase;
+    },
     onSuccess: () => {
       notifySuccess("구매 요청을 결재 확인했습니다.");
       invalidateDashboard();
+      queryClient.invalidateQueries({ queryKey: queryKeys.vendors.list() });
+      if (selectedPurchaseId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.purchaseRequestDetail(selectedPurchaseId),
+        });
+      }
     },
     onError: (error) => notifyError(getErrorMessage(error, "결재 확인에 실패했습니다.")),
   });
@@ -1087,7 +1199,6 @@ export default function AdminDashboardPage() {
               purchaseStatus={purchaseStatus}
               purchaseCreate={purchaseCreate}
               reviewNote={reviewNote}
-              approvedAmount={approvedAmount}
               purchasesQuery={purchasesQuery}
               purchaseDetailQuery={purchaseDetailQuery}
               createPurchaseMutation={createPurchaseMutation}
@@ -1099,7 +1210,6 @@ export default function AdminDashboardPage() {
               setPurchaseCreate={setPurchaseCreate}
               setSelectedPurchaseId={setSelectedPurchaseId}
               setReviewNote={setReviewNote}
-              setApprovedAmount={setApprovedAmount}
             />
           ) : null}
           <ToastContainer position="top-right" autoClose={2400} newestOnTop pauseOnHover />

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -69,10 +69,10 @@ export type PurchaseCreateState = {
   title: string;
   content: string;
   classroomId: string;
-  advancePaymentRequestedAmount: string;
   itemName: string;
+  itemQuantity: string;
   itemReason: string;
-  itemExpectedPrice: string;
+  itemPaymentType: "PREPAID" | "ACTUAL";
 };
 
 export type PermissionFormState = {

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
+import styled from "styled-components";
 import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
 import type {
   PurchaseRequestListItemDto,
@@ -30,6 +31,7 @@ import {
   TextInput,
   TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, spacing } from "@/styles/tokens";
 
 type QueryState<TData> = {
   data?: TData;
@@ -49,7 +51,6 @@ type AdminPurchasesSectionProps = {
   purchaseStatus: PurchaseRequestStatus | "";
   purchaseCreate: PurchaseCreateState;
   reviewNote: string;
-  approvedAmount: string;
   purchasesQuery: QueryState<unknown>;
   purchaseDetailQuery: QueryState<PurchaseRequestResponseDto>;
   createPurchaseMutation: VoidMutationAction;
@@ -61,7 +62,6 @@ type AdminPurchasesSectionProps = {
   setPurchaseCreate: Dispatch<SetStateAction<PurchaseCreateState>>;
   setSelectedPurchaseId: Dispatch<SetStateAction<number | null>>;
   setReviewNote: Dispatch<SetStateAction<string>>;
-  setApprovedAmount: Dispatch<SetStateAction<string>>;
 };
 
 export function AdminPurchasesSection({
@@ -71,7 +71,6 @@ export function AdminPurchasesSection({
   purchaseStatus,
   purchaseCreate,
   reviewNote,
-  approvedAmount,
   purchasesQuery,
   purchaseDetailQuery,
   createPurchaseMutation,
@@ -83,8 +82,51 @@ export function AdminPurchasesSection({
   setPurchaseCreate,
   setSelectedPurchaseId,
   setReviewNote,
-  setApprovedAmount,
 }: AdminPurchasesSectionProps) {
+  const [rejectTargetId, setRejectTargetId] = useState<number | null>(null);
+  const selectedStatus = purchaseDetailQuery.data?.status;
+  const canReviewPurchase = selectedStatus === "PENDING";
+  const canConfirmPurchase = selectedStatus === "PURCHASED";
+  const canDeletePurchase = selectedStatus === "PENDING";
+  const isRejecting = rejectTargetId === selectedPurchaseId && canReviewPurchase;
+  const canSubmitRejection =
+    isRejecting && reviewNote.trim().length > 0 && !rejectPurchaseMutation.isPending;
+  const canShowReceiptRows = selectedStatus === "PURCHASED" || selectedStatus === "CONFIRMED";
+  const receiptRows =
+    purchaseDetailQuery.data?.transactions?.map((transaction, index) => ({
+      id: transaction.id ?? index,
+      label: transaction.itemNames?.join(", ") || "영수증",
+      url: transaction.receiptFileUrl,
+    })) ?? [];
+
+  function approvePurchase() {
+    setReviewNote("");
+    approvePurchaseMutation.mutate();
+  }
+
+  function startRejecting() {
+    if (!selectedPurchaseId || !canReviewPurchase) {
+      return;
+    }
+
+    setReviewNote("");
+    setRejectTargetId(selectedPurchaseId);
+  }
+
+  function cancelRejecting() {
+    setReviewNote("");
+    setRejectTargetId(null);
+  }
+
+  function submitRejection() {
+    if (!canSubmitRejection) {
+      return;
+    }
+
+    rejectPurchaseMutation.mutate();
+    setRejectTargetId(null);
+  }
+
   return (
     <>
       <SectionCard>
@@ -133,23 +175,27 @@ export function AdminPurchasesSection({
             </Select>
           </Label>
           <Label>
-            선금 요청 금액
-            <TextInput
-              value={purchaseCreate.advancePaymentRequestedAmount}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({
-                  ...current,
-                  advancePaymentRequestedAmount: event.target.value,
-                }))
-              }
-            />
-          </Label>
-          <Label>
             품목명
             <TextInput
               value={purchaseCreate.itemName}
               onChange={(event) =>
                 setPurchaseCreate((current) => ({ ...current, itemName: event.target.value }))
+              }
+              required
+            />
+          </Label>
+          <Label>
+            수량
+            <TextInput
+              type="number"
+              min="1"
+              step="1"
+              value={purchaseCreate.itemQuantity}
+              onChange={(event) =>
+                setPurchaseCreate((current) => ({
+                  ...current,
+                  itemQuantity: event.target.value,
+                }))
               }
               required
             />
@@ -164,16 +210,19 @@ export function AdminPurchasesSection({
             />
           </Label>
           <Label>
-            예상 금액
-            <TextInput
-              value={purchaseCreate.itemExpectedPrice}
+            결제 유형
+            <Select
+              value={purchaseCreate.itemPaymentType}
               onChange={(event) =>
                 setPurchaseCreate((current) => ({
                   ...current,
-                  itemExpectedPrice: event.target.value,
+                  itemPaymentType: event.target.value as PurchaseCreateState["itemPaymentType"],
                 }))
               }
-            />
+            >
+              <option value="ACTUAL">실 결제</option>
+              <option value="PREPAID">선금 결제</option>
+            </Select>
           </Label>
           <PrimaryButton disabled={createPurchaseMutation.isPending || !purchaseCreate.classroomId}>
             구매 요청 작성
@@ -223,7 +272,13 @@ export function AdminPurchasesSection({
                     <td>{item.classroomName}</td>
                     <td>{item.requestedByName}</td>
                     <td>{item.status}</td>
-                    <td>{item.advancePaymentRequestedAmount ?? item.totalPrice ?? 0}</td>
+                    <td>
+                      {item.status === "PENDING" ||
+                      item.status === "REJECTED" ||
+                      item.status === "APPROVED"
+                        ? "-"
+                        : (item.totalPrice ?? 0)}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -253,60 +308,100 @@ export function AdminPurchasesSection({
               {purchaseDetailQuery.data?.items?.map((item) => (
                 <ListItem key={item.id}>
                   <span>{item.name}</span>
-                  <span>{item.expectedPrice ?? item.actualPrice ?? 0}원</span>
+                  <span>
+                    {item.quantity ?? 0}개 /{" "}
+                    {item.paymentType === "PREPAID" ? "선금 결제" : "실 결제"}
+                  </span>
                 </ListItem>
               ))}
+              {canShowReceiptRows && receiptRows.length
+                ? receiptRows.map((receipt) => (
+                    <ListItem key={`receipt-${receipt.id}`}>
+                      <span>영수증</span>
+                      <span>
+                        {receipt.url ? (
+                          <ReceiptLink href={receipt.url} target="_blank" rel="noreferrer">
+                            영수증 보기
+                          </ReceiptLink>
+                        ) : (
+                          "-"
+                        )}
+                      </span>
+                    </ListItem>
+                  ))
+                : null}
+              {canShowReceiptRows && receiptRows.length === 0 ? (
+                <ListItem>
+                  <span>영수증</span>
+                  <span>-</span>
+                </ListItem>
+              ) : null}
             </List>
             {purchaseDetailQuery.data?.status === "REJECTED" ? (
               <SectionDescription>
-                거절 사유: {purchaseDetailQuery.data.note?.trim() || "-"}
+                반려 사유: {purchaseDetailQuery.data.note?.trim() || "-"}
               </SectionDescription>
             ) : null}
             <FormGrid onSubmit={(event) => event.preventDefault()}>
-              <Label>
-                처리 사유
-                <TextInput
-                  value={reviewNote}
-                  onChange={(event) => setReviewNote(event.target.value)}
-                />
-              </Label>
-              <Label>
-                승인 선금
-                <TextInput
-                  value={approvedAmount}
-                  onChange={(event) => setApprovedAmount(event.target.value)}
-                />
-              </Label>
-              <ButtonRow>
-                <PrimaryButton
-                  type="button"
-                  disabled={approvePurchaseMutation.isPending}
-                  onClick={() => approvePurchaseMutation.mutate()}
-                >
-                  승인
-                </PrimaryButton>
-                <DangerButton
-                  type="button"
-                  disabled={rejectPurchaseMutation.isPending}
-                  onClick={() => rejectPurchaseMutation.mutate()}
-                >
-                  반려
-                </DangerButton>
-                <SmallButton
-                  type="button"
-                  disabled={confirmPurchaseMutation.isPending}
-                  onClick={() => confirmPurchaseMutation.mutate()}
-                >
-                  결재 확인
-                </SmallButton>
-                <DangerButton
-                  type="button"
-                  disabled={deletePurchaseMutation.isPending}
-                  onClick={() => deletePurchaseMutation.mutate()}
-                >
-                  삭제
-                </DangerButton>
-              </ButtonRow>
+              {isRejecting ? (
+                <>
+                  <Label>
+                    반려 사유
+                    <TextInput
+                      value={reviewNote}
+                      onChange={(event) => setReviewNote(event.target.value)}
+                      autoFocus
+                    />
+                  </Label>
+                  <ButtonRow>
+                    <DangerButton
+                      type="button"
+                      disabled={!canSubmitRejection}
+                      onClick={submitRejection}
+                    >
+                      확인
+                    </DangerButton>
+                    <SmallButton
+                      type="button"
+                      disabled={rejectPurchaseMutation.isPending}
+                      onClick={cancelRejecting}
+                    >
+                      취소
+                    </SmallButton>
+                  </ButtonRow>
+                </>
+              ) : (
+                <ButtonRow>
+                  <ApproveButton
+                    type="button"
+                    disabled={!canReviewPurchase || approvePurchaseMutation.isPending}
+                    onClick={approvePurchase}
+                  >
+                    승인
+                  </ApproveButton>
+                  <DangerButton
+                    type="button"
+                    disabled={!canReviewPurchase || rejectPurchaseMutation.isPending}
+                    onClick={startRejecting}
+                  >
+                    반려
+                  </DangerButton>
+                  <SmallButton
+                    type="button"
+                    disabled={!canConfirmPurchase || confirmPurchaseMutation.isPending}
+                    onClick={() => confirmPurchaseMutation.mutate()}
+                  >
+                    결재 확인
+                  </SmallButton>
+                  <DangerButton
+                    type="button"
+                    disabled={!canDeletePurchase || deletePurchaseMutation.isPending}
+                    onClick={() => deletePurchaseMutation.mutate()}
+                  >
+                    삭제
+                  </DangerButton>
+                </ButtonRow>
+              )}
             </FormGrid>
           </DataState>
         </SectionCard>
@@ -314,3 +409,36 @@ export function AdminPurchasesSection({
     </>
   );
 }
+
+const ApproveButton = styled.button`
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+`;
+
+const ReceiptLink = styled.a`
+  color: ${colors.point};
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+`;

--- a/components/staff/finance-management/FinanceRequestCreatePage.tsx
+++ b/components/staff/finance-management/FinanceRequestCreatePage.tsx
@@ -7,12 +7,13 @@ import styled from "styled-components";
 import { getClassrooms } from "@/api/classroom/classroom.api";
 import { createPurchaseRequest } from "@/api/request/request.api";
 import type { CreatePurchaseRequestDto } from "@/api/request/request.dto";
+import { getVendors } from "@/api/vendor/vendor.api";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-const vendorNames = ["예소디자인", "목민서관", "지성문구", "마트임"] as const;
+const fallbackVendorNames = ["예소디자인", "목민서관", "지성문구", "마트"] as const;
 
 type FinanceItemForm = {
   id: number;
@@ -43,8 +44,23 @@ export default function FinanceRequestCreatePage() {
     queryFn: () => getClassrooms({ page: 0, size: 100 }),
     retry: false,
   });
+  const { data: vendorData } = useQuery({
+    queryKey: queryKeys.vendors.list(),
+    queryFn: () => getVendors(),
+    retry: false,
+  });
 
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
+  const vendorBalances = useMemo(
+    () =>
+      vendorData?.length
+        ? vendorData.map((vendor) => ({
+            name: vendor.name ?? "-",
+            balance: vendor.balance,
+          }))
+        : fallbackVendorNames.map((name) => ({ name, balance: undefined })),
+    [vendorData],
+  );
 
   const mutation = useMutation({
     mutationFn: (body: CreatePurchaseRequestDto) => createPurchaseRequest(body),
@@ -121,7 +137,7 @@ export default function FinanceRequestCreatePage() {
       .map((item, index) => {
         const reason = item.reason ? ` - ${item.reason}` : "";
         const quantity = typeof item.quantity === "number" ? ` ${item.quantity}개` : "";
-        const paymentType = item.paymentType === "PREPAID" ? "선 결제" : "실 결제";
+        const paymentType = item.paymentType === "PREPAID" ? "선금 결제" : "실 결제";
 
         return `${index + 1}. ${item.name}${quantity} / ${paymentType}${reason}`;
       })
@@ -133,7 +149,9 @@ export default function FinanceRequestCreatePage() {
       classroomId: Number(classroomId),
       items: normalizedItems.map((item) => ({
         name: item.name,
+        quantity: item.quantity ?? 1,
         reason: item.reason,
+        paymentType: item.paymentType,
       })),
     });
   }
@@ -191,10 +209,14 @@ export default function FinanceRequestCreatePage() {
               <SectionTitle>현재 거래처별 잔액</SectionTitle>
               <VendorBalanceTable>
                 <tbody>
-                  {vendorNames.map((vendorName) => (
-                    <tr key={vendorName}>
-                      <th scope="row">{vendorName}</th>
-                      <td>-</td>
+                  {vendorBalances.map((vendor) => (
+                    <tr key={vendor.name}>
+                      <th scope="row">{vendor.name}</th>
+                      <td>
+                        {typeof vendor.balance === "number"
+                          ? `${vendor.balance.toLocaleString()}원`
+                          : "-"}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -256,7 +278,7 @@ export default function FinanceRequestCreatePage() {
                               }
                             }}
                           />
-                          <span>선 결제</span>
+                          <span>선금 결제</span>
                         </PaymentTypeOption>
                         <PaymentTypeOption>
                           <input

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ChangeEvent, FormEvent, useEffect, useState } from "react";
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
 import { IconDownload, IconFilePlus } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -11,16 +11,18 @@ import {
   deletePurchaseRequest,
   getPurchaseRequestDetail,
   reportPurchase,
+  updateAdminPurchaseItemReceipts,
+  updatePurchaseItemReceipts,
 } from "@/api/request/request.api";
 import type {
   PurchaseRequestItemResponseDto,
   PurchaseRequestResponseDto,
   PurchaseRequestStatus,
 } from "@/api/request/request.dto";
+import { getVendors } from "@/api/vendor/vendor.api";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
-import { financeReceiptToGoogleDrive } from "@/lib/googleDrive/financeReceiptToGoogleDrive";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -31,24 +33,16 @@ type FinanceRequestDetailPageProps = {
 type PaymentType = "PREPAID" | "ACTUAL";
 
 type VendorBalance = {
+  vendorId?: number;
   vendorName?: string;
   balance?: number;
-  totalAmount?: number;
 };
 
-type ExtendedPurchaseItem = PurchaseRequestItemResponseDto & {
-  quantity?: number;
-  paymentType?: PaymentType;
-  vendorName?: string;
-  purchaseDate?: string;
-};
+type ExtendedPurchaseItem = PurchaseRequestItemResponseDto;
 
-type ExtendedPurchaseRequest = PurchaseRequestResponseDto & {
-  vendorName?: string;
-  vendorBalances?: VendorBalance[];
-};
+type ExtendedPurchaseRequest = PurchaseRequestResponseDto;
 
-const vendorNames = ["예소디자인", "목민서관", "지성문구", "마트"] as const;
+const fallbackVendorNames = ["예소디자인", "목민서관", "지성문구", "마트"] as const;
 
 type EditableItem = {
   id: number;
@@ -56,6 +50,18 @@ type EditableItem = {
   quantity: string;
   reason: string;
   paymentType: PaymentType;
+};
+
+type ReportItem = {
+  itemId: number;
+  vendorId: string;
+  vendorName: string;
+  name: string;
+  price: string;
+  receiptFile: File | null;
+  receiptFileName: string;
+  receiptFileId?: string;
+  receiptFileUrl?: string;
 };
 
 const statusLabels: Record<PurchaseRequestStatus, string> = {
@@ -71,7 +77,7 @@ function getStatusLabel(status?: PurchaseRequestStatus) {
 }
 
 function getPaymentTypeLabel(paymentType?: PaymentType) {
-  if (paymentType === "PREPAID") return "선 결제";
+  if (paymentType === "PREPAID") return "선금 결제";
   if (paymentType === "ACTUAL") return "실 결제";
   return "-";
 }
@@ -101,18 +107,81 @@ function getReceiptName(receipt: {
   originalName?: string;
   ext?: string;
   fileId?: string;
+  receiptFileId?: string;
 }) {
   if (receipt.fileName) {
     return receipt.fileName;
   }
 
   if (!receipt.originalName) {
-    return receipt.fileId ?? "영수증";
+    return receipt.fileId ?? receipt.receiptFileId ?? "영수증";
   }
 
   return receipt.ext && !receipt.originalName.endsWith(`.${receipt.ext}`)
     ? `${receipt.originalName}.${receipt.ext}`
     : receipt.originalName;
+}
+
+function mapPurchaseItemsToEditableItems(items?: PurchaseRequestItemResponseDto[]) {
+  return (items ?? []).map((item, index) => {
+    const extendedItem = item as ExtendedPurchaseItem;
+
+    return {
+      id: item.id ?? index + 1,
+      name: item.name ?? "",
+      quantity: typeof extendedItem.quantity === "number" ? String(extendedItem.quantity) : "1",
+      reason: item.reason ?? "",
+      paymentType: extendedItem.paymentType ?? "ACTUAL",
+    };
+  });
+}
+
+function mapPurchaseItemsToReportItems(purchase?: ExtendedPurchaseRequest): ReportItem[] {
+  if (purchase?.transactions?.length) {
+    return purchase.transactions.map((transaction, index) => {
+      const item = findPurchaseItemForTransaction(transaction.itemNames, purchase.items);
+
+      return {
+        itemId: transaction.id ?? item?.id ?? index + 1,
+        vendorId: typeof transaction.vendorId === "number" ? String(transaction.vendorId) : "",
+        vendorName: transaction.vendorName ?? "",
+        name: transaction.itemNames?.join(", ") || item?.name || "",
+        price: typeof transaction.amount === "number" ? String(transaction.amount) : "0",
+        receiptFile: null,
+        receiptFileName:
+          transaction.receiptFileId || transaction.receiptFileUrl
+            ? getReceiptName({ receiptFileId: transaction.receiptFileId })
+            : "",
+        receiptFileId: transaction.receiptFileId,
+        receiptFileUrl: transaction.receiptFileUrl,
+      };
+    });
+  }
+
+  return (purchase?.items ?? [])
+    .filter((item) => typeof item.id === "number")
+    .map((item) => ({
+      itemId: item.id ?? 0,
+      vendorId: "",
+      vendorName: purchase?.vendorName ?? "",
+      name: item.name ?? "",
+      price: "0",
+      receiptFile: null,
+      receiptFileName: "",
+    }));
+}
+
+function findPurchaseItemForTransaction(
+  transactionItemNames?: string[],
+  items?: PurchaseRequestItemResponseDto[],
+) {
+  return items?.find((item) => {
+    if (!item.name) {
+      return false;
+    }
+
+    return transactionItemNames?.some((name) => name.trim() === item.name);
+  });
 }
 
 export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDetailPageProps) {
@@ -123,17 +192,8 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const [editTitle, setEditTitle] = useState("");
   const [editClassroomName, setEditClassroomName] = useState("");
   const [editItems, setEditItems] = useState<EditableItem[]>([]);
-  const [reportItems, setReportItems] = useState<
-    {
-      itemId: number;
-      vendorName: string;
-      name: string;
-      price: string;
-      purchaseDate: string;
-      receiptFile: File | null;
-      receiptFileName: string;
-    }[]
-  >([]);
+  const [reportItems, setReportItems] = useState<ReportItem[]>([]);
+  const [isReportEditing, setIsReportEditing] = useState(false);
   const {
     data: request,
     isLoading,
@@ -142,6 +202,13 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     queryKey: queryKeys.requests.purchaseDetail(requestId),
     queryFn: () => getPurchaseRequestDetail({ requestId }),
     retry: false,
+  });
+  const { data: vendorData } = useQuery({
+    queryKey: queryKeys.vendors.list(),
+    queryFn: () => getVendors(),
+    retry: false,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
   });
 
   const deleteMutation = useMutation({
@@ -153,137 +220,142 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     },
   });
 
-  useEffect(() => {
-    if (!request) {
-      return;
-    }
-
-    setEditTitle(request.title ?? "");
-    setEditClassroomName(request.classroomName ?? "");
-    setEditItems(
-      (request.items ?? []).map((item, index) => {
-        const extendedItem = item as ExtendedPurchaseItem;
-
-        return {
-          id: item.id ?? index + 1,
-          name: item.name ?? "",
-          quantity: typeof extendedItem.quantity === "number" ? String(extendedItem.quantity) : "1",
-          reason: item.reason ?? "",
-          paymentType: extendedItem.paymentType ?? "ACTUAL",
-        };
-      }),
-    );
-  }, [request]);
-
-  useEffect(() => {
-    if (!request?.items?.length) {
-      setReportItems([]);
-      return;
-    }
-
-    const purchase = request as ExtendedPurchaseRequest;
-    setReportItems(
-      (purchase.items ?? [])
-        .filter((item) => typeof item.id === "number")
-        .map((item) => ({
-          itemId: item.id ?? 0,
-          vendorName: (item as ExtendedPurchaseItem).vendorName ?? purchase.vendorName ?? "",
-          name: item.name ?? "",
-          price: typeof item.actualPrice === "number" ? String(item.actualPrice) : "",
-          purchaseDate: (item as ExtendedPurchaseItem).purchaseDate ?? "",
-          receiptFile: null,
-          receiptFileName: "",
-        })),
-    );
-  }, [request]);
+  const purchase = request as ExtendedPurchaseRequest | undefined;
+  const initialEditItems = useMemo(
+    () => mapPurchaseItemsToEditableItems(request?.items),
+    [request?.items],
+  );
+  const initialReportItems = useMemo(() => mapPurchaseItemsToReportItems(purchase), [purchase]);
+  const activeReportItems = reportItems.length ? reportItems : initialReportItems;
 
   const reportMutation = useMutation({
     mutationFn: async () => {
-      const receiptFileIds: string[] = [];
-
       const uploadedReceiptIds = await Promise.all(
-        reportItems.map(async (item) => {
+        activeReportItems.map(async (item) => {
           if (!item.receiptFile) {
             return null;
           }
 
-          const [, apiUploaded] = await Promise.all([
-            financeReceiptToGoogleDrive(item.receiptFile),
-            uploadPurchaseItemImage(item.receiptFile, item.receiptFile.name),
-          ]);
-
-          return apiUploaded.fileId ?? null;
+          const uploaded = await uploadPurchaseItemImage(item.receiptFile, item.receiptFile.name);
+          return uploaded.fileId ?? null;
         }),
       );
-      receiptFileIds.push(
-        ...uploadedReceiptIds.filter((fileId): fileId is string => Boolean(fileId)),
-      );
 
-      return reportPurchase(
-        { requestId },
-        {
-          items: reportItems.map((item) => ({
-            itemId: item.itemId,
-            price: Number(item.price),
-          })),
-          ...(receiptFileIds.length ? { receiptFileIds } : {}),
-        },
-      );
+      const body = {
+        transactions: activeReportItems.map((item, index) => ({
+          vendorId: Number(item.vendorId),
+          itemNames: item.name
+            .split(",")
+            .map((name) => name.trim())
+            .filter(Boolean),
+          amount: Number(item.price),
+          ...(uploadedReceiptIds[index] || item.receiptFileId
+            ? { receiptFileId: uploadedReceiptIds[index] ?? item.receiptFileId }
+            : {}),
+        })),
+      };
+
+      if (isReportEditing) {
+        return user?.role === "ADMIN"
+          ? updateAdminPurchaseItemReceipts({ requestId }, body)
+          : updatePurchaseItemReceipts({ requestId }, body);
+      }
+
+      return reportPurchase({ requestId }, body);
     },
     onSuccess: () => {
+      setIsReportEditing(false);
+      setReportItems([]);
       queryClient.invalidateQueries({ queryKey: queryKeys.requests.purchaseDetail(requestId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.requests.purchaseList() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.vendors.list() });
     },
   });
 
-  const purchase = request as ExtendedPurchaseRequest | undefined;
-  const detailItems = purchase?.items?.length
-    ? purchase.items.map((item, index) => {
-        const extendedItem = item as ExtendedPurchaseItem;
-        const receipt = purchase.receipts?.[index];
+  const detailItems = purchase?.transactions?.length
+    ? purchase.transactions.map((transaction, index) => {
+        const item = findPurchaseItemForTransaction(transaction.itemNames, purchase.items);
+
         return {
-          id: item.id ?? index,
-          name: item.name ?? "-",
-          reason: item.reason ?? purchase.content ?? "-",
-          quantity: extendedItem.quantity,
-          paymentType: extendedItem.paymentType,
-          vendorName: extendedItem.vendorName ?? purchase.vendorName,
-          price: item.actualPrice,
-          purchaseDate: extendedItem.purchaseDate,
-          receipt,
+          id: transaction.id ?? item?.id ?? index,
+          name: transaction.itemNames?.join(", ") || item?.name || "-",
+          reason: item?.reason ?? purchase.content ?? "-",
+          quantity: item?.quantity,
+          paymentType: item?.paymentType,
+          vendorName: transaction.vendorName,
+          price: transaction.amount,
+          receipt:
+            transaction.receiptFileId || transaction.receiptFileUrl
+              ? {
+                  receiptFileId: transaction.receiptFileId,
+                  fileUrl: transaction.receiptFileUrl,
+                }
+              : undefined,
         };
       })
-    : [
-        {
-          id: purchase?.id ?? 0,
-          name: purchase?.title ?? "-",
-          reason: purchase?.content ?? "-",
-          quantity: undefined,
-          paymentType: undefined,
-          vendorName: purchase?.vendorName,
-          price: purchase?.totalPrice,
-          purchaseDate: undefined,
-          receipt: purchase?.receipts?.[0],
-        },
-      ];
+    : purchase?.items?.length
+      ? purchase.items.map((item, index) => {
+          const extendedItem = item as ExtendedPurchaseItem;
+          return {
+            id: item.id ?? index,
+            name: item.name ?? "-",
+            reason: item.reason ?? purchase.content ?? "-",
+            quantity: extendedItem.quantity,
+            paymentType: extendedItem.paymentType,
+            vendorName: purchase.vendorName,
+            price: undefined,
+            receipt: undefined,
+          };
+        })
+      : [
+          {
+            id: purchase?.id ?? 0,
+            name: purchase?.title ?? "-",
+            reason: purchase?.content ?? "-",
+            quantity: undefined,
+            paymentType: undefined,
+            vendorName: purchase?.vendorName,
+            price: purchase?.totalPrice,
+            receipt: undefined,
+          },
+        ];
   const isRequester =
     authStatus === "authenticated" &&
     typeof user?.id === "number" &&
     typeof request?.requestedById === "number" &&
     user.id === request.requestedById;
+  const canManagePurchaseReport =
+    authStatus === "authenticated" && (user?.role === "ADMIN" || isRequester);
   const canEditRequest = request?.status === "PENDING" && isRequester;
+  const canDeleteRequest = request?.status === "PENDING" && isRequester;
   const canShowReportForm = request?.status === "APPROVED" && isRequester;
+  const canEditPurchaseReport = request?.status === "PURCHASED" && canManagePurchaseReport;
+  const canShowReportEditor = canShowReportForm || isReportEditing;
+  const vendorBalances: VendorBalance[] = vendorData?.length
+    ? vendorData.map((vendor) => ({
+        vendorId: vendor.id,
+        vendorName: vendor.name,
+        balance: vendor.balance,
+      }))
+    : (purchase?.vendorBalances ?? []);
+  const vendorNames = vendorBalances.length
+    ? vendorBalances
+        .map((vendor) => vendor.vendorName)
+        .filter((name): name is string => Boolean(name))
+    : [...fallbackVendorNames];
+  const vendorOptions = vendorBalances
+    .filter((vendor) => typeof vendor.vendorId === "number" && Boolean(vendor.vendorName))
+    .map((vendor) => ({ id: vendor.vendorId as number, name: vendor.vendorName as string }));
   const canSubmitReport =
-    canShowReportForm &&
-    reportItems.length > 0 &&
-    reportItems.every(
+    canShowReportEditor &&
+    activeReportItems.length > 0 &&
+    activeReportItems.every(
       (item) =>
-        item.vendorName.trim().length > 0 &&
+        Number.isInteger(Number(item.vendorId)) &&
         item.name.trim().length > 0 &&
         item.price.trim().length > 0 &&
-        item.purchaseDate.trim().length > 0 &&
         Number.isFinite(Number(item.price)) &&
-        Number(item.price) >= 0,
+        Number(item.price) >= 1,
     ) &&
     !reportMutation.isPending;
 
@@ -291,15 +363,19 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     itemId: number,
     patch: Partial<{
       vendorName: string;
+      vendorId: string;
       name: string;
       price: string;
-      purchaseDate: string;
       receiptFile: File | null;
       receiptFileName: string;
+      receiptFileId: string;
+      receiptFileUrl: string;
     }>,
   ) {
     setReportItems((current) =>
-      current.map((item) => (item.itemId === itemId ? { ...item, ...patch } : item)),
+      (current.length ? current : initialReportItems).map((item) =>
+        item.itemId === itemId ? { ...item, ...patch } : item,
+      ),
     );
   }
 
@@ -313,8 +389,31 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
 
   function updateEditItem(itemId: number, patch: Partial<EditableItem>) {
     setEditItems((current) =>
-      current.map((item) => (item.id === itemId ? { ...item, ...patch } : item)),
+      (current.length ? current : initialEditItems).map((item) =>
+        item.id === itemId ? { ...item, ...patch } : item,
+      ),
     );
+  }
+
+  function startEditing() {
+    if (!request) {
+      return;
+    }
+
+    setEditTitle(request.title ?? "");
+    setEditClassroomName(request.classroomName ?? "");
+    setEditItems(initialEditItems);
+    setIsEditing(true);
+  }
+
+  function startReportEditing() {
+    setReportItems(initialReportItems);
+    setIsReportEditing(true);
+  }
+
+  function cancelReportEditing() {
+    setReportItems([]);
+    setIsReportEditing(false);
   }
 
   function handleReportSubmit(event: FormEvent<HTMLFormElement>) {
@@ -335,7 +434,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       ...request,
       title: editTitle.trim() || request.title,
       classroomName: editClassroomName.trim() || request.classroomName,
-      items: editItems.map((item) => ({
+      items: (editItems.length ? editItems : initialEditItems).map((item) => ({
         id: item.id,
         name: item.name.trim(),
         reason: item.reason.trim() || undefined,
@@ -363,7 +462,8 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
             <ActionButton
               type="button"
               $variant="danger"
-              disabled={deleteMutation.isPending || isLoading || !request}
+              disabled={!canDeleteRequest || deleteMutation.isPending || isLoading}
+              title={canDeleteRequest ? undefined : "대기 중인 본인 작성 글만 삭제할 수 있습니다."}
               onClick={() => deleteMutation.mutate()}
             >
               {deleteMutation.isPending ? "삭제 중" : "삭제"}
@@ -373,7 +473,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
               $variant="edit"
               disabled={!canEditRequest}
               title={canEditRequest ? undefined : "대기 중인 본인 작성 글만 수정할 수 있습니다."}
-              onClick={() => setIsEditing(true)}
+              onClick={startEditing}
             >
               {isEditing ? "수정 중" : "수정"}
             </ActionButton>
@@ -422,10 +522,17 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
               </Section>
 
               <Section>
-                <SectionTitle>상세 품목</SectionTitle>
+                <DetailSectionHeader>
+                  <SectionTitle>상세 품목</SectionTitle>
+                  {canEditPurchaseReport && !isReportEditing ? (
+                    <ReportEditTextButton type="button" onClick={startReportEditing}>
+                      수정
+                    </ReportEditTextButton>
+                  ) : null}
+                </DetailSectionHeader>
                 {isEditing ? (
                   <EditItemList>
-                    {editItems.map((item, index) => (
+                    {(editItems.length ? editItems : initialEditItems).map((item, index) => (
                       <EditItemBlock key={item.id}>
                         <ItemFieldRow>
                           <ItemLabel htmlFor={`editItemName-${item.id}`}>
@@ -476,7 +583,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                                   }
                                 }}
                               />
-                              <span>선 결제</span>
+                              <span>선금 결제</span>
                             </PaymentTypeOption>
                             <PaymentTypeOption>
                               <input
@@ -505,7 +612,6 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                         <th>결제 사유</th>
                         <th>결제 유형</th>
                         <th>결제 금액</th>
-                        <th>구매 일자</th>
                         <th>영수증</th>
                       </tr>
                     </thead>
@@ -519,17 +625,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                           <td>{getPaymentTypeLabel(item.paymentType)}</td>
                           <td>{formatAmount(item.price)}</td>
                           <td>
-                            {item.purchaseDate ? formatUtcToKstShortDate(item.purchaseDate) : "-"}
-                          </td>
-                          <td>
                             {item.receipt ? (
                               <InlineReceiptLink
-                                href={item.receipt.fileUrl ?? item.receipt.url ?? "#"}
+                                href={item.receipt.fileUrl ?? "#"}
                                 download={getReceiptName(item.receipt)}
                               >
-                                {getReceiptName(item.receipt)}
+                                파일
                                 <ReceiptIcon aria-hidden="true">
-                                  <IconDownload size={16} stroke={2.25} />
+                                  <IconDownload size={12} stroke={2.25} />
                                 </ReceiptIcon>
                               </InlineReceiptLink>
                             ) : (
@@ -548,14 +651,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 <VendorBalanceTable>
                   <tbody>
                     {vendorNames.map((vendorName) => {
-                      const balance = purchase?.vendorBalances?.find(
-                        (item) => item.vendorName === vendorName,
-                      );
+                      const balance = vendorBalances.find((item) => item.vendorName === vendorName);
 
                       return (
                         <tr key={vendorName}>
                           <th scope="row">{vendorName}</th>
-                          <td>{formatAmount(balance?.balance ?? balance?.totalAmount)}</td>
+                          <td>{formatAmount(balance?.balance)}</td>
                         </tr>
                       );
                     })}
@@ -571,10 +672,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 ) : null}
               </Section>
 
-              {canShowReportForm ? (
+              {canShowReportEditor ? (
                 <ReportForm onSubmit={handleReportSubmit}>
-                  <SectionTitle>구매 완료 보고</SectionTitle>
-                  {reportItems.map((item, index) => (
+                  <SectionTitle>
+                    {isReportEditing ? "구매 완료 보고 수정" : "구매 완료 보고"}
+                  </SectionTitle>
+                  {activeReportItems.map((item, index) => (
                     <ReportGrid key={item.itemId}>
                       <ReportLabel htmlFor={`reportName-${item.itemId}`}>
                         품목 {index + 1}
@@ -585,15 +688,22 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       <ReportLabel htmlFor={`vendor-${item.itemId}`}>거래처</ReportLabel>
                       <ReportSelect
                         id={`vendor-${item.itemId}`}
-                        value={item.vendorName}
-                        onChange={(event) =>
-                          updateReportItem(item.itemId, { vendorName: event.target.value })
-                        }
+                        value={item.vendorId}
+                        onChange={(event) => {
+                          const vendor = vendorOptions.find(
+                            (option) => String(option.id) === event.target.value,
+                          );
+
+                          updateReportItem(item.itemId, {
+                            vendorId: event.target.value,
+                            vendorName: vendor?.name ?? "",
+                          });
+                        }}
                       >
                         <option value="">거래처 선택</option>
-                        {vendorNames.map((vendorName) => (
-                          <option key={vendorName} value={vendorName}>
-                            {vendorName}
+                        {vendorOptions.map((vendor) => (
+                          <option key={vendor.id} value={vendor.id}>
+                            {vendor.name}
                           </option>
                         ))}
                       </ReportSelect>
@@ -601,21 +711,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       <ReportInput
                         id={`price-${item.itemId}`}
                         type="number"
-                        min="0"
+                        min="1"
                         inputMode="numeric"
                         placeholder="0"
                         value={item.price}
                         onChange={(event) =>
                           updateReportItem(item.itemId, { price: event.target.value })
-                        }
-                      />
-                      <ReportLabel htmlFor={`purchaseDate-${item.itemId}`}>구매 일자</ReportLabel>
-                      <ReportInput
-                        id={`purchaseDate-${item.itemId}`}
-                        type="date"
-                        value={item.purchaseDate}
-                        onChange={(event) =>
-                          updateReportItem(item.itemId, { purchaseDate: event.target.value })
                         }
                       />
                       <ReportLabel htmlFor={`receipt-${item.itemId}`}>영수증</ReportLabel>
@@ -632,11 +733,32 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       </UploadControl>
                     </ReportGrid>
                   ))}
-                  <ReportSubmitButton type="submit" disabled={!canSubmitReport}>
-                    {reportMutation.isPending ? "보고 중" : "구매 완료 보고하기"}
-                  </ReportSubmitButton>
+                  <ReportActionRow>
+                    <ReportSubmitButton type="submit" disabled={!canSubmitReport}>
+                      {reportMutation.isPending
+                        ? isReportEditing
+                          ? "수정 중"
+                          : "보고 중"
+                        : isReportEditing
+                          ? "수정 완료"
+                          : "구매 완료 보고하기"}
+                    </ReportSubmitButton>
+                    {isReportEditing ? (
+                      <CancelEditButton
+                        type="button"
+                        disabled={reportMutation.isPending}
+                        onClick={cancelReportEditing}
+                      >
+                        취소
+                      </CancelEditButton>
+                    ) : null}
+                  </ReportActionRow>
                   {reportMutation.isError ? (
-                    <StateMessage role="alert">구매 완료 보고에 실패했습니다.</StateMessage>
+                    <StateMessage role="alert">
+                      {isReportEditing
+                        ? "구매 완료 보고 수정에 실패했습니다."
+                        : "구매 완료 보고에 실패했습니다."}
+                    </StateMessage>
                   ) : null}
                 </ReportForm>
               ) : null}
@@ -852,6 +974,35 @@ const SectionTitle = styled.h2`
   }
 `;
 
+const DetailSectionHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space20};
+`;
+
+const ReportEditTextButton = styled.button`
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #b3b3b3;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
 const Field = styled.div`
   display: flex;
   align-items: center;
@@ -1056,43 +1207,6 @@ const PaymentTypeOption = styled.label`
   }
 `;
 
-const BalanceList = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-  gap: ${spacing.space8};
-  padding: ${spacing.space12};
-  background-color: ${colors.background};
-
-  @media (min-width: 120rem) {
-    gap: ${spacing.space12};
-    padding: ${spacing.space20};
-  }
-`;
-
-const BalanceItem = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${spacing.space12};
-  min-height: 2.5rem;
-  padding: ${spacing.space8} ${spacing.space12};
-  background-color: ${colors.white};
-  color: #000000;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight130};
-
-  strong {
-    font-weight: 700;
-    white-space: nowrap;
-  }
-
-  @media (min-width: 120rem) {
-    min-height: 3.75rem;
-    padding: ${spacing.space12} ${spacing.space20};
-    font-size: ${typography.fontSize20};
-  }
-`;
-
 const VendorBalanceTable = styled.table`
   width: 100%;
   border-collapse: collapse;
@@ -1129,19 +1243,6 @@ const VendorBalanceTable = styled.table`
   }
 `;
 
-const ReceiptList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.3125rem;
-  min-width: 0;
-  background-color: ${colors.background};
-  padding: ${spacing.space12};
-
-  @media (min-width: 120rem) {
-    padding: ${spacing.space20};
-  }
-`;
-
 const StateMessage = styled.p`
   margin: 0 0 ${spacing.space20};
   color: ${colors.muted};
@@ -1150,58 +1251,12 @@ const StateMessage = styled.p`
   line-height: ${typography.lineHeight150};
 `;
 
-const EmptyText = styled.span`
-  color: ${colors.muted};
-  font-size: ${typography.fontSize14};
-  font-weight: 600;
-  line-height: ${typography.lineHeight150};
-`;
-
-const ReceiptRow = styled.div`
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: ${spacing.space8};
-  min-width: 0;
-`;
-
-const ReceiptName = styled.span`
-  color: #000000;
-  font-size: ${typography.fontSize14};
-  font-weight: 600;
-  line-height: ${typography.lineHeight130};
-  text-decoration: underline;
-  text-underline-offset: 0.125rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize20};
-  }
-`;
-
-const ReceiptDownloadButton = styled.a`
-  display: inline-flex;
-  align-items: center;
-  gap: ${spacing.space8};
-  color: #000000;
-  font-size: ${typography.fontSize14};
-  font-weight: 600;
-  line-height: ${typography.lineHeight130};
-  text-decoration: none;
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize20};
-  }
-`;
-
 const ReceiptIcon = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.2em;
+  height: 1.2rem;
   border-radius: 50%;
   background-color: ${colors.point};
   color: ${colors.white};
@@ -1267,10 +1322,17 @@ const ReportForm = styled.form`
   }
 `;
 
+const ReportActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  flex-wrap: wrap;
+`;
+
 const ReportGrid = styled.div`
   display: grid;
   grid-template-columns:
-    auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 0.8fr) auto minmax(0, 0.8fr)
+    auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 0.8fr)
     auto minmax(8rem, auto);
   align-items: center;
   gap: ${spacing.space12};

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -24,6 +24,9 @@ export const queryKeys = {
   classrooms: {
     list: () => ["classrooms", "list"] as const,
   },
+  vendors: {
+    list: () => ["vendors", "list"] as const,
+  },
   students: {
     list: (params?: { name?: string; status?: string; classroomId?: number }) =>
       ["students", "list", params ?? {}] as const,

--- a/mocks/handlers/file.handlers.ts
+++ b/mocks/handlers/file.handlers.ts
@@ -8,6 +8,7 @@ export const FILE_UPLOAD_RESPONSE = {
   contentType: "image/png",
   fileSize: 102400,
   ext: "png",
+  isGoogleDrive: false,
   url: "https://storage.googleapis.com/example-bucket/purchase-items/receipt.png",
 };
 

--- a/mocks/handlers/request.handlers.ts
+++ b/mocks/handlers/request.handlers.ts
@@ -33,11 +33,9 @@ export const PURCHASE_REQUEST_RESPONSE = {
       quantity: 1,
       reason: "Need new workbook copies",
       paymentType: "ACTUAL",
-      vendorName: "문구점",
-      actualPrice: 30000,
     },
   ],
-  receipts: [],
+  transactions: [],
 };
 
 export const LESSON_EXCHANGE_REQUEST_RESPONSE = {
@@ -153,7 +151,12 @@ export const requestHandlers: RequestHandler[] = [
       classroomId?: number;
       title?: string;
       content?: string;
-      items?: unknown[];
+      items?: {
+        name?: string;
+        quantity?: number;
+        reason?: string;
+        paymentType?: "PREPAID" | "ACTUAL";
+      }[];
     };
     return HttpResponse.json({ ...PURCHASE_REQUEST_RESPONSE, ...body, id: 20 });
   }),
@@ -171,24 +174,58 @@ export const requestHandlers: RequestHandler[] = [
     if (unauthorizedResponse) return unauthorizedResponse;
 
     const body = (await request.json()) as {
-      items?: { itemId?: number; vendorName?: string; name?: string; price?: number }[];
-      receiptFileIds?: string[];
+      transactions?: {
+        vendorId?: number;
+        itemNames?: string[];
+        amount?: number;
+        receiptFileId?: string;
+      }[];
     };
     return HttpResponse.json({
       ...PURCHASE_REQUEST_RESPONSE,
       id: Number(params.requestId),
-      items:
-        body.items?.map((item, index) => ({
-          id: item.itemId ?? index + 1,
-          name: item.name ?? PURCHASE_REQUEST_RESPONSE.items[index]?.name,
-          vendorName: item.vendorName,
-          actualPrice: item.price,
-          quantity: PURCHASE_REQUEST_RESPONSE.items[index]?.quantity,
-          paymentType: PURCHASE_REQUEST_RESPONSE.items[index]?.paymentType,
-        })) ?? PURCHASE_REQUEST_RESPONSE.items,
+      transactions:
+        body.transactions?.map((transaction, index) => ({
+          id: index + 1,
+          vendorId: transaction.vendorId,
+          vendorName: transaction.vendorId ? `거래처 ${transaction.vendorId}` : undefined,
+          itemNames: transaction.itemNames,
+          amount: transaction.amount,
+          receiptFileId: transaction.receiptFileId,
+        })) ?? [],
       status: "PURCHASED",
     });
   }),
+  http.post(
+    `${API_BASE_URL}/api/v1/purchase-requests/:requestId/item-receipts`,
+    async ({ request, params }) => {
+      const unauthorizedResponse = unauthorizedWhenNeeded(request);
+      if (unauthorizedResponse) return unauthorizedResponse;
+
+      const body = (await request.json()) as {
+        transactions?: {
+          vendorId?: number;
+          itemNames?: string[];
+          amount?: number;
+          receiptFileId?: string;
+        }[];
+      };
+      return HttpResponse.json({
+        ...PURCHASE_REQUEST_RESPONSE,
+        id: Number(params.requestId),
+        transactions:
+          body.transactions?.map((transaction, index) => ({
+            id: index + 1,
+            vendorId: transaction.vendorId,
+            vendorName: transaction.vendorId ? `거래처 ${transaction.vendorId}` : undefined,
+            itemNames: transaction.itemNames,
+            amount: transaction.amount,
+            receiptFileId: transaction.receiptFileId,
+          })) ?? [],
+        status: "PURCHASED",
+      });
+    },
+  ),
   http.post(`${API_BASE_URL}/api/v1/purchase-requests/:requestId/reconfirmation`, ({ request }) => {
     return unauthorizedWhenNeeded(request) ?? HttpResponse.json({ message: "재확인을 요청했습니다." });
   }),
@@ -244,6 +281,36 @@ export const requestHandlers: RequestHandler[] = [
       })
     );
   }),
+  http.patch(
+    `${API_BASE_URL}/api/v1/admin/purchase-requests/:requestId/item-receipts`,
+    async ({ request, params }) => {
+      const unauthorizedResponse = unauthorizedWhenNeeded(request);
+      if (unauthorizedResponse) return unauthorizedResponse;
+
+      const body = (await request.json()) as {
+        transactions?: {
+          vendorId?: number;
+          itemNames?: string[];
+          amount?: number;
+          receiptFileId?: string;
+        }[];
+      };
+      return HttpResponse.json({
+        ...PURCHASE_REQUEST_RESPONSE,
+        id: Number(params.requestId),
+        transactions:
+          body.transactions?.map((transaction, index) => ({
+            id: index + 1,
+            vendorId: transaction.vendorId,
+            vendorName: transaction.vendorId ? `거래처 ${transaction.vendorId}` : undefined,
+            itemNames: transaction.itemNames,
+            amount: transaction.amount,
+            receiptFileId: transaction.receiptFileId,
+          })) ?? [],
+        status: "PURCHASED",
+      });
+    },
+  ),
   http.get(`${API_BASE_URL}/api/v1/lesson-exchange-requests`, ({ request }) => {
     return unauthorizedWhenNeeded(request) ?? HttpResponse.json([LESSON_EXCHANGE_REQUEST_RESPONSE]);
   }),


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

개선된 결제 신청 플로우에 따라 UI를 개선하고, 관련 API를 연동하였습니다.

1. 결제 신청 -> 관리자 승인 흐름

   [결제 신청]

    <img width="1897" height="868" alt="스크린샷 2026-06-01 153839" src="https://github.com/user-attachments/assets/d0e7001c-6fba-4fe7-b742-84171bda9ebe" />

   [관리자 승인]

   <img width="1900" height="861" alt="스크린샷 2026-06-01 153915" src="https://github.com/user-attachments/assets/1c03a776-e8f7-42aa-be29-25775b763cc5" />

   [구매 완료 보고]

   <img width="1299" height="666" alt="스크린샷 2026-06-01 153951" src="https://github.com/user-attachments/assets/9be0a1ee-f861-45b7-91ae-c04483f00359" />

   [구매 완료 보고 수정]

   상세 품목 테이블의 오른쪽 상단에 "수정" 버튼을 통해 기존에 제출한 구매 완료 보고 내용을 수정할 수 있습니다.

   금액 수정 & 영수증 첨부
   <img width="1298" height="276" alt="스크린샷 2026-06-01 161758" src="https://github.com/user-attachments/assets/6fb843c6-a6c3-4818-b85d-8ad604dc4efd" />

   결과
   <img width="1274" height="570" alt="스크린샷 2026-06-01 161745" src="https://github.com/user-attachments/assets/cefacd84-d836-4d77-a826-0846ec7e96d0" />

   [관리자 결재 확인]

   관리자가 "실 결제"에 대한 요청 건에 대해 "결재 확인"을 완료하면, 해당 거래처의 잔액에서 거래 금액이 즉시 차감됩니다.
   "선금 결제"에 대한 요청 건인 경우, 해당 거래처의 잔액이 거래 금액만큼 충전됩니다.

   <img width="1495" height="455" alt="스크린샷 2026-06-01 161819" src="https://github.com/user-attachments/assets/576d064f-a830-4d7a-a0b6-b779e15c70c8" />

   <img width="1279" height="588" alt="스크린샷 2026-06-01 161841" src="https://github.com/user-attachments/assets/4b79cf5e-57a5-4fac-b49f-5f2cdb76ccbb" />

2. 결제 신청 -> 관리자 거절 흐름

   [요청 건에 대한 관리자 거절]

   <img width="1498" height="492" alt="스크린샷 2026-06-01 161955" src="https://github.com/user-attachments/assets/59170102-8c2d-48b1-9699-501aff7a4cf6" />

   <img width="1490" height="487" alt="스크린샷 2026-06-01 162014" src="https://github.com/user-attachments/assets/6305f1fc-e5a9-40fd-957a-610a7331b738" />

   <img width="1489" height="483" alt="스크린샷 2026-06-01 162021" src="https://github.com/user-attachments/assets/91cb80ab-6999-45df-bbee-b1e6af13c21f" />

   [거절된 요청 건의 상태]

   <img width="1269" height="251" alt="스크린샷 2026-06-01 164332" src="https://github.com/user-attachments/assets/d3d6cbf1-5521-40d5-90c1-4bac8a1e748d" />

   <img width="1279" height="696" alt="스크린샷 2026-06-01 164349" src="https://github.com/user-attachments/assets/8defb204-e5e2-498f-ac74-b649fccff34b" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #104 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
