### PR TITLE
[FEAT] 메인페이지 공지사항 목록 상세 이동 및 hover 효과 수정

### DIFF
--- a/components/home/MeetingRecordsCard.tsx
+++ b/components/home/MeetingRecordsCard.tsx
@@ -102,8 +102,9 @@ const ListItem = styled.button`
   text-align: left;
   cursor: pointer;
 
-  &:hover ${Title} {
-    text-decoration: underline;
+  &:hover ${Title},
+  &:focus-visible ${Title} {
+    color: ${colors.point};
   }
 
   @media (min-width: 120rem) {

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -1,12 +1,23 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import styled from "styled-components";
 import { getPosts } from "@/api/post/post.api";
+import type { PostSummaryResponseDto } from "@/api/post/post.dto";
 import HomeCard from "@/components/home/HomeCard";
 import { useProtectedHomeNavigation } from "@/components/home/useProtectedHomeNavigation";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, spacing, typography } from "@/styles/tokens";
+
+function buildNoticeHref(notice: PostSummaryResponseDto) {
+  const postId = notice.id;
+  if (typeof postId !== "number") return "/staff/board?type=NOTICE";
+
+  return typeof notice.channelId === "number"
+    ? `/staff/board/${postId}?channelId=${notice.channelId}`
+    : `/staff/board/${postId}`;
+}
 
 export default function NoticeCard() {
   const { isAuthenticated, navigateWhenAuthenticated } = useProtectedHomeNavigation();
@@ -41,7 +52,7 @@ export default function NoticeCard() {
           !isLoading &&
           !isError &&
           notices.map((notice, index) => (
-            <ListItem key={`${notice.id ?? "notice"}-${index}`}>
+            <ListItem key={`${notice.id ?? "notice"}-${index}`} href={buildNoticeHref(notice)}>
               <Title>{notice.title ?? "제목 없음"}</Title>
               {/* <Date>{notice.date}</Date> */} {/*TODO*/}
             </ListItem>
@@ -60,19 +71,6 @@ const List = styled.div`
   flex-direction: column;
 `;
 
-const ListItem = styled.article`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: ${spacing.space16};
-  min-height: 2.625rem;
-  border-bottom: 0.0625rem solid ${colors.border};
-
-  @media (min-width: 120rem) {
-    min-height: 3.6875rem;
-  }
-`;
-
 const Title = styled.h3`
   min-width: 0;
   overflow: hidden;
@@ -85,6 +83,25 @@ const Title = styled.h3`
 
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize24};
+  }
+`;
+
+const ListItem = styled(Link)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${spacing.space16};
+  min-height: 2.625rem;
+  border-bottom: 0.0625rem solid ${colors.border};
+  text-decoration: none;
+
+  &:hover ${Title},
+  &:focus-visible ${Title} {
+    color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.6875rem;
   }
 `;
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

\- 메인페이지 공지사항 목록을 클릭 가능한 Link로 변경했습니다.
\- 공지사항 클릭 시 /staff/board/[postId]?channelId=... 상세 페이지로 이동하도록 연결했습니다.
\- 공지사항과 교학회의록 목록 hover/focus-visible 효과를 행사 사진과 동일한 초록색(colors.point)으로 맞췄습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #127 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
