### PR TITLE
[FEAT] 과목 담당 교사 배정 관리자 페이지 기능 구현

### DIFF
--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -17,6 +17,7 @@ import { AdminLessonExchangeSection } from "@/components/admin/lesson-exchange/A
 import { AdminPurchasesSection } from "@/components/admin/purchase-requests/AdminPurchasesSection";
 import { AdminLessonManagementSection } from "@/components/admin/lesson-management/AdminLessonManagementSection";
 import { AdminSubjectsSection } from "@/components/admin/subjects/AdminSubjectsSection";
+import { AdminSubjectTeachersSection } from "@/components/admin/subject-teachers/AdminSubjectTeachersSection";
 import { AdminUsersSection } from "@/components/admin/users/AdminUsersSection";
 import type {
   AdminMenu,
@@ -98,6 +99,7 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "departments", label: "부서" },
   { key: "classrooms", label: "분반" },
   { key: "subjects", label: "과목 등록" },
+  { key: "subjectTeachers", label: "과목 담당 교사 관리" },
   { key: "lessons", label: "수업" },
   { key: "channels", label: "채널" },
   { key: "posts", label: "게시글" },
@@ -1036,6 +1038,7 @@ export default function AdminDashboardPage() {
       "부서 목록과 상세 정보를 조회하고 부서 생성/수정/삭제, 소속 사용자와 권한 정보를 확인합니다.",
     classrooms: "분반 목록과 상세 정보를 조회하고 분반 생성/수정/삭제 및 이름 검색을 제공합니다.",
     subjects: "분반별 과목 목록을 조회하고 과목 등록/수정/삭제를 관리합니다.",
+    subjectTeachers: "과목별 담당 교사를 조회하고 관리합니다.",
     lessons: "수업 목록을 조회하고 새 수업을 생성합니다.",
     purchases: "구매 요청 작성, 목록/상세 조회, 승인/반려/결재 확인/삭제 처리를 제공합니다.",
     absenceRequests: "결석 요청 목록 조회 및 승인/반려 처리를 제공합니다.",
@@ -1196,6 +1199,7 @@ export default function AdminDashboardPage() {
             />
           ) : null}
           {activeMenu === "subjects" ? <AdminSubjectsSection /> : null}
+          {activeMenu === "subjectTeachers" ? <AdminSubjectTeachersSection /> : null}
           {activeMenu === "lessons" ? <AdminLessonManagementSection /> : null}
           {activeMenu === "absenceRequests" ? <AdminAbsenceRequestsSection /> : null}
           {activeMenu === "lessonExchange" ? <AdminLessonExchangeSection /> : null}

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -11,6 +11,7 @@ export type AdminMenu =
   | "departments"
   | "classrooms"
   | "subjects"
+  | "subjectTeachers"
   | "lessons"
   | "purchases"
   | "absenceRequests"

