### PR TITLE
[FEAT] 사용자 정보 자동 입력 기능 개선

### DIFF
--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -37,6 +37,11 @@ export interface UserClassroomResponseDto {
   type?: ClassroomType;
 }
 
+export interface UserTeacherAssignmentResponseDto {
+  classroomId?: number;
+  classroomName?: string;
+}
+
 export interface UserResponseDto {
   id?: number;
   name?: string;
@@ -47,6 +52,7 @@ export interface UserResponseDto {
   departmentId?: number | null;
   department?: DepartmentResponseDto;
   classroom?: UserClassroomResponseDto;
+  teacherAssignments?: UserTeacherAssignmentResponseDto[];
   residentRegistrationNumberPrefix?: string;
   teacherStartAt?: string;
   teacherEndAt?: string;

--- a/app/staff/class-management/exchange-request/new/page.tsx
+++ b/app/staff/class-management/exchange-request/new/page.tsx
@@ -3,9 +3,11 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
+import { getCurrentUser } from "@/api/user/user.api";
+import { queryKeys } from "@/lib/queryKeys";
 import {
   koreanShortDateToLocalDateTime,
   parseKoreanShortDateToIsoDate,
@@ -20,6 +22,24 @@ export default function Page() {
   const expireDateInputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
+  const currentUserQuery = useQuery({
+    queryKey: queryKeys.user.me(),
+    queryFn: getCurrentUser,
+    retry: false,
+    refetchOnMount: "always",
+  });
+  const currentUser = currentUserQuery.isFetchedAfterMount ? currentUserQuery.data : undefined;
+  const teacherAssignments = currentUser?.teacherAssignments ?? [];
+  const assignmentClassNames = Array.from(
+    new Set(
+      teacherAssignments
+        .map((assignment) => assignment.classroomName?.trim() ?? "")
+        .filter((name) => name.length > 0),
+    ),
+  );
+  const hasMultipleClassNames = assignmentClassNames.length > 1;
+  const className = assignmentClassNames.length === 1 ? assignmentClassNames[0] : "";
+  const writerName = currentUser?.name ?? "";
 
   const createLessonExchangeMutation = useMutation({
     mutationFn: createLessonExchangeRequest,
@@ -110,9 +130,28 @@ export default function Page() {
           <InfoStack>
             <InfoPairRow>
               <FieldLabel htmlFor="className">반 이름</FieldLabel>
-              <InlineInput id="className" name="className" placeholder="반 이름" />
+              {hasMultipleClassNames ? (
+                <InlineSelect id="className" name="className" defaultValue="">
+                  <option value="" disabled>
+                    반 이름을 선택해 주세요
+                  </option>
+                  {assignmentClassNames.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </InlineSelect>
+              ) : (
+                <InlineInput
+                  id="className"
+                  name="className"
+                  placeholder="반 이름"
+                  value={className}
+                  readOnly
+                />
+              )}
               <FieldLabel htmlFor="writer">작성자</FieldLabel>
-              <InlineInput id="writer" name="writer" placeholder="홍길동" />
+              <InlineInput id="writer" name="writer" placeholder="홍길동" value={writerName} readOnly />
               <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
               <DateRow>
                 <DateInput
@@ -367,6 +406,34 @@ const InlineInput = styled.input`
     color: #4f4f4f;
     cursor: not-allowed;
   }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const InlineSelect = styled.select`
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  padding-right: 2rem;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  border: 1px solid #c0c0c0;
+  outline: none;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #8c8c8c 50%),
+    linear-gradient(135deg, #8c8c8c 50%, transparent 50%);
+  background-position:
+    calc(100% - 1rem) calc(50% - 2px),
+    calc(100% - 0.6875rem) calc(50% - 2px);
+  background-size:
+    0.375rem 0.375rem,
+    0.375rem 0.375rem;
+  background-repeat: no-repeat;
 
   @media (min-width: 120rem) {
     min-height: 4rem;

--- a/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
+++ b/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
@@ -2,13 +2,33 @@
 
 import type { FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import styled, { css } from "styled-components";
 import { createAbsenceRequest } from "@/api/request/request.api";
+import { getCurrentUser } from "@/api/user/user.api";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function AbsenceRequestForm() {
   const router = useRouter();
+  const currentUserQuery = useQuery({
+    queryKey: queryKeys.user.me(),
+    queryFn: getCurrentUser,
+    retry: false,
+    refetchOnMount: "always",
+  });
+  const currentUser = currentUserQuery.isFetchedAfterMount ? currentUserQuery.data : undefined;
+  const teacherAssignments = currentUser?.teacherAssignments ?? [];
+  const assignmentClassNames = Array.from(
+    new Set(
+      teacherAssignments
+        .map((assignment) => assignment.classroomName?.trim() ?? "")
+        .filter((name) => name.length > 0),
+    ),
+  );
+  const hasMultipleClassNames = assignmentClassNames.length > 1;
+  const className = assignmentClassNames.length === 1 ? assignmentClassNames[0] : "";
+  const writerName = currentUser?.name ?? "";
 
   const createAbsenceMutation = useMutation({
     mutationFn: createAbsenceRequest,
@@ -60,13 +80,32 @@ export default function AbsenceRequestForm() {
 
           <InfoRow>
             <FieldLabel htmlFor="className">반 이름</FieldLabel>
-            <InlineInput id="className" name="className" placeholder="개나리반" />
+            {hasMultipleClassNames ? (
+              <InlineSelect id="className" name="className" defaultValue="">
+                <option value="" disabled>
+                  반 이름을 선택해 주세요
+                </option>
+                {assignmentClassNames.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </InlineSelect>
+            ) : (
+              <InlineInput
+                id="className"
+                name="className"
+                placeholder="개나리반"
+                value={className}
+                readOnly
+              />
+            )}
 
             <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
             <InlineInput id="lessonDate" name="lessonDate" type="date" />
 
             <FieldLabel htmlFor="writer">작성자</FieldLabel>
-            <InlineInput id="writer" name="writer" placeholder="홍길동" />
+            <InlineInput id="writer" name="writer" placeholder="홍길동" value={writerName} readOnly />
           </InfoRow>
         </Section>
 
@@ -222,6 +261,22 @@ const SectionTitle = styled.h2`
 
 const InlineInput = styled.input`
   ${inputStyle}
+`;
+
+const InlineSelect = styled.select`
+  ${inputStyle}
+  padding-right: 2rem;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #8c8c8c 50%),
+    linear-gradient(135deg, #8c8c8c 50%, transparent 50%);
+  background-position:
+    calc(100% - 1rem) calc(50% - 2px),
+    calc(100% - 0.6875rem) calc(50% - 2px);
+  background-size:
+    0.375rem 0.375rem,
+    0.375rem 0.375rem;
+  background-repeat: no-repeat;
 `;
 
 const TitleInput = styled.input`

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -32,13 +32,8 @@ import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 const lessonPeriods = [1, 2, 3] as const;
 const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
 
-/** TODO: users/me classroomId 필드가 고정 될 때까지 테스트를 위해 기본값으로 설정 */
-const CLASS_JOURNAL_FORM_DEFAULTS = {
-  classroomId: 1,
-  classroomName: "벚꽃반",
-  residentRegistrationNumberPrefix: "900101",
-  phoneNumber: "01012345678",
-} as const;
+/** TODO: users/me에서 classroomId를 안정적으로 내려주기 전까지 조회 기본값으로 사용 */
+const CLASS_JOURNAL_DEFAULT_CLASSROOM_ID = 1;
 
 function buildAttendanceNameKey(rowIndex: number, column: number) {
   return `${rowIndex}-${column}`;
@@ -55,7 +50,7 @@ function resolveClassroomName(
     .flatMap((student) => student.classrooms ?? [])
     .find((classroom) => classroom.id === classroomId)?.name;
 
-  return fromStudents?.trim() ? fromStudents : CLASS_JOURNAL_FORM_DEFAULTS.classroomName;
+  return fromStudents?.trim() ? fromStudents : "";
 }
 
 function trimTrailingClockSeconds(time?: string) {
@@ -129,21 +124,21 @@ export default function ClassJournalCreatePage() {
   const [attendanceNameOverrides, setAttendanceNameOverrides] = useState<Record<string, string>>({});
   const [additionalAttendanceRows, setAdditionalAttendanceRows] = useState(0);
 
-  const classroomId = String(CLASS_JOURNAL_FORM_DEFAULTS.classroomId);
-  const birthPrefix = CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix;
-  const phoneNumber = CLASS_JOURNAL_FORM_DEFAULTS.phoneNumber;
-
   const currentUserQuery = useQuery({
     queryKey: queryKeys.user.me(),
     queryFn: getCurrentUser,
     retry: false,
+    refetchOnMount: "always",
   });
 
-  const parsedClassroomId = Number.parseInt(classroomId, 10);
+  const currentUser = currentUserQuery.isFetchedAfterMount ? currentUserQuery.data : undefined;
+  const teacherAssignments = currentUser?.teacherAssignments ?? [];
+  const singleTeacherAssignment = teacherAssignments.length === 1 ? teacherAssignments[0] : undefined;
+  const parsedClassroomId = Number.parseInt(String(singleTeacherAssignment?.classroomId ?? ""), 10);
   const enrollmentClassroomId =
     Number.isFinite(parsedClassroomId) && parsedClassroomId > 0
       ? parsedClassroomId
-      : CLASS_JOURNAL_FORM_DEFAULTS.classroomId;
+      : CLASS_JOURNAL_DEFAULT_CLASSROOM_ID;
 
   const studentsQuery = useQuery({
     queryKey: queryKeys.students.list({
@@ -229,10 +224,10 @@ export default function ClassJournalCreatePage() {
   });
 
   const isSubmitting = submitMutation.isPending;
-  const currentUser = currentUserQuery.data;
   const scheduleDetail = dailyScheduleDetailQuery.data;
-
-  const writerName = scheduleDetail?.teacherName ?? currentUser?.name ?? "";
+  const writerName = currentUser?.name ?? "";
+  const birthPrefix = currentUser?.residentRegistrationNumberPrefix ?? "";
+  const phoneNumber = currentUser?.phoneNumber ?? "";
 
   const resolvedLessonDate = useMemo(() => {
     if (!scheduleDetail?.lessonDate) return "";
@@ -253,9 +248,10 @@ export default function ClassJournalCreatePage() {
       ),
     [enrollmentClassroomId, enrolledStudents, scheduleDetail?.classroomName],
   );
+  const assignedClassroomName = singleTeacherAssignment?.classroomName?.trim() ?? "";
 
   const lessonDateValue = lessonDateText || resolvedLessonDate;
-  const classroomNameValue = classroomNameText || resolvedClassroomName;
+  const classroomNameValue = classroomNameText || assignedClassroomName || resolvedClassroomName;
   const activityTimeValue = activityTimeText || resolvedActivityTime;
 
   const apiAttendanceNames = useMemo(() => {
@@ -316,7 +312,7 @@ export default function ClassJournalCreatePage() {
     }
 
     const residentRegistrationNumberPrefix =
-      birthPrefix.trim() || CLASS_JOURNAL_FORM_DEFAULTS.residentRegistrationNumberPrefix;
+      birthPrefix.trim();
 
     submitMutation.mutate({
       dailyScheduleId,

--- a/mocks/handlers/user.handlers.ts
+++ b/mocks/handlers/user.handlers.ts
@@ -22,6 +22,12 @@ export const USER_LIST_RESPONSE = {
 };
 
 export const USER_DETAIL_RESPONSE = USER_LIST_RESPONSE.content[0];
+export const USER_ME_RESPONSE = {
+  ...USER_DETAIL_RESPONSE,
+  residentRegistrationNumberPrefix: "900101",
+  phoneNumber: "010-2222-3333",
+  teacherAssignments: [{ classroomId: 1, classroomName: "벚꽃반" }],
+};
 
 export const TEACHER_CONTACT_LIST_RESPONSE = [
   {
@@ -68,7 +74,7 @@ export const userHandlers: RequestHandler[] = [
     return HttpResponse.json({ ...USER_DETAIL_RESPONSE, ...body, id: 2 });
   }),
   http.get(`${API_BASE_URL}/api/v1/users/me`, ({ request }) => {
-    return unauthorizedWhenNeeded(request) ?? HttpResponse.json(USER_DETAIL_RESPONSE);
+    return unauthorizedWhenNeeded(request) ?? HttpResponse.json(USER_ME_RESPONSE);
   }),
   http.patch(`${API_BASE_URL}/api/v1/users/me`, async ({ request }) => {
     const unauthorizedResponse = unauthorizedWhenNeeded(request);


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

#### 수업일지

* 작성자 → name
* 주민번호 앞자리 → residentRegistrationNumberPrefix
* 연락처 → phoneNumber
  * 값이 없는 경우 빈 값으로 처리
* 반 이름 → teacherAssignments[0].classroomName 기본으로 적용

#### 수업 교환 신청 / 수업 결강 신청

조회한 사용자 정보를 신청 폼의 기본값으로 자동 입력
* 작성자 → name
* 반 이름 → teacherAssignments[0].classroomName
    * 담당 반이 여러개라면 드롭다운으로 반 선택이 가능하도록 UI 구현

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #123

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
