### PR TITLE
[FEAT] 수업 일지 과목 선택 기능 추가

### DIFF
--- a/api/dailySchedule/dailySchedule.api.test.ts
+++ b/api/dailySchedule/dailySchedule.api.test.ts
@@ -10,6 +10,7 @@ import { setAccessToken } from "../client/tokenStorage";
 import {
   createJournal,
   getDailyScheduleDetail,
+  getDailyScheduleDetailIfExists,
   getDailySchedules,
   getVolunteerHours,
   updateStudentAttendances,
@@ -96,6 +97,26 @@ describe("dailySchedule.api", () => {
     expect(observedVolunteerQueryString).toContain("teacherId=3");
     expect(observedVolunteerQueryString).toContain("from=2026-06-01");
     expect(observedVolunteerQueryString).toContain("to=2026-06-30");
+  });
+
+  it("returns null when no daily schedule exists", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedDetailQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/daily-schedules/detail`, ({ request }) => {
+        observedDetailQueryString = new URL(request.url).search;
+        return HttpResponse.json({ message: "Not found" }, { status: 404 });
+      }),
+    );
+
+    await expect(
+      getDailyScheduleDetailIfExists({ classroomId: 2, lessonDate: "2026-06-01" }),
+    ).resolves.toBeNull();
+
+    expect(observedDetailQueryString).toContain("classroomId=2");
+    expect(observedDetailQueryString).toContain("lessonDate=2026-06-01");
   });
 
   it("creates a journal with the expected request body", async () => {

--- a/api/dailySchedule/dailySchedule.api.ts
+++ b/api/dailySchedule/dailySchedule.api.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from "axios";
 import authClient from "../client/authClient";
 import type {
   CreateDailyScheduleJournalRequestDto,
@@ -40,6 +41,18 @@ export async function getDailyScheduleDetail(query: DailyScheduleDetailQueryPara
   );
 
   return response.data;
+}
+
+// 날짜/분반 기준으로 일정 존재 여부를 확인한 뒤 상세를 조회하는 요청
+export async function getDailyScheduleDetailIfExists(query: DailyScheduleDetailQueryParamsDto) {
+  try {
+    return await getDailyScheduleDetail(query);
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 // 봉사 인정 시간을 조회하는 요청

--- a/api/dailySchedule/dailySchedule.dto.ts
+++ b/api/dailySchedule/dailySchedule.dto.ts
@@ -5,6 +5,8 @@ export type DailyStudentAttendanceStatus = "PRESENT" | "ABSENT" | "LATE";
 export interface DailyScheduleListQueryParamsDto {
   keyword?: string;
   mine?: boolean;
+  classroomId?: number;
+  lessonDate?: string;
   page?: number;
   size?: number;
 }

--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -39,7 +39,9 @@ export interface UserClassroomResponseDto {
 
 export interface UserTeacherAssignmentResponseDto {
   classroomId?: number;
+  classNameId?: number;
   classroomName?: string;
+  subjectName?: string;
 }
 
 export interface UserResponseDto {

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -427,7 +427,6 @@ export default function ClassJournalCreatePage() {
               type="text"
               value={writerName}
               placeholder="작성자"
-              disabled
               readOnly
             />
           </InfoField>
@@ -452,7 +451,6 @@ export default function ClassJournalCreatePage() {
               type="text"
               value={formatPhone(phoneNumber)}
               placeholder="010-0000-0000"
-              disabled
               readOnly
             />
           </InfoField>

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
@@ -11,11 +11,12 @@ import type {
 } from "@/api/dailySchedule/dailySchedule.dto";
 import {
   createJournal,
-  getDailyScheduleDetail,
+  getDailyScheduleDetailIfExists,
   updateStudentAttendances,
 } from "@/api/dailySchedule/dailySchedule.api";
 import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
+import type { UserTeacherAssignmentResponseDto } from "@/api/user/user.dto";
 import { getCurrentUser } from "@/api/user/user.api";
 import { buildClassAttendanceSheetPayload } from "@/lib/googleSheet/classAttendance/classAttendanceSheetPayload";
 import { sendClassAttendanceToGoogleSheet } from "@/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet";
@@ -37,6 +38,32 @@ const CLASS_JOURNAL_DEFAULT_CLASSROOM_ID = 1;
 
 function buildAttendanceNameKey(rowIndex: number, column: number) {
   return `${rowIndex}-${column}`;
+}
+
+interface ResolvedTeacherAssignment {
+  subjectName: string;
+  classroomId: number;
+  classroomName: string;
+}
+
+function resolveTeacherAssignmentClassroomId(assignment: UserTeacherAssignmentResponseDto) {
+  const rawClassroomId = assignment.classroomId ?? assignment.classNameId;
+  const parsedClassroomId = Number.parseInt(String(rawClassroomId ?? ""), 10);
+
+  if (!Number.isFinite(parsedClassroomId) || parsedClassroomId <= 0) return null;
+  return parsedClassroomId;
+}
+
+function normalizeTeacherAssignments(teacherAssignments: UserTeacherAssignmentResponseDto[]) {
+  return teacherAssignments.flatMap((assignment, index) => {
+    const classroomId = resolveTeacherAssignmentClassroomId(assignment);
+    if (!classroomId) return [];
+
+    const classroomName = assignment.classroomName?.trim() ?? "";
+    const subjectName = assignment.subjectName?.trim() || classroomName || `수업 ${index + 1}`;
+
+    return [{ subjectName, classroomId, classroomName }];
+  });
 }
 
 function resolveClassroomName(
@@ -133,12 +160,43 @@ export default function ClassJournalCreatePage() {
 
   const currentUser = currentUserQuery.isFetchedAfterMount ? currentUserQuery.data : undefined;
   const teacherAssignments = currentUser?.teacherAssignments ?? [];
-  const singleTeacherAssignment = teacherAssignments.length === 1 ? teacherAssignments[0] : undefined;
-  const parsedClassroomId = Number.parseInt(String(singleTeacherAssignment?.classroomId ?? ""), 10);
-  const enrollmentClassroomId =
-    Number.isFinite(parsedClassroomId) && parsedClassroomId > 0
-      ? parsedClassroomId
-      : CLASS_JOURNAL_DEFAULT_CLASSROOM_ID;
+  const resolvedTeacherAssignments = useMemo(
+    () => normalizeTeacherAssignments(teacherAssignments),
+    [teacherAssignments],
+  );
+  const hasMultipleTeacherAssignments = resolvedTeacherAssignments.length > 1;
+  const [selectedAssignmentClassroomId, setSelectedAssignmentClassroomId] = useState<number | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!hasMultipleTeacherAssignments) {
+      if (selectedAssignmentClassroomId !== null) setSelectedAssignmentClassroomId(null);
+      return;
+    }
+
+    const hasSelectedAssignment = resolvedTeacherAssignments.some(
+      (assignment) => assignment.classroomId === selectedAssignmentClassroomId,
+    );
+
+    if (!hasSelectedAssignment) {
+      setSelectedAssignmentClassroomId(resolvedTeacherAssignments[0]?.classroomId ?? null);
+    }
+  }, [hasMultipleTeacherAssignments, resolvedTeacherAssignments, selectedAssignmentClassroomId]);
+
+  const selectedTeacherAssignment = useMemo(() => {
+    if (hasMultipleTeacherAssignments) {
+      return (
+        resolvedTeacherAssignments.find(
+          (assignment) => assignment.classroomId === selectedAssignmentClassroomId,
+        ) ?? resolvedTeacherAssignments[0]
+      );
+    }
+
+    return resolvedTeacherAssignments[0];
+  }, [hasMultipleTeacherAssignments, resolvedTeacherAssignments, selectedAssignmentClassroomId]);
+
+  const enrollmentClassroomId = selectedTeacherAssignment?.classroomId ?? CLASS_JOURNAL_DEFAULT_CLASSROOM_ID;
 
   const studentsQuery = useQuery({
     queryKey: queryKeys.students.list({
@@ -164,10 +222,13 @@ export default function ClassJournalCreatePage() {
   const dailyScheduleDetailQuery = useQuery({
     queryKey: ["daily-schedules", "detail", enrollmentClassroomId, todayIsoDate] as const,
     queryFn: () =>
-      getDailyScheduleDetail({
+      getDailyScheduleDetailIfExists({
         classroomId: enrollmentClassroomId,
         lessonDate: todayIsoDate,
       }),
+    enabled:
+      enrollmentClassroomId > 0 &&
+      (!hasMultipleTeacherAssignments || selectedAssignmentClassroomId !== null),
     retry: false,
   });
 
@@ -248,7 +309,7 @@ export default function ClassJournalCreatePage() {
       ),
     [enrollmentClassroomId, enrolledStudents, scheduleDetail?.classroomName],
   );
-  const assignedClassroomName = singleTeacherAssignment?.classroomName?.trim() ?? "";
+  const assignedClassroomName = selectedTeacherAssignment?.classroomName?.trim() ?? "";
 
   const lessonDateValue = lessonDateText || resolvedLessonDate;
   const classroomNameValue = classroomNameText || assignedClassroomName || resolvedClassroomName;
@@ -397,7 +458,45 @@ export default function ClassJournalCreatePage() {
           </InfoField>
 
           <InfoField>
-            <FieldLabel htmlFor="classroomName">담당 수업</FieldLabel>
+            <FieldLabel htmlFor="subjectName">과목</FieldLabel>
+            {hasMultipleTeacherAssignments ? (
+              <SubjectSelect
+                id="subjectName"
+                name="subjectName"
+                value={String(selectedAssignmentClassroomId ?? "")}
+                onChange={(event) => {
+                  const nextClassroomId = Number.parseInt(event.target.value, 10);
+                  setSelectedAssignmentClassroomId(
+                    Number.isFinite(nextClassroomId) && nextClassroomId > 0
+                      ? nextClassroomId
+                      : null,
+                  );
+                }}
+              >
+                {resolvedTeacherAssignments.map((assignment) => (
+                  <option
+                    key={`${assignment.classroomId}-${assignment.subjectName}`}
+                    value={assignment.classroomId}
+                  >
+                    {assignment.subjectName}
+                  </option>
+                ))}
+              </SubjectSelect>
+            ) : (
+              <ReadOnlyFieldInput
+                id="subjectName"
+                name="subjectName"
+                type="text"
+                value={resolvedTeacherAssignments[0]?.subjectName ?? ""}
+                placeholder="과목"
+                disabled
+                readOnly
+              />
+            )}
+          </InfoField>
+
+          <InfoField>
+            <FieldLabel htmlFor="classroomName">담당 반</FieldLabel>
             <EditableFieldInput
               id="classroomName"
               name="classroomName"
@@ -740,6 +839,13 @@ const ReadOnlyFieldInput = styled(FieldInput)`
 
 const EditableFieldInput = styled(FieldInput)`
   color: #000000;
+`;
+
+const SubjectSelect = styled.select`
+  ${fieldBaseStyle}
+  color: #000000;
+  appearance: none;
+  cursor: pointer;
 `;
 
 const LessonSection = styled.section`

--- a/mocks/handlers/user.handlers.ts
+++ b/mocks/handlers/user.handlers.ts
@@ -26,7 +26,7 @@ export const USER_ME_RESPONSE = {
   ...USER_DETAIL_RESPONSE,
   residentRegistrationNumberPrefix: "900101",
   phoneNumber: "010-2222-3333",
-  teacherAssignments: [{ classroomId: 1, classroomName: "벚꽃반" }],
+  teacherAssignments: [{ classroomId: 1, classroomName: "벚꽃반", subjectName: "국어" }],
 };
 
 export const TEACHER_CONTACT_LIST_RESPONSE = [


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

- 한 명의 교사가 여러 개의 과목을 담당하는 케이스를 고려하여 수업 일지를 작성할 때 과목을 선택할 수 있도록 드롭다운으로 UI 추가 구현
- 과목을 선택하면 담당 반 자동 입력 구현
- `GET /api/v1/daily-schedules/detail` 로 dailySchdule 데이터 조회 api를 변경

<img width="1194" height="580" alt="스크린샷 2026-06-06 오후 1 52 22" src="https://github.com/user-attachments/assets/3f33746f-cc41-4090-b858-881582f7acc9" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #125

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
