### PR TITLE
[FEAT] 수업 교환 요청 관리자 페이지 기능 구현

### DIFF
--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -13,6 +13,7 @@ import { AdminClassroomsSection } from "@/components/admin/classes/AdminClassroo
 import { AdminDepartmentsSection } from "@/components/admin/departments/AdminDepartmentsSection";
 import { AdminPostsSection } from "@/components/admin/posts/AdminPostsSection";
 import { AdminAbsenceRequestsSection } from "@/components/admin/absence-requests/AdminAbsenceRequestsSection";
+import { AdminLessonExchangeSection } from "@/components/admin/lesson-exchange/AdminLessonExchangeSection";
 import { AdminPurchasesSection } from "@/components/admin/purchase-requests/AdminPurchasesSection";
 import { AdminLessonManagementSection } from "@/components/admin/lesson-management/AdminLessonManagementSection";
 import { AdminSubjectsSection } from "@/components/admin/subjects/AdminSubjectsSection";
@@ -102,6 +103,7 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "posts", label: "게시글" },
   { key: "purchases", label: "구매 요청" },
   { key: "absenceRequests", label: "결석 요청" },
+  { key: "lessonExchange", label: "수업 교환 요청" },
 ];
 
 const fallbackPermissions: PermissionDefinitionDto[] = [
@@ -1037,6 +1039,7 @@ export default function AdminDashboardPage() {
     lessons: "수업 목록을 조회하고 새 수업을 생성합니다.",
     purchases: "구매 요청 작성, 목록/상세 조회, 승인/반려/결재 확인/삭제 처리를 제공합니다.",
     absenceRequests: "결석 요청 목록 조회 및 승인/반려 처리를 제공합니다.",
+    lessonExchange: "수업 교환 요청 목록 조회 및 승인/반려 처리를 제공합니다.",
   }[activeMenu];
 
   return (
@@ -1195,6 +1198,7 @@ export default function AdminDashboardPage() {
           {activeMenu === "subjects" ? <AdminSubjectsSection /> : null}
           {activeMenu === "lessons" ? <AdminLessonManagementSection /> : null}
           {activeMenu === "absenceRequests" ? <AdminAbsenceRequestsSection /> : null}
+          {activeMenu === "lessonExchange" ? <AdminLessonExchangeSection /> : null}
           {activeMenu === "purchases" ? (
             <AdminPurchasesSection
               classrooms={classrooms}

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -13,7 +13,8 @@ export type AdminMenu =
   | "subjects"
   | "lessons"
   | "purchases"
-  | "absenceRequests";
+  | "absenceRequests"
+  | "lessonExchange";
 
 export type UserFormState = {
   email: string;

--- a/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
@@ -2,6 +2,7 @@
 
 import styled from "styled-components";
 import {
+  ABSENCE_ITEMS_PER_PAGE,
   ABSENCE_STATUS_OPTIONS,
   formatAbsenceDate,
   type AbsenceStatusFilter,
@@ -10,7 +11,6 @@ import { AbsenceStatusBadge } from "@/components/admin/absence-requests/AbsenceS
 import type { AdminAbsenceRequestsViewModel } from "@/components/admin/absence-requests/useAdminAbsenceRequests";
 import {
   ControlRow,
-  DataState,
   SectionCard,
   SectionTitle,
   Select,
@@ -18,7 +18,11 @@ import {
   Table,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { colors, spacing, typography } from "@/styles/tokens";
+
+const ABSENCE_TABLE_HEADER_HEIGHT = "2.5rem";
+const ABSENCE_TABLE_ROW_HEIGHT = "3.75rem";
 
 type AdminAbsenceRequestsListPanelProps = Pick<
   AdminAbsenceRequestsViewModel,
@@ -52,6 +56,10 @@ export function AdminAbsenceRequestsListPanel({
   goToPrevPage,
   goToNextPage,
 }: AdminAbsenceRequestsListPanelProps) {
+  const isLoading = absenceRequestsQuery.isLoading;
+  const isError = absenceRequestsQuery.isError;
+  const isEmpty = !isLoading && !isError && sortedRequests.length === 0;
+
   return (
     <SectionCard>
       <SectionTitle>결석 요청 목록</SectionTitle>
@@ -80,22 +88,32 @@ export function AdminAbsenceRequestsListPanel({
         <SmallButton type="submit">검색</SmallButton>
       </ControlRow>
 
-      <DataState
-        isLoading={absenceRequestsQuery.isLoading}
-        isError={absenceRequestsQuery.isError}
-        isEmpty={sortedRequests.length === 0}
-        loadingLabel="결석 요청 목록 불러오는 중"
-        errorLabel="결석 요청 목록을 불러오지 못했습니다."
-        emptyLabel="결석 요청이 없습니다."
-      >
-        <AbsenceListTable>
+      <ListTableArea>
+        <TableViewport>
+          {isLoading ? (
+            <ListOverlay>
+              <LoadingSpinner label="결석 요청 목록 불러오는 중" />
+            </ListOverlay>
+          ) : null}
+          {isError ? (
+            <ListOverlay role="alert">
+              <ListOverlayMessage>결석 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
+            </ListOverlay>
+          ) : null}
+          {isEmpty ? (
+            <ListOverlay>
+              <ListOverlayMessage>결석 요청이 없습니다.</ListOverlayMessage>
+            </ListOverlay>
+          ) : null}
+
+          <AbsenceListTable>
           <thead>
             <tr>
               <th>제목</th>
               <th>분반</th>
               <th>요청자</th>
               <th>상태</th>
-              <th>요청일</th>
+              <th>일자</th>
             </tr>
           </thead>
           <tbody>
@@ -111,11 +129,17 @@ export function AdminAbsenceRequestsListPanel({
                 <td>
                   <AbsenceStatusBadge status={item.status} />
                 </td>
-                <td>{formatAbsenceDate(item.createdAt)}</td>
+                <td>
+                  <ScheduleCell>
+                    <ScheduleLine>수업일 {formatAbsenceDate(item.lessonDate)}</ScheduleLine>
+                    <ScheduleLine $muted>요청일 {formatAbsenceDate(item.createdAt)}</ScheduleLine>
+                  </ScheduleCell>
+                </td>
               </AbsenceTableRow>
             ))}
           </tbody>
-        </AbsenceListTable>
+          </AbsenceListTable>
+        </TableViewport>
 
         <PaginationNav aria-label="페이지 이동">
           <PageArrowButton
@@ -138,12 +162,44 @@ export function AdminAbsenceRequestsListPanel({
             ›
           </PageArrowButton>
         </PaginationNav>
-      </DataState>
+      </ListTableArea>
     </SectionCard>
   );
 }
 
+const ListTableArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: calc(
+    ${ABSENCE_TABLE_HEADER_HEIGHT} +
+      ${ABSENCE_ITEMS_PER_PAGE} * ${ABSENCE_TABLE_ROW_HEIGHT} + 2.75rem
+  );
+`;
+
+const TableViewport = styled.div`
+  position: relative;
+  flex: 1 1 auto;
+`;
+
+const ListOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(255 255 255 / 72%);
+`;
+
+const ListOverlayMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
 const AbsenceTableRow = styled.tr<{ $selected: boolean }>`
+  height: ${ABSENCE_TABLE_ROW_HEIGHT};
   background-color: ${({ $selected }) => ($selected ? colors.pointSoft : "transparent")};
 `;
 
@@ -152,6 +208,32 @@ const AbsenceListTable = styled(Table)`
   td {
     vertical-align: middle;
   }
+
+  thead tr {
+    height: ${ABSENCE_TABLE_HEADER_HEIGHT};
+  }
+
+  tbody tr {
+    height: ${ABSENCE_TABLE_ROW_HEIGHT};
+  }
+
+  th:last-child,
+  td:last-child {
+    width: 1%;
+    white-space: nowrap;
+  }
+`;
+
+const ScheduleCell = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+`;
+
+const ScheduleLine = styled.span<{ $muted?: boolean }>`
+  color: ${({ $muted }) => ($muted ? "#64706c" : "#050505")};
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
 `;
 
 const StatusSelect = styled(Select)`
@@ -167,7 +249,9 @@ const PaginationNav = styled.nav`
   align-items: center;
   justify-content: flex-end;
   gap: ${spacing.space8};
-  margin-top: ${spacing.space12};
+  margin-top: auto;
+  padding-top: ${spacing.space12};
+  flex-shrink: 0;
 `;
 
 const PageArrowButton = styled.button`

--- a/components/admin/absence-requests/absenceRequestConstants.ts
+++ b/components/admin/absence-requests/absenceRequestConstants.ts
@@ -1,7 +1,7 @@
 import type { AbsenceRequestStatus } from "@/api/request/request.dto";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
-export const ABSENCE_ITEMS_PER_PAGE = 10;
+export const ABSENCE_ITEMS_PER_PAGE = 8;
 
 export const ABSENCE_STATUS_OPTIONS = [
   { value: "", label: "전체" },

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import styled from "styled-components";
+import { formatLessonExchangeDate } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
+import { LessonExchangeStatusBadge } from "@/components/admin/lesson-exchange/LessonExchangeStatusBadge";
+import type { AdminLessonExchangeRequestsViewModel } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
+import {
+  ButtonRow,
+  DangerButton,
+  DataState,
+  FormGrid,
+  PrimaryButton,
+  SectionCard,
+  SectionDescription,
+  SectionTitle,
+  TextArea,
+} from "@/components/admin/AdminDashboardSectionParts";
+import { spacing, typography } from "@/styles/tokens";
+
+type AdminLessonExchangeRequestsDetailPanelProps = Pick<
+  AdminLessonExchangeRequestsViewModel,
+  | "selectedRequestId"
+  | "lessonExchangeDetailQuery"
+  | "rejectNote"
+  | "setRejectNote"
+  | "handleApprove"
+  | "handleReject"
+  | "isActionPending"
+>;
+
+export function AdminLessonExchangeRequestsDetailPanel({
+  selectedRequestId,
+  lessonExchangeDetailQuery,
+  rejectNote,
+  setRejectNote,
+  handleApprove,
+  handleReject,
+  isActionPending,
+}: AdminLessonExchangeRequestsDetailPanelProps) {
+  const detail = lessonExchangeDetailQuery.data;
+  const isLoading = selectedRequestId !== null && lessonExchangeDetailQuery.isLoading;
+  const isError = selectedRequestId !== null && lessonExchangeDetailQuery.isError;
+  const rejectionNote = detail?.rejectionNote?.trim();
+  const isProcessed = Boolean(detail?.processedAt);
+  const isExpired = detail?.status === "EXPIRED";
+  const showProcessingMeta =
+    isProcessed ||
+    detail?.status === "APPROVED" ||
+    detail?.status === "REJECTED" ||
+    detail?.status === "COMPLETED" ||
+    detail?.status === "CANCELLED";
+
+  return (
+    <SectionCard>
+      <SectionTitle>수업 교환 요청 상세/처리</SectionTitle>
+      <SectionDescription>
+        선택한 수업 교환 요청의 상세 정보를 확인하고 승인 또는 반려 처리를 수행합니다.
+      </SectionDescription>
+
+      <DataState
+        isLoading={isLoading}
+        isError={isError}
+        isEmpty={!selectedRequestId}
+        loadingLabel="수업 교환 요청 상세 불러오는 중"
+        errorLabel="수업 교환 요청 상세를 불러오지 못했습니다."
+        emptyLabel="수업 교환 요청을 선택하세요."
+      >
+        <DetailStack>
+          <DetailFields>
+            <DetailField $fullWidth>
+              <DetailFieldLabel>제목</DetailFieldLabel>
+              <DetailFieldValue>{detail?.title ?? "-"}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>분반</DetailFieldLabel>
+              <DetailFieldValue>{detail?.classroomName ?? "-"}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>요청자</DetailFieldLabel>
+              <DetailFieldValue>{detail?.requestedByName ?? "-"}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>수업일</DetailFieldLabel>
+              <DetailFieldValue>{formatLessonExchangeDate(detail?.lessonDate)}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>만료일</DetailFieldLabel>
+              <DetailFieldValue>{formatLessonExchangeDate(detail?.expiresAt)}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>요청일</DetailFieldLabel>
+              <DetailFieldValue>{formatLessonExchangeDate(detail?.createdAt)}</DetailFieldValue>
+            </DetailField>
+            <DetailField>
+              <DetailFieldLabel>상태</DetailFieldLabel>
+              <DetailFieldValue>
+                <LessonExchangeStatusBadge status={detail?.status} />
+              </DetailFieldValue>
+            </DetailField>
+          </DetailFields>
+
+          <ContentSection>
+            <DetailField $fullWidth $compact>
+              <DetailFieldLabel>내용</DetailFieldLabel>
+              <DetailTextBox>{detail?.content?.trim() || "-"}</DetailTextBox>
+            </DetailField>
+
+            {rejectionNote || showProcessingMeta ? <CompactDivider /> : null}
+
+            {rejectionNote ? (
+              <DetailField $fullWidth $compact>
+                <DetailFieldLabel>반려 사유</DetailFieldLabel>
+                <DetailNoteBox>{rejectionNote}</DetailNoteBox>
+              </DetailField>
+            ) : null}
+
+            {showProcessingMeta ? (
+              <ProcessingMetaFields $spacedFromRejection={Boolean(rejectionNote)}>
+                  <DetailField>
+                    <DetailFieldLabel>처리자</DetailFieldLabel>
+                    <DetailFieldValue>{detail?.processedByName ?? "-"}</DetailFieldValue>
+                  </DetailField>
+                  <DetailField>
+                    <DetailFieldLabel>처리일</DetailFieldLabel>
+                    <DetailFieldValue>{formatLessonExchangeDate(detail?.processedAt)}</DetailFieldValue>
+                  </DetailField>
+                  <DetailField>
+                    <DetailFieldLabel>완료일</DetailFieldLabel>
+                    <DetailFieldValue>{formatLessonExchangeDate(detail?.completedAt)}</DetailFieldValue>
+                  </DetailField>
+                  <DetailField>
+                    <DetailFieldLabel>취소일</DetailFieldLabel>
+                    <DetailFieldValue>{formatLessonExchangeDate(detail?.cancelledAt)}</DetailFieldValue>
+                  </DetailField>
+              </ProcessingMetaFields>
+            ) : null}
+
+            <ActionDivider />
+          </ContentSection>
+
+          <ActionSection>
+            <DetailFieldLabel>처리</DetailFieldLabel>
+            {isExpired ? (
+              <UnavailableBadge>만료된 요청으로 처리불가</UnavailableBadge>
+            ) : isProcessed ? (
+              <ProcessedBadge>처리 완료</ProcessedBadge>
+            ) : (
+              <FormGrid onSubmit={(event) => event.preventDefault()}>
+                <RejectNoteTextArea
+                  value={rejectNote}
+                  placeholder="반려 사유를 입력해 주세요."
+                  disabled={isActionPending}
+                  onChange={(event) => setRejectNote(event.target.value)}
+                />
+                <ButtonRow>
+                  <PrimaryButton type="button" disabled={isActionPending} onClick={handleApprove}>
+                    승인
+                  </PrimaryButton>
+                  <DangerButton
+                    type="button"
+                    disabled={isActionPending || !rejectNote.trim()}
+                    onClick={handleReject}
+                  >
+                    반려
+                  </DangerButton>
+                </ButtonRow>
+              </FormGrid>
+            )}
+          </ActionSection>
+        </DetailStack>
+      </DataState>
+    </SectionCard>
+  );
+}
+
+const DetailStack = styled.div`
+  display: grid;
+  gap: ${spacing.space20};
+`;
+
+const DetailFields = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space16};
+`;
+
+const DetailField = styled.div<{ $fullWidth?: boolean; $compact?: boolean }>`
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? spacing.space4 : spacing.space8)};
+  min-width: 0;
+  grid-column: ${({ $fullWidth }) => ($fullWidth ? "1 / -1" : "auto")};
+`;
+
+const DetailFieldLabel = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const DetailFieldValue = styled.div`
+  color: #1f2b28;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  word-break: break-word;
+`;
+
+const DetailTextBox = styled.div`
+  padding: ${spacing.space8} ${spacing.space12};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  background: #fafbfa;
+  color: #1f2b28;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const DetailNoteBox = styled(DetailTextBox)`
+  border-color: #f3c6c2;
+  background: #fff7f6;
+`;
+
+const CompactDivider = styled.hr`
+  width: 100%;
+  margin: ${spacing.space8} 0;
+  border: 0;
+  border-top: 1px solid #e6e9e7;
+`;
+
+const ActionDivider = styled(CompactDivider)`
+  margin-top: ${spacing.space4};
+  margin-bottom: ${spacing.space4};
+`;
+
+const ContentSection = styled.section`
+  display: grid;
+  gap: ${spacing.space8};
+  margin: 0;
+`;
+
+const ProcessingMetaFields = styled.div<{ $spacedFromRejection?: boolean }>`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${spacing.space16};
+  margin-top: ${({ $spacedFromRejection }) => ($spacedFromRejection ? spacing.space8 : "0")};
+`;
+
+const ActionSection = styled.section`
+  display: grid;
+  gap: ${spacing.space12};
+  margin-top: -${spacing.space8};
+`;
+
+const RejectNoteTextArea = styled(TextArea)`
+  resize: none;
+  font-weight: 500;
+`;
+
+const UnavailableBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 3.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  background: #fff3e0;
+  color: #b45f06;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+`;
+
+const ProcessedBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 3.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  background: #dcf4ea;
+  color: #3da75c;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+`;

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import styled from "styled-components";
-import { formatLessonExchangeDate } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
-import { LessonExchangeStatusBadge } from "@/components/admin/lesson-exchange/LessonExchangeStatusBadge";
+import { LessonExchangeDetailFieldItems } from "@/components/admin/lesson-exchange/LessonExchangeDetailFieldItems";
+import {
+  LESSON_EXCHANGE_BASIC_DETAIL_FIELDS,
+  LESSON_EXCHANGE_PROCESSING_META_FIELDS,
+} from "@/components/admin/lesson-exchange/lessonExchangeDetailFields";
+import {
+  getLessonExchangeDetailActionState,
+  getLessonExchangeRejectionNote,
+  hasLessonExchangeSupplementalContent,
+  shouldShowLessonExchangeProcessingMeta,
+} from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
 import type { AdminLessonExchangeRequestsViewModel } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
 import {
   ButtonRow,
@@ -17,38 +26,30 @@ import {
 } from "@/components/admin/AdminDashboardSectionParts";
 import { spacing, typography } from "@/styles/tokens";
 
-type AdminLessonExchangeRequestsDetailPanelProps = Pick<
-  AdminLessonExchangeRequestsViewModel,
-  | "selectedRequestId"
-  | "lessonExchangeDetailQuery"
-  | "rejectNote"
-  | "setRejectNote"
-  | "handleApprove"
-  | "handleReject"
-  | "isActionPending"
->;
+type AdminLessonExchangeRequestsDetailPanelProps = {
+  viewModel: AdminLessonExchangeRequestsViewModel;
+};
 
 export function AdminLessonExchangeRequestsDetailPanel({
-  selectedRequestId,
-  lessonExchangeDetailQuery,
-  rejectNote,
-  setRejectNote,
-  handleApprove,
-  handleReject,
-  isActionPending,
+  viewModel,
 }: AdminLessonExchangeRequestsDetailPanelProps) {
+  const {
+    selectedRequestId,
+    lessonExchangeDetailQuery,
+    rejectNote,
+    setRejectNote,
+    handleApprove,
+    handleReject,
+    isActionPending,
+  } = viewModel;
+
   const detail = lessonExchangeDetailQuery.data;
   const isLoading = selectedRequestId !== null && lessonExchangeDetailQuery.isLoading;
   const isError = selectedRequestId !== null && lessonExchangeDetailQuery.isError;
-  const rejectionNote = detail?.rejectionNote?.trim();
-  const isProcessed = Boolean(detail?.processedAt);
-  const isExpired = detail?.status === "EXPIRED";
-  const showProcessingMeta =
-    isProcessed ||
-    detail?.status === "APPROVED" ||
-    detail?.status === "REJECTED" ||
-    detail?.status === "COMPLETED" ||
-    detail?.status === "CANCELLED";
+  const actionState = getLessonExchangeDetailActionState(detail);
+  const rejectionNote = getLessonExchangeRejectionNote(detail);
+  const showProcessingMeta = shouldShowLessonExchangeProcessingMeta(detail);
+  const hasSupplementalContent = hasLessonExchangeSupplementalContent(detail);
 
   return (
     <SectionCard>
@@ -67,106 +68,71 @@ export function AdminLessonExchangeRequestsDetailPanel({
       >
         <DetailStack>
           <DetailFields>
-            <DetailField $fullWidth>
-              <DetailFieldLabel>제목</DetailFieldLabel>
-              <DetailFieldValue>{detail?.title ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>분반</DetailFieldLabel>
-              <DetailFieldValue>{detail?.classroomName ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>요청자</DetailFieldLabel>
-              <DetailFieldValue>{detail?.requestedByName ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>수업일</DetailFieldLabel>
-              <DetailFieldValue>{formatLessonExchangeDate(detail?.lessonDate)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>만료일</DetailFieldLabel>
-              <DetailFieldValue>{formatLessonExchangeDate(detail?.expiresAt)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>요청일</DetailFieldLabel>
-              <DetailFieldValue>{formatLessonExchangeDate(detail?.createdAt)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>상태</DetailFieldLabel>
-              <DetailFieldValue>
-                <LessonExchangeStatusBadge status={detail?.status} />
-              </DetailFieldValue>
-            </DetailField>
+            <LessonExchangeDetailFieldItems fields={LESSON_EXCHANGE_BASIC_DETAIL_FIELDS} detail={detail} />
           </DetailFields>
 
-          <ContentSection>
-            <DetailField $fullWidth $compact>
-              <DetailFieldLabel>내용</DetailFieldLabel>
-              <DetailTextBox>{detail?.content?.trim() || "-"}</DetailTextBox>
-            </DetailField>
-
-            {rejectionNote || showProcessingMeta ? <CompactDivider /> : null}
-
-            {rejectionNote ? (
+          <DetailLowerBlock>
+            <ContentSection>
               <DetailField $fullWidth $compact>
-                <DetailFieldLabel>반려 사유</DetailFieldLabel>
-                <DetailNoteBox>{rejectionNote}</DetailNoteBox>
+                <DetailFieldLabel>내용</DetailFieldLabel>
+                <DetailTextBox>{detail?.content?.trim() || "-"}</DetailTextBox>
               </DetailField>
-            ) : null}
 
-            {showProcessingMeta ? (
-              <ProcessingMetaFields $spacedFromRejection={Boolean(rejectionNote)}>
-                  <DetailField>
-                    <DetailFieldLabel>처리자</DetailFieldLabel>
-                    <DetailFieldValue>{detail?.processedByName ?? "-"}</DetailFieldValue>
-                  </DetailField>
-                  <DetailField>
-                    <DetailFieldLabel>처리일</DetailFieldLabel>
-                    <DetailFieldValue>{formatLessonExchangeDate(detail?.processedAt)}</DetailFieldValue>
-                  </DetailField>
-                  <DetailField>
-                    <DetailFieldLabel>완료일</DetailFieldLabel>
-                    <DetailFieldValue>{formatLessonExchangeDate(detail?.completedAt)}</DetailFieldValue>
-                  </DetailField>
-                  <DetailField>
-                    <DetailFieldLabel>취소일</DetailFieldLabel>
-                    <DetailFieldValue>{formatLessonExchangeDate(detail?.cancelledAt)}</DetailFieldValue>
-                  </DetailField>
-              </ProcessingMetaFields>
-            ) : null}
+              {hasSupplementalContent ? (
+                <SupplementalSection>
+                  <CompactDivider />
 
-            <ActionDivider />
-          </ContentSection>
+                  {rejectionNote ? (
+                    <DetailField $fullWidth $compact>
+                      <DetailFieldLabel>반려 사유</DetailFieldLabel>
+                      <DetailNoteBox>{rejectionNote}</DetailNoteBox>
+                    </DetailField>
+                  ) : null}
 
-          <ActionSection>
-            <DetailFieldLabel>처리</DetailFieldLabel>
-            {isExpired ? (
-              <UnavailableBadge>만료된 요청으로 처리불가</UnavailableBadge>
-            ) : isProcessed ? (
-              <ProcessedBadge>처리 완료</ProcessedBadge>
-            ) : (
-              <FormGrid onSubmit={(event) => event.preventDefault()}>
-                <RejectNoteTextArea
-                  value={rejectNote}
-                  placeholder="반려 사유를 입력해 주세요."
-                  disabled={isActionPending}
-                  onChange={(event) => setRejectNote(event.target.value)}
-                />
-                <ButtonRow>
-                  <PrimaryButton type="button" disabled={isActionPending} onClick={handleApprove}>
-                    승인
-                  </PrimaryButton>
-                  <DangerButton
-                    type="button"
-                    disabled={isActionPending || !rejectNote.trim()}
-                    onClick={handleReject}
-                  >
-                    반려
-                  </DangerButton>
-                </ButtonRow>
-              </FormGrid>
-            )}
-          </ActionSection>
+                  {showProcessingMeta ? (
+                    <ProcessingMetaFields>
+                      <LessonExchangeDetailFieldItems
+                        fields={LESSON_EXCHANGE_PROCESSING_META_FIELDS}
+                        detail={detail}
+                      />
+                    </ProcessingMetaFields>
+                  ) : null}
+                </SupplementalSection>
+              ) : null}
+            </ContentSection>
+
+            {hasSupplementalContent ? <CompactDivider /> : null}
+
+            <ActionSection>
+              <DetailFieldLabel>처리</DetailFieldLabel>
+              {actionState === "expired" ? (
+                <UnavailableBadge>만료된 요청으로 처리불가</UnavailableBadge>
+              ) : null}
+              {actionState === "processed" ? <ProcessedBadge>처리 완료</ProcessedBadge> : null}
+              {actionState === "actionable" ? (
+                <FormGrid onSubmit={(event) => event.preventDefault()}>
+                  <RejectNoteTextArea
+                    value={rejectNote}
+                    placeholder="반려 사유를 입력해 주세요."
+                    disabled={isActionPending}
+                    onChange={(event) => setRejectNote(event.target.value)}
+                  />
+                  <ButtonRow>
+                    <PrimaryButton type="button" disabled={isActionPending} onClick={handleApprove}>
+                      승인
+                    </PrimaryButton>
+                    <DangerButton
+                      type="button"
+                      disabled={isActionPending || !rejectNote.trim()}
+                      onClick={handleReject}
+                    >
+                      반려
+                    </DangerButton>
+                  </ButtonRow>
+                </FormGrid>
+              ) : null}
+            </ActionSection>
+          </DetailLowerBlock>
         </DetailStack>
       </DataState>
     </SectionCard>
@@ -198,13 +164,6 @@ const DetailFieldLabel = styled.span`
   line-height: ${typography.lineHeight130};
 `;
 
-const DetailFieldValue = styled.div`
-  color: #1f2b28;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight150};
-  word-break: break-word;
-`;
-
 const DetailTextBox = styled.div`
   padding: ${spacing.space8} ${spacing.space12};
   border: 1px solid #e6e9e7;
@@ -224,33 +183,36 @@ const DetailNoteBox = styled(DetailTextBox)`
 
 const CompactDivider = styled.hr`
   width: 100%;
-  margin: ${spacing.space8} 0;
+  margin: 0;
   border: 0;
   border-top: 1px solid #e6e9e7;
 `;
 
-const ActionDivider = styled(CompactDivider)`
-  margin-top: ${spacing.space4};
-  margin-bottom: ${spacing.space4};
+const DetailLowerBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
 `;
 
 const ContentSection = styled.section`
   display: grid;
-  gap: ${spacing.space8};
+  gap: ${spacing.space12};
   margin: 0;
 `;
 
-const ProcessingMetaFields = styled.div<{ $spacedFromRejection?: boolean }>`
+const SupplementalSection = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const ProcessingMetaFields = styled.div`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: ${spacing.space16};
-  margin-top: ${({ $spacedFromRejection }) => ($spacedFromRejection ? spacing.space8 : "0")};
 `;
 
 const ActionSection = styled.section`
   display: grid;
   gap: ${spacing.space12};
-  margin-top: -${spacing.space8};
 `;
 
 const RejectNoteTextArea = styled(TextArea)`

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
@@ -23,38 +23,28 @@ import { colors, spacing, typography } from "@/styles/tokens";
 const TABLE_HEADER_HEIGHT = "2.5rem";
 const TABLE_ROW_HEIGHT = "3.75rem";
 
-type AdminLessonExchangeRequestsListPanelProps = Pick<
-  AdminLessonExchangeRequestsViewModel,
-  | "statusFilter"
-  | "keywordInput"
-  | "setKeywordInput"
-  | "handleSearch"
-  | "handleStatusFilterChange"
-  | "lessonExchangeRequestsQuery"
-  | "sortedRequests"
-  | "selectedRequestId"
-  | "selectLessonExchangeRequest"
-  | "currentPage"
-  | "totalPages"
-  | "goToPrevPage"
-  | "goToNextPage"
->;
+type AdminLessonExchangeRequestsListPanelProps = {
+  viewModel: AdminLessonExchangeRequestsViewModel;
+};
 
 export function AdminLessonExchangeRequestsListPanel({
-  statusFilter,
-  keywordInput,
-  setKeywordInput,
-  handleSearch,
-  handleStatusFilterChange,
-  lessonExchangeRequestsQuery,
-  sortedRequests,
-  selectedRequestId,
-  selectLessonExchangeRequest,
-  currentPage,
-  totalPages,
-  goToPrevPage,
-  goToNextPage,
+  viewModel,
 }: AdminLessonExchangeRequestsListPanelProps) {
+  const {
+    statusFilter,
+    keywordInput,
+    setKeywordInput,
+    handleSearch,
+    handleStatusFilterChange,
+    lessonExchangeRequestsQuery,
+    sortedRequests,
+    selectedRequestId,
+    selectLessonExchangeRequest,
+    currentPage,
+    totalPages,
+    goToPrevPage,
+    goToNextPage,
+  } = viewModel;
   const isLoading = lessonExchangeRequestsQuery.isLoading;
   const isError = lessonExchangeRequestsQuery.isError;
   const isEmpty = !isLoading && !isError && sortedRequests.length === 0;

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import styled from "styled-components";
+import {
+  LESSON_EXCHANGE_ITEMS_PER_PAGE,
+  LESSON_EXCHANGE_STATUS_OPTIONS,
+  type LessonExchangeStatusFilter,
+} from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
+import { LessonExchangeStatusBadge } from "@/components/admin/lesson-exchange/LessonExchangeStatusBadge";
+import type { AdminLessonExchangeRequestsViewModel } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
+import {
+  ControlRow,
+  SectionCard,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextInput,
+} from "@/components/admin/AdminDashboardSectionParts";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+const TABLE_HEADER_HEIGHT = "2.5rem";
+const TABLE_ROW_HEIGHT = "3.75rem";
+
+type AdminLessonExchangeRequestsListPanelProps = Pick<
+  AdminLessonExchangeRequestsViewModel,
+  | "statusFilter"
+  | "keywordInput"
+  | "setKeywordInput"
+  | "handleSearch"
+  | "handleStatusFilterChange"
+  | "lessonExchangeRequestsQuery"
+  | "sortedRequests"
+  | "selectedRequestId"
+  | "selectLessonExchangeRequest"
+  | "currentPage"
+  | "totalPages"
+  | "goToPrevPage"
+  | "goToNextPage"
+>;
+
+export function AdminLessonExchangeRequestsListPanel({
+  statusFilter,
+  keywordInput,
+  setKeywordInput,
+  handleSearch,
+  handleStatusFilterChange,
+  lessonExchangeRequestsQuery,
+  sortedRequests,
+  selectedRequestId,
+  selectLessonExchangeRequest,
+  currentPage,
+  totalPages,
+  goToPrevPage,
+  goToNextPage,
+}: AdminLessonExchangeRequestsListPanelProps) {
+  const isLoading = lessonExchangeRequestsQuery.isLoading;
+  const isError = lessonExchangeRequestsQuery.isError;
+  const isEmpty = !isLoading && !isError && sortedRequests.length === 0;
+
+  return (
+    <SectionCard>
+      <SectionTitle>수업 교환 요청 목록</SectionTitle>
+      <ControlRow
+        as="form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSearch();
+        }}
+      >
+        <StatusSelect
+          value={statusFilter}
+          onChange={(event) =>
+            handleStatusFilterChange(event.target.value as LessonExchangeStatusFilter)
+          }
+        >
+          {LESSON_EXCHANGE_STATUS_OPTIONS.map((option) => (
+            <option key={option.label} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </StatusSelect>
+        <KeywordInput
+          value={keywordInput}
+          placeholder="검색어"
+          onChange={(event) => setKeywordInput(event.target.value)}
+        />
+        <SmallButton type="submit">검색</SmallButton>
+      </ControlRow>
+
+      <ListTableArea>
+        <TableViewport>
+          {isLoading ? (
+            <ListOverlay>
+              <LoadingSpinner label="수업 교환 요청 목록 불러오는 중" />
+            </ListOverlay>
+          ) : null}
+          {isError ? (
+            <ListOverlay role="alert">
+              <ListOverlayMessage>수업 교환 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
+            </ListOverlay>
+          ) : null}
+          {isEmpty ? (
+            <ListOverlay>
+              <ListOverlayMessage>수업 교환 요청이 없습니다.</ListOverlayMessage>
+            </ListOverlay>
+          ) : null}
+
+          <LessonExchangeListTable>
+            <thead>
+              <tr>
+                <th>제목</th>
+                <th>분반</th>
+                <th>요청자</th>
+                <th>상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRequests.map((item) => (
+                <LessonExchangeTableRow
+                  key={item.id}
+                  $selected={item.id === selectedRequestId}
+                  onClick={() => selectLessonExchangeRequest(item)}
+                >
+                  <td>{item.title ?? "-"}</td>
+                  <td>{item.classroomName ?? "-"}</td>
+                  <td>{item.requestedByName ?? "-"}</td>
+                  <td>
+                    <LessonExchangeStatusBadge status={item.status} />
+                  </td>
+                </LessonExchangeTableRow>
+              ))}
+            </tbody>
+          </LessonExchangeListTable>
+        </TableViewport>
+
+        <PaginationNav aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={currentPage <= 1 || lessonExchangeRequestsQuery.isFetching}
+            onClick={goToPrevPage}
+          >
+            ‹
+          </PageArrowButton>
+          <PageIndicator>
+            {currentPage} / {totalPages}
+          </PageIndicator>
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={currentPage >= totalPages || lessonExchangeRequestsQuery.isFetching}
+            onClick={goToNextPage}
+          >
+            ›
+          </PageArrowButton>
+        </PaginationNav>
+      </ListTableArea>
+    </SectionCard>
+  );
+}
+
+const ListTableArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: calc(
+    ${TABLE_HEADER_HEIGHT} + ${LESSON_EXCHANGE_ITEMS_PER_PAGE} * ${TABLE_ROW_HEIGHT} + 2.75rem
+  );
+`;
+
+const TableViewport = styled.div`
+  position: relative;
+  flex: 1 1 auto;
+`;
+
+const ListOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(255 255 255 / 72%);
+`;
+
+const ListOverlayMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const LessonExchangeTableRow = styled.tr<{ $selected: boolean }>`
+  height: ${TABLE_ROW_HEIGHT};
+  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : "transparent")};
+`;
+
+const LessonExchangeListTable = styled(Table)`
+  th,
+  td {
+    vertical-align: middle;
+  }
+
+  thead tr {
+    height: ${TABLE_HEADER_HEIGHT};
+  }
+
+  tbody tr {
+    height: ${TABLE_ROW_HEIGHT};
+  }
+
+  th:last-child,
+  td:last-child {
+    width: 1%;
+    white-space: nowrap;
+  }
+`;
+
+const StatusSelect = styled(Select)`
+  max-width: 10rem;
+`;
+
+const KeywordInput = styled(TextInput)`
+  max-width: 16rem;
+`;
+
+const PaginationNav = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space8};
+  margin-top: auto;
+  padding-top: ${spacing.space12};
+  flex-shrink: 0;
+`;
+
+const PageArrowButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid #e6e9e7;
+  border-radius: 999px;
+  background: ${colors.white};
+  color: #64706c;
+  font-family: inherit;
+  font-size: 1.125rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    border-color: #88cd5a;
+    background: #f5fff0;
+    color: #5eb63a;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
+  }
+`;
+
+const PageIndicator = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.75rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 999px;
+  background: #f4f6f5;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
@@ -1,5 +1,39 @@
 "use client";
 
+import { AdminLessonExchangeRequestsDetailPanel } from "@/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel";
+import { AdminLessonExchangeRequestsListPanel } from "@/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel";
+import { useAdminLessonExchangeRequests } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
+import { TwoColumnGrid } from "@/components/admin/AdminDashboardSectionParts";
+
 export function AdminLessonExchangeSection() {
-  return null;
+  const lessonExchangeRequests = useAdminLessonExchangeRequests();
+
+  return (
+    <TwoColumnGrid>
+      <AdminLessonExchangeRequestsListPanel
+        statusFilter={lessonExchangeRequests.statusFilter}
+        keywordInput={lessonExchangeRequests.keywordInput}
+        setKeywordInput={lessonExchangeRequests.setKeywordInput}
+        handleSearch={lessonExchangeRequests.handleSearch}
+        handleStatusFilterChange={lessonExchangeRequests.handleStatusFilterChange}
+        lessonExchangeRequestsQuery={lessonExchangeRequests.lessonExchangeRequestsQuery}
+        sortedRequests={lessonExchangeRequests.sortedRequests}
+        selectedRequestId={lessonExchangeRequests.selectedRequestId}
+        selectLessonExchangeRequest={lessonExchangeRequests.selectLessonExchangeRequest}
+        currentPage={lessonExchangeRequests.currentPage}
+        totalPages={lessonExchangeRequests.totalPages}
+        goToPrevPage={lessonExchangeRequests.goToPrevPage}
+        goToNextPage={lessonExchangeRequests.goToNextPage}
+      />
+      <AdminLessonExchangeRequestsDetailPanel
+        selectedRequestId={lessonExchangeRequests.selectedRequestId}
+        lessonExchangeDetailQuery={lessonExchangeRequests.lessonExchangeDetailQuery}
+        rejectNote={lessonExchangeRequests.rejectNote}
+        setRejectNote={lessonExchangeRequests.setRejectNote}
+        handleApprove={lessonExchangeRequests.handleApprove}
+        handleReject={lessonExchangeRequests.handleReject}
+        isActionPending={lessonExchangeRequests.isActionPending}
+      />
+    </TwoColumnGrid>
+  );
 }

--- a/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export function AdminLessonExchangeSection() {
+  return null;
+}

--- a/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
@@ -6,34 +6,12 @@ import { useAdminLessonExchangeRequests } from "@/components/admin/lesson-exchan
 import { TwoColumnGrid } from "@/components/admin/AdminDashboardSectionParts";
 
 export function AdminLessonExchangeSection() {
-  const lessonExchangeRequests = useAdminLessonExchangeRequests();
+  const viewModel = useAdminLessonExchangeRequests();
 
   return (
     <TwoColumnGrid>
-      <AdminLessonExchangeRequestsListPanel
-        statusFilter={lessonExchangeRequests.statusFilter}
-        keywordInput={lessonExchangeRequests.keywordInput}
-        setKeywordInput={lessonExchangeRequests.setKeywordInput}
-        handleSearch={lessonExchangeRequests.handleSearch}
-        handleStatusFilterChange={lessonExchangeRequests.handleStatusFilterChange}
-        lessonExchangeRequestsQuery={lessonExchangeRequests.lessonExchangeRequestsQuery}
-        sortedRequests={lessonExchangeRequests.sortedRequests}
-        selectedRequestId={lessonExchangeRequests.selectedRequestId}
-        selectLessonExchangeRequest={lessonExchangeRequests.selectLessonExchangeRequest}
-        currentPage={lessonExchangeRequests.currentPage}
-        totalPages={lessonExchangeRequests.totalPages}
-        goToPrevPage={lessonExchangeRequests.goToPrevPage}
-        goToNextPage={lessonExchangeRequests.goToNextPage}
-      />
-      <AdminLessonExchangeRequestsDetailPanel
-        selectedRequestId={lessonExchangeRequests.selectedRequestId}
-        lessonExchangeDetailQuery={lessonExchangeRequests.lessonExchangeDetailQuery}
-        rejectNote={lessonExchangeRequests.rejectNote}
-        setRejectNote={lessonExchangeRequests.setRejectNote}
-        handleApprove={lessonExchangeRequests.handleApprove}
-        handleReject={lessonExchangeRequests.handleReject}
-        isActionPending={lessonExchangeRequests.isActionPending}
-      />
+      <AdminLessonExchangeRequestsListPanel viewModel={viewModel} />
+      <AdminLessonExchangeRequestsDetailPanel viewModel={viewModel} />
     </TwoColumnGrid>
   );
 }

--- a/components/admin/lesson-exchange/LessonExchangeDetailFieldItems.tsx
+++ b/components/admin/lesson-exchange/LessonExchangeDetailFieldItems.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import styled from "styled-components";
+import type { LessonExchangeDetailFieldConfig } from "@/components/admin/lesson-exchange/lessonExchangeDetailFields";
+import type { LessonExchangeRequestDetailDto } from "@/api/lessonExchange/lessonExchange.dto";
+import { spacing, typography } from "@/styles/tokens";
+
+type LessonExchangeDetailFieldItemsProps = {
+  fields: LessonExchangeDetailFieldConfig[];
+  detail?: LessonExchangeRequestDetailDto;
+  compact?: boolean;
+};
+
+export function LessonExchangeDetailFieldItems({
+  fields,
+  detail,
+  compact = false,
+}: LessonExchangeDetailFieldItemsProps) {
+  return (
+    <>
+      {fields.map((field) => (
+        <DetailField key={field.label} $fullWidth={field.fullWidth} $compact={compact}>
+          <DetailFieldLabel>{field.label}</DetailFieldLabel>
+          <DetailFieldValue>{field.render(detail)}</DetailFieldValue>
+        </DetailField>
+      ))}
+    </>
+  );
+}
+
+const DetailField = styled.div<{ $fullWidth?: boolean; $compact?: boolean }>`
+  display: grid;
+  gap: ${({ $compact }) => ($compact ? spacing.space4 : spacing.space8)};
+  min-width: 0;
+  grid-column: ${({ $fullWidth }) => ($fullWidth ? "1 / -1" : "auto")};
+`;
+
+const DetailFieldLabel = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const DetailFieldValue = styled.div`
+  color: #1f2b28;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  word-break: break-word;
+`;

--- a/components/admin/lesson-exchange/LessonExchangeStatusBadge.tsx
+++ b/components/admin/lesson-exchange/LessonExchangeStatusBadge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import styled from "styled-components";
+import type { LessonExchangeRequestStatus } from "@/api/lessonExchange/lessonExchange.dto";
+import { formatLessonExchangeStatus } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
+import { typography } from "@/styles/tokens";
+
+export function LessonExchangeStatusBadge({ status }: { status?: LessonExchangeRequestStatus }) {
+  if (!status) return <>-</>;
+
+  return <Badge $status={status}>{formatLessonExchangeStatus(status)}</Badge>;
+}
+
+const Badge = styled.span<{ $status: LessonExchangeRequestStatus }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 3.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+
+  color: ${({ $status }) => {
+    switch ($status) {
+      case "APPROVED":
+      case "COMPLETED":
+        return "#3DA75C";
+      case "REJECTED":
+        return "#DA3A30";
+      case "CANCELLED":
+        return "#64706C";
+      case "EXPIRED":
+        return "#B45F06";
+      case "PENDING":
+      default:
+        return "#E5AD34";
+    }
+  }};
+
+  background: ${({ $status }) => {
+    switch ($status) {
+      case "APPROVED":
+      case "COMPLETED":
+        return "#DCF4EA";
+      case "REJECTED":
+        return "#FDEBE9";
+      case "CANCELLED":
+        return "#EEF0EF";
+      case "EXPIRED":
+        return "#FFF3E0";
+      case "PENDING":
+      default:
+        return "#FFF6DB";
+    }
+  }};
+`;

--- a/components/admin/lesson-exchange/lessonExchangeDetailFields.tsx
+++ b/components/admin/lesson-exchange/lessonExchangeDetailFields.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { LessonExchangeRequestDetailDto } from "@/api/lessonExchange/lessonExchange.dto";
+import { formatLessonExchangeDate } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
+import { LessonExchangeStatusBadge } from "@/components/admin/lesson-exchange/LessonExchangeStatusBadge";
+
+export type LessonExchangeDetailFieldConfig = {
+  label: string;
+  fullWidth?: boolean;
+  render: (detail?: LessonExchangeRequestDetailDto) => ReactNode;
+};
+
+export const LESSON_EXCHANGE_BASIC_DETAIL_FIELDS: LessonExchangeDetailFieldConfig[] = [
+  {
+    label: "제목",
+    fullWidth: true,
+    render: (detail) => detail?.title ?? "-",
+  },
+  {
+    label: "분반",
+    render: (detail) => detail?.classroomName ?? "-",
+  },
+  {
+    label: "요청자",
+    render: (detail) => detail?.requestedByName ?? "-",
+  },
+  {
+    label: "수업일",
+    render: (detail) => formatLessonExchangeDate(detail?.lessonDate),
+  },
+  {
+    label: "만료일",
+    render: (detail) => formatLessonExchangeDate(detail?.expiresAt),
+  },
+  {
+    label: "요청일",
+    render: (detail) => formatLessonExchangeDate(detail?.createdAt),
+  },
+  {
+    label: "상태",
+    render: (detail) => <LessonExchangeStatusBadge status={detail?.status} />,
+  },
+];
+
+export const LESSON_EXCHANGE_PROCESSING_META_FIELDS: LessonExchangeDetailFieldConfig[] = [
+  {
+    label: "처리자",
+    render: (detail) => detail?.processedByName ?? "-",
+  },
+  {
+    label: "처리일",
+    render: (detail) => formatLessonExchangeDate(detail?.processedAt),
+  },
+  {
+    label: "완료일",
+    render: (detail) => formatLessonExchangeDate(detail?.completedAt),
+  },
+  {
+    label: "취소일",
+    render: (detail) => formatLessonExchangeDate(detail?.cancelledAt),
+  },
+];

--- a/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
+++ b/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
@@ -1,0 +1,33 @@
+import type { LessonExchangeRequestStatus } from "@/api/lessonExchange/lessonExchange.dto";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+export const LESSON_EXCHANGE_ITEMS_PER_PAGE = 8;
+
+export const LESSON_EXCHANGE_STATUS_OPTIONS = [
+  { value: "", label: "전체" },
+  { value: "PENDING", label: "승인 대기" },
+  { value: "APPROVED", label: "승인" },
+  { value: "REJECTED", label: "반려" },
+  { value: "CANCELLED", label: "취소" },
+  { value: "EXPIRED", label: "만료" },
+] as const;
+
+export type LessonExchangeStatusFilter = (typeof LESSON_EXCHANGE_STATUS_OPTIONS)[number]["value"];
+
+const LESSON_EXCHANGE_STATUS_LABELS: Record<string, string> = {
+  PENDING: "승인 대기",
+  APPROVED: "승인",
+  REJECTED: "반려",
+  CANCELLED: "취소",
+  EXPIRED: "만료",
+  COMPLETED: "완료",
+};
+
+export function formatLessonExchangeStatus(status?: LessonExchangeRequestStatus) {
+  if (!status) return "-";
+  return LESSON_EXCHANGE_STATUS_LABELS[status] ?? "-";
+}
+
+export function formatLessonExchangeDate(value?: string) {
+  return value ? formatUtcToKstShortDate(value) : "-";
+}

--- a/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
+++ b/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
@@ -1,5 +1,17 @@
-import type { LessonExchangeRequestStatus } from "@/api/lessonExchange/lessonExchange.dto";
+import type {
+  LessonExchangeRequestDetailDto,
+  LessonExchangeRequestStatus,
+} from "@/api/lessonExchange/lessonExchange.dto";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+const TERMINAL_LESSON_EXCHANGE_STATUSES: LessonExchangeRequestStatus[] = [
+  "APPROVED",
+  "REJECTED",
+  "COMPLETED",
+  "CANCELLED",
+];
+
+export type LessonExchangeDetailActionState = "empty" | "actionable" | "processed" | "expired";
 
 export const LESSON_EXCHANGE_ITEMS_PER_PAGE = 8;
 
@@ -30,4 +42,48 @@ export function formatLessonExchangeStatus(status?: LessonExchangeRequestStatus)
 
 export function formatLessonExchangeDate(value?: string) {
   return value ? formatUtcToKstShortDate(value) : "-";
+}
+
+export function isLessonExchangeTerminalStatus(status?: LessonExchangeRequestStatus) {
+  if (!status) return false;
+  return TERMINAL_LESSON_EXCHANGE_STATUSES.includes(status);
+}
+
+export function isLessonExchangeExpired(detail?: LessonExchangeRequestDetailDto) {
+  return detail?.status === "EXPIRED";
+}
+
+/** 처리 완료·종료 상태(승인/반려/완료/취소) 또는 processedAt 존재 */
+export function isLessonExchangeProcessed(detail?: LessonExchangeRequestDetailDto) {
+  if (!detail) return false;
+  return Boolean(detail.processedAt) || isLessonExchangeTerminalStatus(detail.status);
+}
+
+export function shouldShowLessonExchangeProcessingMeta(detail?: LessonExchangeRequestDetailDto) {
+  return isLessonExchangeProcessed(detail);
+}
+
+export function canProcessLessonExchangeRequest(detail?: LessonExchangeRequestDetailDto) {
+  if (!detail || isLessonExchangeExpired(detail)) return false;
+  return detail.status === "PENDING" && !isLessonExchangeProcessed(detail);
+}
+
+export function getLessonExchangeRejectionNote(detail?: LessonExchangeRequestDetailDto) {
+  return detail?.rejectionNote?.trim() ?? "";
+}
+
+export function hasLessonExchangeSupplementalContent(detail?: LessonExchangeRequestDetailDto) {
+  return Boolean(
+    getLessonExchangeRejectionNote(detail) || shouldShowLessonExchangeProcessingMeta(detail),
+  );
+}
+
+export function getLessonExchangeDetailActionState(
+  detail?: LessonExchangeRequestDetailDto,
+): LessonExchangeDetailActionState {
+  if (!detail) return "empty";
+  if (isLessonExchangeExpired(detail)) return "expired";
+  if (canProcessLessonExchangeRequest(detail)) return "actionable";
+  if (isLessonExchangeProcessed(detail)) return "processed";
+  return "empty";
 }

--- a/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
+++ b/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  approveLessonExchangeRequest,
+  getLessonExchangeRequestDetail,
+  getLessonExchangeRequests,
+  rejectLessonExchangeRequest,
+} from "@/api/lessonExchange/lessonExchange.api";
+import type {
+  LessonExchangeListQueryParamsDto,
+  LessonExchangeRequestListItemDto,
+} from "@/api/lessonExchange/lessonExchange.dto";
+import {
+  LESSON_EXCHANGE_ITEMS_PER_PAGE,
+  type LessonExchangeStatusFilter,
+} from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useAdminLessonExchangeRequests() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<LessonExchangeStatusFilter>("");
+  const [keywordInput, setKeywordInput] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(1);
+  const [selectedRequestId, setSelectedRequestId] = useState<number | null>(null);
+  const [rejectNote, setRejectNote] = useState("");
+  const [pendingActionId, setPendingActionId] = useState<number | null>(null);
+
+  const lessonExchangeRequestsQuery = useQuery({
+    queryKey: [
+      ...queryKeys.requests.lessonExchangeList(),
+      "admin",
+      statusFilter,
+      keyword,
+      page,
+      LESSON_EXCHANGE_ITEMS_PER_PAGE,
+    ],
+    queryFn: () => {
+      const query: LessonExchangeListQueryParamsDto = {
+        keyword: keyword.trim() || undefined,
+        page: page - 1,
+        size: LESSON_EXCHANGE_ITEMS_PER_PAGE,
+      };
+
+      if (statusFilter) {
+        query.status = statusFilter;
+      }
+
+      return getLessonExchangeRequests(query);
+    },
+  });
+
+  const lessonExchangeRequests = lessonExchangeRequestsQuery.data?.content ?? [];
+  const totalPages = Math.max(1, lessonExchangeRequestsQuery.data?.totalPages ?? 1);
+  const currentPage = page <= totalPages ? page : totalPages;
+
+  const lessonExchangeDetailQuery = useQuery({
+    queryKey: queryKeys.requests.lessonExchangeDetail(selectedRequestId ?? 0),
+    queryFn: () => getLessonExchangeRequestDetail({ requestId: selectedRequestId! }),
+    enabled: selectedRequestId !== null,
+  });
+
+  const invalidateQueries = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.requests.lessonExchangeList() });
+    if (selectedRequestId !== null) {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeDetail(selectedRequestId),
+      });
+    }
+  };
+
+  const approveMutation = useMutation({
+    mutationFn: (requestId: number) => approveLessonExchangeRequest({ requestId }),
+    onMutate: (requestId) => {
+      setPendingActionId(requestId);
+    },
+    onSuccess: () => {
+      invalidateQueries();
+      setRejectNote("");
+    },
+    onSettled: () => {
+      setPendingActionId(null);
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ requestId, note }: { requestId: number; note: string }) =>
+      rejectLessonExchangeRequest({ requestId }, { note }),
+    onMutate: ({ requestId }) => {
+      setPendingActionId(requestId);
+    },
+    onSuccess: () => {
+      invalidateQueries();
+      setRejectNote("");
+    },
+    onSettled: () => {
+      setPendingActionId(null);
+    },
+  });
+
+  const sortedRequests = useMemo(
+    () =>
+      [...lessonExchangeRequests].sort((a, b) => {
+        const aTime = new Date(a.createdAt ?? 0).getTime();
+        const bTime = new Date(b.createdAt ?? 0).getTime();
+        return bTime - aTime;
+      }),
+    [lessonExchangeRequests],
+  );
+
+  const resetSelection = () => {
+    setSelectedRequestId(null);
+    setRejectNote("");
+  };
+
+  const handleSearch = () => {
+    setKeyword(keywordInput);
+    setPage(1);
+    resetSelection();
+  };
+
+  const handleStatusFilterChange = (value: LessonExchangeStatusFilter) => {
+    setStatusFilter(value);
+    setPage(1);
+    resetSelection();
+  };
+
+  const selectLessonExchangeRequest = (item: LessonExchangeRequestListItemDto) => {
+    setSelectedRequestId(item.id);
+    setRejectNote("");
+  };
+
+  const handleApprove = () => {
+    if (!selectedRequestId || approveMutation.isPending) return;
+    approveMutation.mutate(selectedRequestId);
+  };
+
+  const handleReject = () => {
+    if (!selectedRequestId || rejectMutation.isPending) return;
+
+    const note = rejectNote.trim();
+    if (!note) return;
+
+    rejectMutation.mutate({ requestId: selectedRequestId, note });
+  };
+
+  const isActionPending =
+    pendingActionId === selectedRequestId &&
+    (approveMutation.isPending || rejectMutation.isPending);
+
+  const goToPrevPage = () => {
+    setPage((current) => Math.max(1, current - 1));
+    resetSelection();
+  };
+
+  const goToNextPage = () => {
+    setPage((current) => Math.min(totalPages, current + 1));
+    resetSelection();
+  };
+
+  return {
+    statusFilter,
+    keywordInput,
+    setKeywordInput,
+    handleSearch,
+    handleStatusFilterChange,
+    lessonExchangeRequestsQuery,
+    sortedRequests,
+    selectedRequestId,
+    lessonExchangeDetailQuery,
+    selectLessonExchangeRequest,
+    currentPage,
+    totalPages,
+    goToPrevPage,
+    goToNextPage,
+    rejectNote,
+    setRejectNote,
+    handleApprove,
+    handleReject,
+    isActionPending,
+  };
+}
+
+export type AdminLessonExchangeRequestsViewModel = ReturnType<typeof useAdminLessonExchangeRequests>;

--- a/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
+++ b/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
@@ -13,6 +13,7 @@ import type {
   LessonExchangeRequestListItemDto,
 } from "@/api/lessonExchange/lessonExchange.dto";
 import {
+  canProcessLessonExchangeRequest,
   LESSON_EXCHANGE_ITEMS_PER_PAGE,
   type LessonExchangeStatusFilter,
 } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
@@ -133,12 +134,19 @@ export function useAdminLessonExchangeRequests() {
   };
 
   const handleApprove = () => {
-    if (!selectedRequestId || approveMutation.isPending) return;
+    const detail = lessonExchangeDetailQuery.data;
+    if (!selectedRequestId || approveMutation.isPending || !canProcessLessonExchangeRequest(detail)) {
+      return;
+    }
+
     approveMutation.mutate(selectedRequestId);
   };
 
   const handleReject = () => {
-    if (!selectedRequestId || rejectMutation.isPending) return;
+    const detail = lessonExchangeDetailQuery.data;
+    if (!selectedRequestId || rejectMutation.isPending || !canProcessLessonExchangeRequest(detail)) {
+      return;
+    }
 
     const note = rejectNote.trim();
     if (!note) return;

--- a/components/admin/subjects/create/AdminSubjectCreateForm.tsx
+++ b/components/admin/subjects/create/AdminSubjectCreateForm.tsx
@@ -44,6 +44,11 @@ const ChoiceGrid = styled.div`
   gap: ${spacing.space8};
 `;
 
+const ChoiceStack = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
 const ChoiceButton = styled.button<{ $selected: boolean }>`
   display: flex;
   flex-direction: column;
@@ -77,6 +82,27 @@ const ChoiceMeta = styled.span`
   font-size: ${typography.fontSize13};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
+`;
+
+const CenteredChoiceButton = styled(ChoiceButton)`
+  position: relative;
+  text-align: center;
+`;
+
+const CenteredChoiceTitle = styled(ChoiceTitle)`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+const ChoiceHeightPlaceholder = styled.div`
+  visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space4};
 `;
 
 const DayChoiceButton = styled(ChoiceButton)`
@@ -129,9 +155,8 @@ export function AdminSubjectCreateForm() {
   });
 
   const teachersQuery = useQuery({
-    queryKey: ["admin", "subjects", "teachers", { role: "VOLUNTEER", currentTeacher: true }],
-    queryFn: () =>
-      getUsers({ role: "VOLUNTEER", currentTeacher: true, page: 0, size: 100 }),
+    queryKey: ["admin", "subjects", "teachers", { role: "VOLUNTEER" }],
+    queryFn: () => getUsers({ role: "VOLUNTEER", page: 0, size: 100 }),
   });
 
   const classrooms = classroomsQuery.data?.content ?? [];
@@ -192,6 +217,18 @@ export function AdminSubjectCreateForm() {
     <form onSubmit={handleSubmit}>
       <SubjectFormGrid>
         <SubjectLabel>
+          과목명
+          <TextInput
+            value={name}
+            onChange={(event) => {
+              setSubmitError(null);
+              setName(event.target.value);
+            }}
+            required
+          />
+        </SubjectLabel>
+
+        <SubjectLabel>
           분반
           <DataState
             isLoading={classroomsQuery.isLoading}
@@ -229,15 +266,62 @@ export function AdminSubjectCreateForm() {
         </SubjectLabel>
 
         <SubjectLabel>
-          과목명
-          <TextInput
-            value={name}
-            onChange={(event) => {
-              setSubmitError(null);
-              setName(event.target.value);
-            }}
-            required
-          />
+          담당 교사
+          <ChoiceStack>
+            <ChoiceGrid>
+              <CenteredChoiceButton
+                type="button"
+                $selected={teacherSelection === TEACHER_UNSELECTED}
+                aria-pressed={teacherSelection === TEACHER_UNSELECTED}
+                onClick={() => {
+                  setSubmitError(null);
+                  setTeacherSelection(TEACHER_UNSELECTED);
+                }}
+              >
+                <ChoiceHeightPlaceholder aria-hidden>
+                  <ChoiceTitle>{"\u00A0"}</ChoiceTitle>
+                  <ChoiceMeta>{"\u00A0"}</ChoiceMeta>
+                </ChoiceHeightPlaceholder>
+                <CenteredChoiceTitle $selected={teacherSelection === TEACHER_UNSELECTED}>
+                  교사 미지정
+                </CenteredChoiceTitle>
+              </CenteredChoiceButton>
+            </ChoiceGrid>
+            <DataState
+              compact
+              isLoading={teachersQuery.isLoading}
+              isError={teachersQuery.isError}
+              isEmpty={teachers.length === 0}
+              loadingLabel="교사 목록 불러오는 중"
+              errorLabel="교사 목록을 불러오지 못했습니다."
+              emptyLabel="활동 중인 교사가 없습니다."
+            >
+              <ChoiceGrid>
+                {teachers.map((teacher) => {
+                  const id = getUserId(teacher);
+                  if (id == null) return null;
+
+                  const isSelected = teacherSelection === id;
+
+                  return (
+                    <ChoiceButton
+                      key={id}
+                      type="button"
+                      $selected={isSelected}
+                      aria-pressed={isSelected}
+                      onClick={() => {
+                        setSubmitError(null);
+                        setTeacherSelection(id);
+                      }}
+                    >
+                      <ChoiceTitle $selected={isSelected}>{teacher.name ?? "—"}</ChoiceTitle>
+                      {teacher.email ? <ChoiceMeta>{teacher.email}</ChoiceMeta> : null}
+                    </ChoiceButton>
+                  );
+                })}
+              </ChoiceGrid>
+            </DataState>
+          </ChoiceStack>
         </SubjectLabel>
 
         <DateRow>
@@ -311,57 +395,6 @@ export function AdminSubjectCreateForm() {
             }}
             required
           />
-        </SubjectLabel>
-
-        <SubjectLabel>
-          담당 교사
-          <ChoiceGrid>
-            <ChoiceButton
-              type="button"
-              $selected={teacherSelection === TEACHER_UNSELECTED}
-              aria-pressed={teacherSelection === TEACHER_UNSELECTED}
-              onClick={() => {
-                setSubmitError(null);
-                setTeacherSelection(TEACHER_UNSELECTED);
-              }}
-            >
-              <ChoiceTitle $selected={teacherSelection === TEACHER_UNSELECTED}>
-                교사 미선택
-              </ChoiceTitle>
-            </ChoiceButton>
-            <DataState
-              compact
-              isLoading={teachersQuery.isLoading}
-              isError={teachersQuery.isError}
-              isEmpty={teachers.length === 0}
-              loadingLabel="교사 목록 불러오는 중"
-              errorLabel="교사 목록을 불러오지 못했습니다."
-              emptyLabel="활동 중인 교사가 없습니다."
-            >
-              {teachers.map((teacher) => {
-                const id = getUserId(teacher);
-                if (id == null) return null;
-
-                const isSelected = teacherSelection === id;
-
-                return (
-                  <ChoiceButton
-                    key={id}
-                    type="button"
-                    $selected={isSelected}
-                    aria-pressed={isSelected}
-                    onClick={() => {
-                      setSubmitError(null);
-                      setTeacherSelection(id);
-                    }}
-                  >
-                    <ChoiceTitle $selected={isSelected}>{teacher.name ?? "—"}</ChoiceTitle>
-                    {teacher.email ? <ChoiceMeta>{teacher.email}</ChoiceMeta> : null}
-                  </ChoiceButton>
-                );
-              })}
-            </DataState>
-          </ChoiceGrid>
         </SubjectLabel>
 
         <SubjectLabel>


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 과목 등록 관리자 페이지 UI 개선

- 필드 순서 변경
<img width="1216" height="521" alt="스크린샷 2026-06-04 오전 1 55 43" src="https://github.com/user-attachments/assets/e67e3185-e074-49bd-9d11-ad77ae91daac" />
<img width="1200" height="548" alt="스크린샷 2026-06-04 오전 1 55 51" src="https://github.com/user-attachments/assets/73caa372-232a-4cf6-b865-dc6026580e28" />

2. 결석 요청 관리자 페이지 UI 개선
- 수업일과 요청일 목록에 추가 표시
<img width="1200" height="808" alt="스크린샷 2026-06-04 오전 1 56 01" src="https://github.com/user-attachments/assets/ca73daf3-011b-47b8-a4fc-493ac06323f4" />

3. 수업 교환 관리자 페이지 승인 / 반려 기능 구현
<img width="1219" height="835" alt="스크린샷 2026-06-04 오전 1 54 52" src="https://github.com/user-attachments/assets/2976481a-a9ee-4ecc-ab2b-92e4a4e69159" />
<img width="1217" height="827" alt="스크린샷 2026-06-04 오전 1 54 43" src="https://github.com/user-attachments/assets/53489d5c-e312-4a3d-b628-9c50c34b7145" />
<img width="1200" height="795" alt="스크린샷 2026-06-04 오전 1 55 25" src="https://github.com/user-attachments/assets/3ed461a2-49e3-4e62-aaeb-c5cdfd2b7fbd" />
<img width="1200" height="792" alt="스크린샷 2026-06-04 오전 1 55 06" src="https://github.com/user-attachments/assets/852137dc-a941-4d0c-9792-b4b39b43d5e4" />
<img width="1206" height="800" alt="스크린샷 2026-06-04 오전 1 55 14" src="https://github.com/user-attachments/assets/222620aa-1748-4afd-b4d2-2b0165a6d31a" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #120

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
