### PR TITLE
[HOTFIX] 행사 상세 첨부 링크를 dto 변경에 따라 url에서 downloadUrl로 수정

### DIFF
--- a/components/info/events/EventDetailPageClient.tsx
+++ b/components/info/events/EventDetailPageClient.tsx
@@ -125,7 +125,7 @@ export default function EventDetailPageClient({ postId, channelId }: EventDetail
           <FileList>
             {attachments.length > 0 ? (
               attachments.map((file) => {
-                const href = file.downloadUrl ?? file.url ?? "#";
+                const href = file.downloadUrl ?? "#";
                 const label = file.originalName ?? file.fileId ?? "첨부파일";
                 return (
                   <FileLink key={`${file.fileId ?? label}-${file.sortOrder ?? 0}`} href={href}>


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- `EventDetailPageClient`에서 첨부 파일 링크 생성 시 존재하지 않는 `file.url`을 참조해 TypeScript 빌드가 실패하던 문제를 수정했습니다.
- `PostAttachmentInfoDto`에 맞게 `downloadUrl`만 사용하도록 변경했습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #115

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