--- a/components/admin/subject-teachers/AdminSubjectTeacherAssignPanel.tsx
+++ b/components/admin/subject-teachers/AdminSubjectTeacherAssignPanel.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import styled from "styled-components";
+import {
+  ButtonRow,
+  DataState,
+  InlineStatus,
+  Label,
+  PrimaryButton,
+  SectionCard,
+  SectionHeaderRow,
+  SectionTitle,
+} from "@/components/admin/AdminDashboardSectionParts";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import {
+  getTeacherClassroomName,
+  getTeacherUserId,
+  useAdminSubjectTeacherAssign,
+} from "@/components/admin/subject-teachers/useAdminSubjectTeacherAssign";
+import {
+  CenteredChoiceButton,
+  CenteredChoiceTitle,
+  ChoiceButton,
+  ChoiceGrid,
+  ChoiceHeightPlaceholder,
+  ChoiceMeta,
+  ChoiceStack,
+  ChoiceTitle,
+} from "@/components/admin/subjects/shared/subjectChoiceStyles";
+import { spacing } from "@/styles/tokens";
+
+const SectionHeader = styled(SectionHeaderRow)`
+  margin-bottom: ${spacing.space12};
+`;
+
+const PanelBody = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+`;
+
+const AssignLabel = styled(Label)`
+  gap: ${spacing.space8};
+`;
+
+const FooterStack = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+type AdminSubjectTeacherAssignPanelProps = {
+  subject: SubjectDetailResponseDto | null;
+};
+
+export function AdminSubjectTeacherAssignPanel({ subject }: AdminSubjectTeacherAssignPanelProps) {
+  const assign = useAdminSubjectTeacherAssign({ subject });
+
+  if (!subject) {
+    return (
+      <SectionCard>
+        <SectionHeader>
+          <SectionTitle>과목 담당 교사 관리</SectionTitle>
+        </SectionHeader>
+        <InlineStatus>과목을 선택하세요.</InlineStatus>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard>
+      <SectionHeader>
+        <SectionTitle>과목 담당 교사 관리</SectionTitle>
+      </SectionHeader>
+
+      <PanelBody>
+        <AssignLabel>
+          교사 선택
+          <ChoiceStack>
+            <ChoiceGrid>
+              <CenteredChoiceButton
+                type="button"
+                $selected={assign.isUnselectedChoiceSelected}
+                $disabled={assign.isUnselectedChoiceDisabled}
+                disabled={assign.isUnselectedChoiceDisabled}
+                aria-pressed={assign.isUnselectedChoiceSelected}
+                onClick={assign.selectTeacherUnselected}
+              >
+                <ChoiceHeightPlaceholder aria-hidden>
+                  <ChoiceTitle>{"\u00A0"}</ChoiceTitle>
+                  <ChoiceMeta>{"\u00A0"}</ChoiceMeta>
+                </ChoiceHeightPlaceholder>
+                <CenteredChoiceTitle $disabled={assign.isUnselectedChoiceDisabled}>
+                  교사 미선택
+                </CenteredChoiceTitle>
+              </CenteredChoiceButton>
+            </ChoiceGrid>
+
+            <DataState
+              compact
+              isLoading={assign.teachersQuery.isLoading}
+              isError={assign.teachersQuery.isError}
+              isEmpty={assign.teachers.length === 0}
+              loadingLabel="교사 목록 불러오는 중"
+              errorLabel="교사 목록을 불러오지 못했습니다."
+              emptyLabel="활동 중인 교사가 없습니다."
+            >
+              <ChoiceGrid>
+                {assign.teachers.map((teacher) => {
+                  const teacherId = getTeacherUserId(teacher);
+                  if (teacherId == null) return null;
+
+                  const isDisabled = assign.isTeacherChoiceDisabled(teacherId);
+                  const isSelected = assign.selectedTeacherId === teacherId;
+
+                  return (
+                    <ChoiceButton
+                      key={teacherId}
+                      type="button"
+                      $selected={isSelected}
+                      $disabled={isDisabled}
+                      disabled={isDisabled}
+                      aria-pressed={isSelected}
+                      onClick={() => assign.setSelectedTeacherId(teacherId)}
+                    >
+                      <ChoiceTitle $selected={isSelected} $disabled={isDisabled}>
+                        {teacher.name ?? "—"}
+                      </ChoiceTitle>
+                      <ChoiceMeta>{getTeacherClassroomName(teacher)}</ChoiceMeta>
+                    </ChoiceButton>
+                  );
+                })}
+              </ChoiceGrid>
+            </DataState>
+          </ChoiceStack>
+        </AssignLabel>
+
+        <FooterStack>
+          <ButtonRow>
+            <PrimaryButton
+              type="button"
+              disabled={!assign.canSubmit}
+              onClick={assign.handleSubmit}
+            >
+              {assign.isSubmitting
+                ? "처리 중..."
+                : assign.isTeacherUnassigned
+                  ? "교사 배정"
+                  : "교사 변경"}
+            </PrimaryButton>
+          </ButtonRow>
+
+          {assign.submitError ? <InlineStatus role="alert">{assign.submitError}</InlineStatus> : null}
+        </FooterStack>
+      </PanelBody>
+    </SectionCard>
+  );
+}

--- a/components/admin/subject-teachers/AdminSubjectTeachersSection.tsx
+++ b/components/admin/subject-teachers/AdminSubjectTeachersSection.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AdminSubjectsListDetailBlock } from "@/components/admin/subjects/AdminSubjectsListDetailBlock";
+
 export function AdminSubjectTeachersSection() {
-  return null;
+  return <AdminSubjectsListDetailBlock readOnly />;
 }

--- a/components/admin/subject-teachers/AdminSubjectTeachersSection.tsx
+++ b/components/admin/subject-teachers/AdminSubjectTeachersSection.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export function AdminSubjectTeachersSection() {
+  return null;
+}

--- a/components/admin/subject-teachers/useAdminSubjectTeacherAssign.ts
+++ b/components/admin/subject-teachers/useAdminSubjectTeacherAssign.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { assignSubjectTeacher } from "@/api/subject/subject.api";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import { getUsers } from "@/api/user/user.api";
+import type { UserListItemDto } from "@/api/user/user.dto";
+import { getSubjectId } from "@/components/admin/subjects/shared/subjectDisplay";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function getTeacherUserId(user: UserListItemDto) {
+  return typeof user.id === "number" ? user.id : null;
+}
+
+export function getTeacherClassroomName(user: UserListItemDto) {
+  return user.classroom?.name?.trim() || user.email?.trim() || "—";
+}
+
+export function getSubjectTeacherId(subject?: SubjectDetailResponseDto | null) {
+  const teacherId = subject?.teacherId;
+  return typeof teacherId === "number" ? teacherId : null;
+}
+
+type UseAdminSubjectTeacherAssignParams = {
+  subject: SubjectDetailResponseDto | null;
+};
+
+const TEACHER_UNSELECTED = "unselected" as const;
+
+export function useAdminSubjectTeacherAssign({ subject }: UseAdminSubjectTeacherAssignParams) {
+  const queryClient = useQueryClient();
+  const subjectId = subject ? getSubjectId(subject) : null;
+  const assignedTeacherId = getSubjectTeacherId(subject);
+  const isTeacherUnassigned = assignedTeacherId == null;
+
+  const [selectedTeacherId, setSelectedTeacherId] = useState<number | typeof TEACHER_UNSELECTED | null>(
+    null,
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const teachersQuery = useQuery({
+    queryKey: queryKeys.admin.activeVolunteerTeachers(),
+    queryFn: () =>
+      getUsers({
+        role: "VOLUNTEER",
+        page: 0,
+        size: 100,
+      }),
+  });
+
+  const teachers = teachersQuery.data?.content ?? [];
+
+  useEffect(() => {
+    setSelectedTeacherId(null);
+    setSubmitError(null);
+  }, [subjectId]);
+
+  const assignTeacherMutation = useMutation({
+    mutationFn: async (teacherId: number | null) => {
+      if (subjectId == null) throw new Error("과목을 선택해 주세요.");
+      return assignSubjectTeacher({ subjectId }, { teacherId });
+    },
+    onSuccess: async () => {
+      setSubmitError(null);
+      setSelectedTeacherId(null);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.admin.subjects() });
+    },
+    onError: (error) => {
+      const message =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "과목 담당 교사 변경에 실패했습니다.";
+      setSubmitError(message);
+    },
+  });
+
+  const isTeacherChoiceDisabled = (teacherId: number) => assignedTeacherId === teacherId;
+  const isUnselectedChoiceDisabled = isTeacherUnassigned;
+  const isUnselectedChoiceSelected = selectedTeacherId === TEACHER_UNSELECTED;
+
+  const canSubmit =
+    subjectId != null &&
+    selectedTeacherId != null &&
+    (selectedTeacherId === TEACHER_UNSELECTED
+      ? !isUnselectedChoiceDisabled
+      : !isTeacherChoiceDisabled(selectedTeacherId)) &&
+    !assignTeacherMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit || selectedTeacherId == null) return;
+    const nextTeacherId = selectedTeacherId === TEACHER_UNSELECTED ? null : selectedTeacherId;
+
+    const successMessage = isTeacherUnassigned
+      ? "과목 담당 교사를 배정했습니다."
+      : "과목 담당 교사를 변경했습니다.";
+
+    assignTeacherMutation.mutate(nextTeacherId, {
+      onSuccess: async () => {
+        toast.success(successMessage);
+      },
+    });
+  };
+
+  return {
+    subject,
+    isTeacherUnassigned,
+    assignedTeacherId,
+    selectedTeacherId,
+    isUnselectedChoiceDisabled,
+    isUnselectedChoiceSelected,
+    selectTeacherUnselected: () => {
+      setSubmitError(null);
+      setSelectedTeacherId(TEACHER_UNSELECTED);
+    },
+    setSelectedTeacherId: (teacherId: number) => {
+      setSubmitError(null);
+      setSelectedTeacherId(teacherId);
+    },
+    teachers,
+    teachersQuery,
+    isTeacherChoiceDisabled,
+    canSubmit,
+    handleSubmit,
+    submitError,
+    isSubmitting: assignTeacherMutation.isPending,
+  };
+}
+
+export type AdminSubjectTeacherAssignViewModel = ReturnType<typeof useAdminSubjectTeacherAssign>;

--- a/components/admin/subjects/AdminSubjectsListDetailBlock.tsx
+++ b/components/admin/subjects/AdminSubjectsListDetailBlock.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import styled from "styled-components";
+import { getSubjects } from "@/api/subject/subject.api";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import {
+  SectionCard,
+  SectionHeaderRow,
+  SectionTitle,
+  TwoColumnGrid,
+} from "@/components/admin/AdminDashboardSectionParts";
+import { AdminSubjectDetailPanel } from "@/components/admin/subjects/detail/AdminSubjectDetailPanel";
+import { useAdminSubjectDetail } from "@/components/admin/subjects/detail/useAdminSubjectDetail";
+import { AdminSubjectListPanel } from "@/components/admin/subjects/list/AdminSubjectListPanel";
+import { filterActiveSubjects, getSubjectId } from "@/components/admin/subjects/shared/subjectDisplay";
+import { AdminSubjectTeacherAssignPanel } from "@/components/admin/subject-teachers/AdminSubjectTeacherAssignPanel";
+import { queryKeys } from "@/lib/queryKeys";
+import { spacing } from "@/styles/tokens";
+
+const PageStack = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+`;
+
+const ListSectionHeader = styled(SectionHeaderRow)`
+  margin-bottom: ${spacing.space12};
+`;
+
+type AdminSubjectsListDetailBlockProps = {
+  readOnly?: boolean;
+};
+
+export function AdminSubjectsListDetailBlock({ readOnly = false }: AdminSubjectsListDetailBlockProps) {
+  const [selectedSubjectId, setSelectedSubjectId] = useState<number | null>(null);
+
+  const subjectsQuery = useQuery({
+    queryKey: queryKeys.admin.subjects(),
+    queryFn: () => getSubjects(),
+  });
+
+  const subjects = useMemo(() => {
+    const items = Array.isArray(subjectsQuery.data) ? subjectsQuery.data : [];
+    return filterActiveSubjects(items);
+  }, [subjectsQuery.data]);
+
+  const selectedSubject = useMemo(
+    () => subjects.find((subject) => getSubjectId(subject) === selectedSubjectId) ?? null,
+    [selectedSubjectId, subjects],
+  );
+
+  const handleSelectSubject = (subject: SubjectDetailResponseDto) => {
+    const subjectId = getSubjectId(subject);
+    if (subjectId == null) return;
+    setSelectedSubjectId(subjectId);
+  };
+
+  const subjectDetail = useAdminSubjectDetail({
+    subject: selectedSubject,
+    onClearSelection: () => setSelectedSubjectId(null),
+  });
+
+  return (
+    <PageStack>
+      <TwoColumnGrid>
+        <SectionCard>
+          <ListSectionHeader>
+            <SectionTitle>과목 목록</SectionTitle>
+          </ListSectionHeader>
+          <AdminSubjectListPanel
+            subjects={subjects}
+            selectedSubjectId={selectedSubjectId}
+            isLoading={subjectsQuery.isLoading}
+            isError={subjectsQuery.isError}
+            onSelectSubject={handleSelectSubject}
+          />
+        </SectionCard>
+        <SectionCard>
+          <ListSectionHeader>
+            <SectionTitle>과목 상세</SectionTitle>
+          </ListSectionHeader>
+          <AdminSubjectDetailPanel
+            subject={selectedSubject}
+            detail={subjectDetail}
+            readOnly={readOnly}
+          />
+        </SectionCard>
+      </TwoColumnGrid>
+
+      {readOnly ? <AdminSubjectTeacherAssignPanel subject={selectedSubject} /> : null}
+    </PageStack>
+  );
+}

--- a/components/admin/subjects/AdminSubjectsSection.tsx
+++ b/components/admin/subjects/AdminSubjectsSection.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
-import { getSubjects } from "@/api/subject/subject.api";
-import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
 import { AdminSubjectCreateForm } from "@/components/admin/subjects/create/AdminSubjectCreateForm";
-import { AdminSubjectDetailPanel } from "@/components/admin/subjects/detail/AdminSubjectDetailPanel";
-import { AdminSubjectListPanel } from "@/components/admin/subjects/list/AdminSubjectListPanel";
-import { filterActiveSubjects, getSubjectId } from "@/components/admin/subjects/shared/subjectDisplay";
-import { useAdminSubjectDetail } from "@/components/admin/subjects/detail/useAdminSubjectDetail";
+import { AdminSubjectsListDetailBlock } from "@/components/admin/subjects/AdminSubjectsListDetailBlock";
 import {
   SectionCard,
   SectionHeaderRow,
   SectionTitle,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
-import { queryKeys } from "@/lib/queryKeys";
 import { spacing } from "@/styles/tokens";
 
 const PageStack = styled.div`
@@ -28,39 +19,7 @@ const CreateSectionHeader = styled(SectionHeaderRow)`
   margin-bottom: ${spacing.space12};
 `;
 
-const ListSectionHeader = styled(SectionHeaderRow)`
-  margin-bottom: ${spacing.space12};
-`;
-
 export function AdminSubjectsSection() {
-  const [selectedSubjectId, setSelectedSubjectId] = useState<number | null>(null);
-
-  const subjectsQuery = useQuery({
-    queryKey: queryKeys.admin.subjects(),
-    queryFn: () => getSubjects(),
-  });
-
-  const subjects = useMemo(() => {
-    const items = Array.isArray(subjectsQuery.data) ? subjectsQuery.data : [];
-    return filterActiveSubjects(items);
-  }, [subjectsQuery.data]);
-
-  const selectedSubject = useMemo(
-    () => subjects.find((subject) => getSubjectId(subject) === selectedSubjectId) ?? null,
-    [selectedSubjectId, subjects],
-  );
-
-  const handleSelectSubject = (subject: SubjectDetailResponseDto) => {
-    const subjectId = getSubjectId(subject);
-    if (subjectId == null) return;
-    setSelectedSubjectId(subjectId);
-  };
-
-  const subjectDetail = useAdminSubjectDetail({
-    subject: selectedSubject,
-    onClearSelection: () => setSelectedSubjectId(null),
-  });
-
   return (
     <PageStack>
       <SectionCard>
@@ -70,26 +29,7 @@ export function AdminSubjectsSection() {
         <AdminSubjectCreateForm />
       </SectionCard>
 
-      <TwoColumnGrid>
-        <SectionCard>
-          <ListSectionHeader>
-            <SectionTitle>과목 목록</SectionTitle>
-          </ListSectionHeader>
-          <AdminSubjectListPanel
-            subjects={subjects}
-            selectedSubjectId={selectedSubjectId}
-            isLoading={subjectsQuery.isLoading}
-            isError={subjectsQuery.isError}
-            onSelectSubject={handleSelectSubject}
-          />
-        </SectionCard>
-        <SectionCard>
-          <ListSectionHeader>
-            <SectionTitle>과목 상세</SectionTitle>
-          </ListSectionHeader>
-          <AdminSubjectDetailPanel subject={selectedSubject} detail={subjectDetail} />
-        </SectionCard>
-      </TwoColumnGrid>
+      <AdminSubjectsListDetailBlock />
     </PageStack>
   );
 }

--- a/components/admin/subjects/detail/AdminSubjectDetailPanel.tsx
+++ b/components/admin/subjects/detail/AdminSubjectDetailPanel.tsx
@@ -11,9 +11,14 @@ import type { AdminSubjectDetailViewModel } from "@/components/admin/subjects/de
 type AdminSubjectDetailPanelProps = {
   subject: SubjectDetailResponseDto | null;
   detail: AdminSubjectDetailViewModel;
+  readOnly?: boolean;
 };
 
-export function AdminSubjectDetailPanel({ subject, detail }: AdminSubjectDetailPanelProps) {
+export function AdminSubjectDetailPanel({
+  subject,
+  detail,
+  readOnly = false,
+}: AdminSubjectDetailPanelProps) {
   return (
     <DataState
       isLoading={false}
@@ -30,7 +35,7 @@ export function AdminSubjectDetailPanel({ subject, detail }: AdminSubjectDetailP
             <AdminSubjectDetailDescription subject={subject} detail={detail} />
           </>
         ) : null}
-        <AdminSubjectDetailActions subject={subject} detail={detail} />
+        {readOnly ? null : <AdminSubjectDetailActions subject={subject} detail={detail} />}
       </DetailStack>
     </DataState>
   );

--- a/components/admin/subjects/shared/subjectChoiceStyles.ts
+++ b/components/admin/subjects/shared/subjectChoiceStyles.ts
@@ -1,0 +1,81 @@
+import styled from "styled-components";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+export const ChoiceGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${spacing.space8};
+`;
+
+export const ChoiceStack = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+export const ChoiceButton = styled.button<{ $selected?: boolean; $disabled?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: ${spacing.space4};
+  min-width: 9rem;
+  margin: 0;
+  padding: ${spacing.space8} ${spacing.space12};
+  border: 1px solid
+    ${({ $selected, $disabled }) => {
+      if ($disabled) return "#e1e5e3";
+      return $selected ? colors.point : "#e1e5e3";
+    }};
+  border-radius: 0.5rem;
+  background-color: ${({ $selected, $disabled }) => {
+    if ($disabled) return "#f4f6f5";
+    return $selected ? colors.pointSoft : colors.white;
+  }};
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+  opacity: ${({ $disabled }) => ($disabled ? 0.55 : 1)};
+
+  &:hover:not(:disabled) {
+    border-color: ${colors.point};
+  }
+`;
+
+export const ChoiceTitle = styled.span<{ $selected?: boolean; $disabled?: boolean }>`
+  color: ${({ $selected, $disabled }) => {
+    if ($disabled) return "#94a39d";
+    return $selected ? colors.text : "#64706c";
+  }};
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const ChoiceMeta = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+`;
+
+export const CenteredChoiceButton = styled(ChoiceButton)`
+  position: relative;
+  text-align: center;
+`;
+
+export const CenteredChoiceTitle = styled(ChoiceTitle)`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+export const ChoiceHeightPlaceholder = styled.div`
+  visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space4};
+`;

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -72,6 +72,7 @@ export const queryKeys = {
     classroomDetail: (classroomId: number) =>
       ["admin", "classrooms", "detail", classroomId] as const,
     subjects: (classroomId?: number) => ["admin", "subjects", { classroomId }] as const,
+    activeVolunteerTeachers: () => ["admin", "users", "active-volunteer-teachers"] as const,
     purchaseRequests: (status?: string) => ["admin", "purchase-requests", { status }] as const,
     purchaseRequestDetail: (requestId: number) =>
       ["admin", "purchase-requests", "detail", requestId] as const,


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 관리자 페이지의 과목 담당 교사 관리 기능을 추가하고, 기존 과목 목록/상세 로직을 재사용할 수 있도록 구조를 개선했습니다.

#### 과목 담당 교사 관리

* 신규 과목 담당 교사 관리 섹션 추가
* 공용 과목 목록/상세 컴포넌트를 조회 전용(readOnly) 모드로 사용

#### 담당 교사 배정/변경
* GET `/api/v1/users`
* `role=VOLUNTEER` 조건으로 교사 목록 조회
* 분기 적용
    * 선택한 과목의 담당 교사가 없는 경우
        * 교사 미선택 버튼 비활성화
    * 선택한 과목의 담당 교사가 있는 경우
        * 현재 담당 교사 버튼 비활성화
        * 교사 미선택 선택 가능
* 교사 미선택 선택 시
    * `teacherId: null` 전송

#### 교사 배정 API 연동
* `PATCH /api/v1/subjects/{subjectId}/teacher` api 연동

<img width="1710" height="1068" alt="스크린샷 2026-06-05 오전 1 44 49" src="https://github.com/user-attachments/assets/81f24f93-b6dc-4ae4-95c2-7b508274f424" />

<img width="1710" height="1069" alt="스크린샷 2026-06-05 오전 1 46 16" src="https://github.com/user-attachments/assets/13589dee-bc39-403a-bd7d-067a43271d92" />

<img width="1709" height="1067" alt="스크린샷 2026-06-05 오전 1 44 39" src="https://github.com/user-attachments/assets/37c27c76-790d-4676-86c6-0752399c4959" />


## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #119

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
