### PR TITLE
[REFACTOR] 관리자 페이지 개편

### DIFF
--- a/api/department/department.api.ts
+++ b/api/department/department.api.ts
@@ -3,7 +3,9 @@ import type {
   CreateDepartmentRequestDto,
   DepartmentDetailResponseDto,
   DepartmentListResponseDto,
+  DepartmentPermissionRequestDto,
   DepartmentPathParamsDto,
+  PermissionResponseDto,
   DepartmentResponseDto,
   UpdateDepartmentRequestDto,
 } from "./department.dto";
@@ -43,4 +45,30 @@ export async function updateDepartment(
 // 특정 부서를 삭제하는 요청
 export async function deleteDepartment(pathParams: DepartmentPathParamsDto) {
   await authClient.delete(`/api/v1/departments/${pathParams.id}`);
+}
+
+// 특정 부서에 권한을 추가하는 요청
+export async function addDepartmentPermission(
+  pathParams: DepartmentPathParamsDto,
+  body: DepartmentPermissionRequestDto,
+) {
+  const response = await authClient.post<PermissionResponseDto[]>(
+    `/api/v1/departments/${pathParams.id}/permissions`,
+    body,
+  );
+  return response.data;
+}
+
+// 특정 부서에서 권한을 제거하는 요청
+export async function removeDepartmentPermission(
+  pathParams: DepartmentPathParamsDto,
+  body: DepartmentPermissionRequestDto,
+) {
+  const response = await authClient.delete<PermissionResponseDto[]>(
+    `/api/v1/departments/${pathParams.id}/permissions`,
+    {
+      data: body,
+    },
+  );
+  return response.data;
 }

--- a/api/lessonExchange/lessonExchange.dto.ts
+++ b/api/lessonExchange/lessonExchange.dto.ts
@@ -73,6 +73,7 @@ export interface LessonExchangeRequestListItemDto {
   classroomName: string;
   requestedByName: string;
   title: string;
+  lessonDate?: string;
   status: LessonExchangeRequestStatus;
   createdAt: string;
 }

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -18,6 +18,7 @@ export interface RequestStatusQueryParamsDto {
 
 export interface PurchaseRequestStatusQueryParamsDto {
   status?: PurchaseRequestStatus;
+  keyword?: string;
 }
 
 export interface RequestPathParamsDto {

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -17,6 +17,7 @@ import {
   getTeacherContacts,
   getUsers,
   removeUserPermission,
+  updateUser,
   updateCurrentUser,
 } from "./user.api";
 
@@ -67,6 +68,42 @@ describe("user.api", () => {
     expect(observedBody).toEqual({
       name: "Updated Teacher",
       email: "updated@example.com",
+    });
+  });
+
+  it("updates a user with departmentId in the expected PATCH body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.patch(`${API_BASE_URL}/api/v1/users/1`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          ...USER_LIST_RESPONSE.content[0],
+          departmentId: 2,
+        });
+      }),
+    );
+
+    const response = await updateUser(
+      { userId: 1 },
+      {
+        name: "Teacher One",
+        email: "teacher1@example.com",
+        phoneNumber: "010-2222-3333",
+        role: "VOLUNTEER",
+        departmentId: 2,
+      },
+    );
+
+    expect(response.departmentId).toBe(2);
+    expect(observedBody).toEqual({
+      name: "Teacher One",
+      email: "teacher1@example.com",
+      phoneNumber: "010-2222-3333",
+      role: "VOLUNTEER",
+      departmentId: 2,
     });
   });
 

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -256,11 +256,14 @@ function buildPermissionCode(form: PermissionFormState) {
 }
 
 function mapCreateUserFormToPayload(form: UserFormState) {
+  const name = form.name.trim();
+  const email = form.email.trim();
+
   return {
-    email: form.email.trim(),
-    nickname: form.nickname.trim(),
+    email,
+    nickname: form.nickname.trim() || name || email,
     password: form.password,
-    name: form.name.trim(),
+    name,
     phoneNumber: form.phoneNumber.trim() || undefined,
     role: form.role,
     departmentId: form.departmentId ? (toNumber(form.departmentId) ?? null) : null,
@@ -270,8 +273,6 @@ function mapCreateUserFormToPayload(form: UserFormState) {
 function mapUpdateUserFormToPayload(form: UserFormState) {
   return {
     email: form.email.trim(),
-    nickname: form.nickname.trim(),
-    ...(form.password ? { password: form.password } : {}),
     name: form.name.trim(),
     phoneNumber: form.phoneNumber.trim() || undefined,
     role: form.role,
@@ -376,6 +377,9 @@ export default function AdminDashboardPage() {
   const [classroomForm, setClassroomForm] = useState<ClassroomFormState>(emptyClassroomForm);
   const [postEdit, setPostEdit] = useState<PostEditState>(emptyPostEdit);
   const [isPostEditing, setIsPostEditing] = useState(false);
+  const [isUserEditing, setIsUserEditing] = useState(false);
+  const [isUserCreateModalOpen, setIsUserCreateModalOpen] = useState(false);
+  const [isUserDeleteConfirmOpen, setIsUserDeleteConfirmOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
@@ -491,12 +495,22 @@ export default function AdminDashboardPage() {
   const users = useMemo(() => usersQuery.data?.content ?? [], [usersQuery.data?.content]);
   const filteredUsers = useMemo(() => {
     const keyword = userSearch.trim().toLowerCase();
-    if (!keyword) {
-      return users;
-    }
-    return users.filter((item) =>
-      [item.name, item.nickname, item.email, item.role].some((value) =>
-        value?.toLowerCase().includes(keyword),
+    const collator = new Intl.Collator(["ko-KR", "en-US"], {
+      numeric: true,
+      sensitivity: "base",
+    });
+    const searchedUsers = keyword
+      ? users.filter((item) =>
+          [item.name, item.nickname, item.email, item.role].some((value) =>
+            value?.toLowerCase().includes(keyword),
+          ),
+        )
+      : users;
+
+    return [...searchedUsers].sort((first, second) =>
+      collator.compare(
+        first.name ?? first.nickname ?? first.email ?? "",
+        second.name ?? second.nickname ?? second.email ?? "",
       ),
     );
   }, [userSearch, users]);
@@ -577,6 +591,8 @@ export default function AdminDashboardPage() {
       return;
     }
     setSelectedUserId(item.id);
+    setIsUserEditing(false);
+    setIsUserDeleteConfirmOpen(false);
     setUserForm({
       email: item.email ?? "",
       nickname: item.nickname ?? "",
@@ -584,7 +600,12 @@ export default function AdminDashboardPage() {
       name: item.name ?? "",
       phoneNumber: item.phoneNumber ?? "",
       role: item.role ?? "VOLUNTEER",
-      departmentId: item.departmentId ? String(item.departmentId) : "",
+      departmentId:
+        item.departmentId !== null && item.departmentId !== undefined
+          ? String(item.departmentId)
+          : typeof item.department?.id === "number"
+            ? String(item.department.id)
+            : "",
     });
   }
 
@@ -653,6 +674,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => createUser(mapCreateUserFormToPayload(userForm)),
     onSuccess: () => {
       notifySuccess("사용자를 생성했습니다.");
+      setIsUserCreateModalOpen(false);
       setUserForm(emptyUserForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
     },
@@ -663,6 +685,7 @@ export default function AdminDashboardPage() {
       updateUser({ userId: selectedUserId ?? 0 }, mapUpdateUserFormToPayload(userForm)),
     onSuccess: () => {
       notifySuccess("사용자를 수정했습니다.");
+      setIsUserEditing(false);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
       if (selectedUserId) {
         queryClient.invalidateQueries({ queryKey: queryKeys.admin.userDetail(selectedUserId) });
@@ -675,6 +698,8 @@ export default function AdminDashboardPage() {
     onSuccess: () => {
       notifySuccess("사용자를 삭제했습니다.");
       setSelectedUserId(null);
+      setIsUserEditing(false);
+      setIsUserDeleteConfirmOpen(false);
       setUserForm(emptyUserForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
     },
@@ -1045,7 +1070,7 @@ export default function AdminDashboardPage() {
   if (!isAdmin) {
     return (
       <Main>
-        <AdminContent>
+        <AdminContent $compact={activeMenu === "users"}>
           <StatePanel>
             <LoadingSpinner label="관리자 권한 확인 중" />
           </StatePanel>
@@ -1106,7 +1131,7 @@ export default function AdminDashboardPage() {
       </Sidebar>
 
       <Main>
-        <AdminContent>
+        <AdminContent $compact={activeMenu === "users"}>
           <AccountText>{user?.email}</AccountText>
           <PageHeader>
             <Title>{currentTitle}</Title>
@@ -1128,7 +1153,11 @@ export default function AdminDashboardPage() {
           {activeMenu === "users" ? (
             <AdminUsersSection
               filteredUsers={filteredUsers}
+              departments={departments}
               selectedUserId={selectedUserId}
+              isUserEditing={isUserEditing}
+              isUserCreateModalOpen={isUserCreateModalOpen}
+              isUserDeleteConfirmOpen={isUserDeleteConfirmOpen}
               userSearch={userSearch}
               userForm={userForm}
               permissionForm={permissionForm}
@@ -1136,7 +1165,6 @@ export default function AdminDashboardPage() {
               availableActions={availableActions}
               canUseGlobalPermission={canUseGlobalPermission}
               canUseTargetPermission={canUseTargetPermission}
-              generatedPermissionCode={generatedPermissionCode}
               usersQuery={usersQuery}
               userDetailQuery={userDetailQuery}
               userPermissionsQuery={userPermissionsQuery}
@@ -1146,6 +1174,9 @@ export default function AdminDashboardPage() {
               addPermissionMutation={addPermissionMutation}
               removePermissionMutation={removePermissionMutation}
               setSelectedUserId={setSelectedUserId}
+              setIsUserEditing={setIsUserEditing}
+              setIsUserCreateModalOpen={setIsUserCreateModalOpen}
+              setIsUserDeleteConfirmOpen={setIsUserDeleteConfirmOpen}
               setUserSearch={setUserSearch}
               setUserForm={setUserForm}
               setPermissionForm={setPermissionForm}
@@ -1448,19 +1479,25 @@ const Main = styled.main`
   background-color: #f4f6f5;
 `;
 
-const AdminContent = styled.div`
+const AdminContent = styled.div<{ $compact?: boolean }>`
   position: relative;
   display: grid;
-  gap: ${spacing.space16};
+  gap: ${({ $compact }) => ($compact ? spacing.space12 : spacing.space16)};
   width: 100%;
   max-width: ${layout.adminMaxWidth};
   margin: 0 auto;
-  padding: 3.25rem ${spacing.space20} ${spacing.space32};
+  padding: ${({ $compact }) =>
+    $compact
+      ? `2.75rem ${spacing.space20} ${spacing.space20}`
+      : `3.25rem ${spacing.space20} ${spacing.space32}`};
 
   @media (min-width: 120rem) {
-    gap: ${spacing.space24};
+    gap: ${({ $compact }) => ($compact ? spacing.space16 : spacing.space24)};
     max-width: ${layout.adminMaxWidthLarge};
-    padding: 5.625rem ${spacing.space24} 4.125rem;
+    padding: ${({ $compact }) =>
+      $compact
+        ? `3.75rem ${spacing.space24} ${spacing.space20}`
+        : `5.625rem ${spacing.space24} 4.125rem`};
   }
 `;
 

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -1277,7 +1277,8 @@ export default function AdminDashboardPage() {
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
             activeMenu === "purchases" ||
-            activeMenu === "absenceRequests"
+            activeMenu === "absenceRequests" ||
+            activeMenu === "lessonExchange"
           }
         >
           <StatePanel>
@@ -1348,7 +1349,8 @@ export default function AdminDashboardPage() {
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
             activeMenu === "purchases" ||
-            activeMenu === "absenceRequests"
+            activeMenu === "absenceRequests" ||
+            activeMenu === "lessonExchange"
           }
         >
           <AccountText>{user?.email}</AccountText>

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -63,6 +63,7 @@ import {
   confirmPurchase,
   createPurchaseRequest,
   deleteAdminPurchaseRequest,
+  getAbsenceRequests,
   getAdminPurchaseRequestDetail,
   getAllPurchaseRequests,
   rejectAdminPurchaseRequest,
@@ -84,6 +85,7 @@ import {
   updateUser,
 } from "@/api/user/user.api";
 import type { PermissionDefinitionDto } from "@/api/user/user.dto";
+import { getLessonExchangeRequests } from "@/api/lessonExchange/lessonExchange.api";
 import { chargeVendor, getVendors } from "@/api/vendor/vendor.api";
 import type { VendorResponseDto } from "@/api/vendor/vendor.dto";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
@@ -93,15 +95,15 @@ import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "dashboard", label: "대시보드" },
-  { key: "users", label: "사용자" },
-  { key: "departments", label: "부서" },
-  { key: "classrooms", label: "분반" },
+  { key: "users", label: "사용자 관리" },
+  { key: "departments", label: "부서 관리" },
+  { key: "classrooms", label: "분반 관리" },
   { key: "lessons", label: "수업 관리" },
-  { key: "channels", label: "채널" },
-  { key: "posts", label: "게시글" },
-  { key: "purchases", label: "구매 요청" },
-  { key: "absenceRequests", label: "결석 요청" },
-  { key: "lessonExchange", label: "수업 교환 요청" },
+  { key: "channels", label: "채널 관리" },
+  { key: "posts", label: "게시글 관리" },
+  { key: "purchases", label: "결제 요청 관리" },
+  { key: "absenceRequests", label: "결강 요청 관리" },
+  { key: "lessonExchange", label: "수업 교환 요청 관리" },
 ];
 
 const fallbackPermissions: PermissionDefinitionDto[] = [
@@ -406,6 +408,16 @@ export default function AdminDashboardPage() {
     queryFn: () => getAllPurchaseRequests({ status: "PENDING" }),
     enabled: isAdmin,
   });
+  const pendingAbsenceRequestsQuery = useQuery({
+    queryKey: [...queryKeys.requests.absenceList(), "dashboard", "PENDING"],
+    queryFn: () => getAbsenceRequests({ status: "PENDING", page: 0, size: 1 }),
+    enabled: isAdmin,
+  });
+  const pendingLessonExchangeRequestsQuery = useQuery({
+    queryKey: [...queryKeys.requests.lessonExchangeList(), "dashboard", "PENDING"],
+    queryFn: () => getLessonExchangeRequests({ status: "PENDING", page: 0, size: 1 }),
+    enabled: isAdmin,
+  });
   const channelsQuery = useQuery({
     queryKey: queryKeys.admin.channels(),
     queryFn: () => getChannels({ name: channelSearch || undefined }),
@@ -525,7 +537,31 @@ export default function AdminDashboardPage() {
       label: "분반",
       value: getTotalFromPage(classrooms.length, classroomsQuery.data?.totalElements),
     },
-    { label: "대기 중 구매 요청", value: pendingPurchasesQuery.data?.length ?? 0 },
+  ];
+  const pendingPurchaseCount = pendingPurchasesQuery.data?.length ?? 0;
+  const pendingAbsenceRequestCount = pendingAbsenceRequestsQuery.data?.totalElements ?? 0;
+  const pendingLessonExchangeRequestCount =
+    pendingLessonExchangeRequestsQuery.data?.totalElements ?? 0;
+  const requestSummaries = [
+    {
+      label: "대기 중인 결제 요청",
+      count: pendingPurchaseCount,
+      description: `${pendingPurchaseCount}건의 검토가 필요합니다.`,
+      menu: "purchases" as const,
+      onClick: () => setPurchaseStatus("PENDING"),
+    },
+    {
+      label: "대기 중인 결강 요청",
+      count: pendingAbsenceRequestCount,
+      description: `${pendingAbsenceRequestCount}건의 검토가 필요합니다.`,
+      menu: "absenceRequests" as const,
+    },
+    {
+      label: "대기 중인 수업 교환 요청",
+      count: pendingLessonExchangeRequestCount,
+      description: `${pendingLessonExchangeRequestCount}건의 검토가 필요합니다.`,
+      menu: "lessonExchange" as const,
+    },
   ];
 
   function notifySuccess(message: string) {
@@ -931,9 +967,7 @@ export default function AdminDashboardPage() {
               {
                 amount: transaction.amount as number,
                 memo: `${purchase?.title ?? "구매 요청"} 선금 결제 충전`,
-                ...(transaction.receiptFileId
-                  ? { receiptFileId: transaction.receiptFileId }
-                  : {}),
+                ...(transaction.receiptFileId ? { receiptFileId: transaction.receiptFileId } : {}),
               },
             );
             prepaidTargetBalances.set(vendorId, chargedVendor.balance ?? 0);
@@ -1022,21 +1056,23 @@ export default function AdminDashboardPage() {
 
   const currentTitle = navigationItems.find((item) => item.key === activeMenu)?.label ?? "대시보드";
   const currentDescription = {
-    dashboard:
-      "전체 사용자, 부서, 분반, 승인 대기 구매 요청을 요약하고 주요 관리 화면으로 이동합니다.",
+    dashboard: "전체 운영 현황과 대기 중인 요청을 확인하고, 주요 관리 메뉴로 이동할 수 있습니다.",
     users:
-      "사용자 목록 조회, 역할 확인, 사용자 생성/수정/삭제, 직접 권한 조회와 권한 부여를 제공합니다.",
-    channels:
-      "채널 목록 조회, 유형과 연결 대상 확인, 채널 생성/수정/삭제 및 활성 상태 관리를 제공합니다.",
-    posts:
-      "공지/부서/반별 채널 게시글 작성, 이미지 첨부, 게시글 조회/수정/삭제/고정 관리를 제공합니다.",
+      "사이트에 가입된 계정 목록을 조회하고, 계정별 상세 정보와 권한을 수정하거나 계정을 생성/삭제할 수 있습니다.",
     departments:
-      "부서 목록과 상세 정보를 조회하고 부서 생성/수정/삭제, 소속 사용자와 권한 정보를 확인합니다.",
-    classrooms: "분반 목록과 상세 정보를 조회하고 분반 생성/수정/삭제 및 이름 검색을 제공합니다.",
-    lessons: "분반별 시간표를 확인하고 시간표 칸에서 수업 정보를 관리합니다.",
-    purchases: "구매 요청 작성, 목록/상세 조회, 승인/반려/결재 확인/삭제 처리를 제공합니다.",
-    absenceRequests: "결석 요청 목록 조회 및 승인/반려 처리를 제공합니다.",
-    lessonExchange: "수업 교환 요청 목록 조회 및 승인/반려 처리를 제공합니다.",
+      "사이트에 등록된 부서 목록과 상세 정보를 조회하고, 부서를 생성/수정/삭제할 수 있습니다.",
+    classrooms:
+      "사이트에 등록된 분반 목록과 상세 정보를 조회하고, 분반을 생성/수정/삭제할 수 있습니다.",
+    lessons:
+      "반별 시간표를 확인하고, 시간표의 각 칸을 선택하여 반별·요일별 수업 정보를 관리할 수 있습니다.",
+    channels:
+      "게시물 분류를 위한 채널 목록을 조회하고, 채널별 상태를 관리하거나 채널을 생성/수정/삭제할 수 있습니다.",
+    posts: "채널별 게시물 목록을 조회하고, 게시물을 생성/수정/삭제할 수 있습니다.",
+    purchases:
+      "물품 구매 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 및 결제 확정 처리를 할 수 있습니다.",
+    absenceRequests: "결강 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 처리를 할 수 있습니다.",
+    lessonExchange:
+      "수업 교환 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 처리를 할 수 있습니다.",
   }[activeMenu];
 
   return (
@@ -1079,12 +1115,14 @@ export default function AdminDashboardPage() {
           {activeMenu === "dashboard" ? (
             <AdminMainDashboardSection
               stats={stats}
+              requestSummaries={requestSummaries}
               usersQuery={usersQuery}
               departmentsQuery={departmentsQuery}
               classroomsQuery={classroomsQuery}
               pendingPurchasesQuery={pendingPurchasesQuery}
+              pendingAbsenceRequestsQuery={pendingAbsenceRequestsQuery}
+              pendingLessonExchangeRequestsQuery={pendingLessonExchangeRequestsQuery}
               setActiveMenu={setActiveMenu}
-              setPurchaseStatus={setPurchaseStatus}
             />
           ) : null}
           {activeMenu === "users" ? (

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -218,12 +218,16 @@ const emptyPostCreate: PostCreateState = {
 
 const emptyPurchaseCreate: PurchaseCreateState = {
   title: "",
-  content: "",
   classroomId: "",
-  itemName: "",
-  itemQuantity: "1",
-  itemReason: "",
-  itemPaymentType: "ACTUAL",
+  items: [
+    {
+      id: "purchase-item-1",
+      itemName: "",
+      itemQuantity: "1",
+      itemReason: "",
+      itemPaymentType: "ACTUAL",
+    },
+  ],
 };
 
 const emptyPermissionForm: PermissionFormState = {
@@ -375,6 +379,7 @@ export default function AdminDashboardPage() {
   const [postChannelTypeFilter, setPostChannelTypeFilter] = useState("all");
   const [postScopeFilter, setPostScopeFilter] = useState("all");
   const [classroomSearch, setClassroomSearch] = useState("");
+  const [purchaseSearch, setPurchaseSearch] = useState("");
   const [purchaseStatus, setPurchaseStatus] = useState<PurchaseRequestStatus | "">("");
   const [userForm, setUserForm] = useState<UserFormState>(emptyUserForm);
   const [channelForm, setChannelForm] = useState<ChannelFormState>(emptyChannelForm);
@@ -395,6 +400,7 @@ export default function AdminDashboardPage() {
   const [isClassroomCreateModalOpen, setIsClassroomCreateModalOpen] = useState(false);
   const [isClassroomDeleteConfirmOpen, setIsClassroomDeleteConfirmOpen] = useState(false);
   const [isPostCreateModalOpen, setIsPostCreateModalOpen] = useState(false);
+  const [isPurchaseCreateModalOpen, setIsPurchaseCreateModalOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
@@ -474,6 +480,11 @@ export default function AdminDashboardPage() {
   const purchasesQuery = useQuery({
     queryKey: queryKeys.admin.purchaseRequests(purchaseStatus || undefined),
     queryFn: () => getAllPurchaseRequests(purchaseStatus ? { status: purchaseStatus } : undefined),
+    enabled: isAdmin,
+  });
+  const vendorsQuery = useQuery({
+    queryKey: queryKeys.vendors.list(),
+    queryFn: () => getVendors(),
     enabled: isAdmin,
   });
   const permissionRegistryQuery = useQuery({
@@ -622,7 +633,25 @@ export default function AdminDashboardPage() {
     );
   }, [channelSearch, channels]);
   const posts = postsQuery.data?.content ?? [];
-  const purchases = purchasesQuery.data ?? [];
+  const purchases = useMemo(() => {
+    const rawPurchases = purchasesQuery.data ?? [];
+    const keyword = purchaseSearch.trim().toLowerCase();
+
+    if (!keyword) {
+      return rawPurchases;
+    }
+
+    return rawPurchases.filter((item) =>
+      [
+        item.id ? String(item.id) : "",
+        item.title,
+        item.classroomName,
+        item.requestedByName,
+        item.status,
+        item.totalPrice !== undefined && item.totalPrice !== null ? String(item.totalPrice) : "",
+      ].some((value) => value?.toLowerCase().includes(keyword)),
+    );
+  }, [purchaseSearch, purchasesQuery.data]);
   const registry = permissionRegistryQuery.data?.length
     ? permissionRegistryQuery.data
     : fallbackPermissions;
@@ -1086,20 +1115,23 @@ export default function AdminDashboardPage() {
     mutationFn: () =>
       createPurchaseRequest({
         title: purchaseCreate.title.trim(),
-        content: purchaseCreate.content.trim(),
+        content:
+          purchaseCreate.items
+            .map((item) => item.itemReason.trim())
+            .filter(Boolean)
+            .join("\n") || `${purchaseCreate.title.trim()} 결제 요청`,
         classroomId: toNumber(purchaseCreate.classroomId) ?? 0,
-        items: [
-          {
-            name: purchaseCreate.itemName.trim(),
-            quantity: Math.max(1, Math.trunc(toNumber(purchaseCreate.itemQuantity) ?? 1)),
-            reason: purchaseCreate.itemReason.trim() || undefined,
-            paymentType: purchaseCreate.itemPaymentType,
-          },
-        ],
+        items: purchaseCreate.items.map((item) => ({
+          name: item.itemName.trim(),
+          quantity: Math.max(1, Math.trunc(toNumber(item.itemQuantity) ?? 1)),
+          reason: item.itemReason.trim() || undefined,
+          paymentType: item.itemPaymentType,
+        })),
       }),
     onSuccess: () => {
       notifySuccess("구매 요청을 작성했습니다.");
       setPurchaseCreate(emptyPurchaseCreate);
+      setIsPurchaseCreateModalOpen(false);
       invalidateDashboard();
     },
     onError: (error) => notifyError(getErrorMessage(error, "구매 요청 작성에 실패했습니다.")),
@@ -1201,7 +1233,7 @@ export default function AdminDashboardPage() {
       return confirmedPurchase;
     },
     onSuccess: () => {
-      notifySuccess("구매 요청을 결재 확인했습니다.");
+      notifySuccess("구매 요청을 결제 확인했습니다.");
       invalidateDashboard();
       queryClient.invalidateQueries({ queryKey: queryKeys.vendors.list() });
       if (selectedPurchaseId) {
@@ -1210,7 +1242,7 @@ export default function AdminDashboardPage() {
         });
       }
     },
-    onError: (error) => notifyError(getErrorMessage(error, "결재 확인에 실패했습니다.")),
+    onError: (error) => notifyError(getErrorMessage(error, "결제 확인에 실패했습니다.")),
   });
   const deletePurchaseMutation = useMutation({
     mutationFn: () => deleteAdminPurchaseRequest({ requestId: selectedPurchaseId ?? 0 }),
@@ -1236,7 +1268,8 @@ export default function AdminDashboardPage() {
             activeMenu === "channels" ||
             activeMenu === "posts" ||
             activeMenu === "departments" ||
-            activeMenu === "classrooms"
+            activeMenu === "classrooms" ||
+            activeMenu === "purchases"
           }
         >
           <StatePanel>
@@ -1305,7 +1338,8 @@ export default function AdminDashboardPage() {
             activeMenu === "channels" ||
             activeMenu === "posts" ||
             activeMenu === "departments" ||
-            activeMenu === "classrooms"
+            activeMenu === "classrooms" ||
+            activeMenu === "purchases"
           }
         >
           <AccountText>{user?.email}</AccountText>
@@ -1478,19 +1512,25 @@ export default function AdminDashboardPage() {
               purchases={purchases}
               selectedPurchaseId={selectedPurchaseId}
               purchaseStatus={purchaseStatus}
+              purchaseSearch={purchaseSearch}
+              isPurchaseCreateModalOpen={isPurchaseCreateModalOpen}
               purchaseCreate={purchaseCreate}
               reviewNote={reviewNote}
               purchasesQuery={purchasesQuery}
               purchaseDetailQuery={purchaseDetailQuery}
+              vendorsQuery={vendorsQuery}
               createPurchaseMutation={createPurchaseMutation}
               approvePurchaseMutation={approvePurchaseMutation}
               rejectPurchaseMutation={rejectPurchaseMutation}
               confirmPurchaseMutation={confirmPurchaseMutation}
               deletePurchaseMutation={deletePurchaseMutation}
               setPurchaseStatus={setPurchaseStatus}
+              setPurchaseSearch={setPurchaseSearch}
+              setIsPurchaseCreateModalOpen={setIsPurchaseCreateModalOpen}
               setPurchaseCreate={setPurchaseCreate}
               setSelectedPurchaseId={setSelectedPurchaseId}
               setReviewNote={setReviewNote}
+              emptyPurchaseCreate={emptyPurchaseCreate}
             />
           ) : null}
           <ToastContainer position="top-right" autoClose={2400} newestOnTop pauseOnHover />

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -386,6 +386,9 @@ export default function AdminDashboardPage() {
   const [isDepartmentEditing, setIsDepartmentEditing] = useState(false);
   const [isDepartmentCreateModalOpen, setIsDepartmentCreateModalOpen] = useState(false);
   const [isDepartmentDeleteConfirmOpen, setIsDepartmentDeleteConfirmOpen] = useState(false);
+  const [isClassroomEditing, setIsClassroomEditing] = useState(false);
+  const [isClassroomCreateModalOpen, setIsClassroomCreateModalOpen] = useState(false);
+  const [isClassroomDeleteConfirmOpen, setIsClassroomDeleteConfirmOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
@@ -542,7 +545,28 @@ export default function AdminDashboardPage() {
       collator.compare(first.name ?? "", second.name ?? ""),
     );
   }, [departmentSearch, departments]);
-  const classrooms = classroomsQuery.data?.content ?? [];
+  const classrooms = useMemo(
+    () => classroomsQuery.data?.content ?? [],
+    [classroomsQuery.data?.content],
+  );
+  const filteredClassrooms = useMemo(() => {
+    const keyword = classroomSearch.trim().toLowerCase();
+    const collator = new Intl.Collator(["ko-KR", "en-US"], {
+      numeric: true,
+      sensitivity: "base",
+    });
+    const searchedClassrooms = keyword
+      ? classrooms.filter((item) =>
+          [item.name, item.type, item.description, item.id ? String(item.id) : ""].some((value) =>
+            value?.toLowerCase().includes(keyword),
+          ),
+        )
+      : classrooms;
+
+    return [...searchedClassrooms].sort((first, second) =>
+      collator.compare(first.name ?? "", second.name ?? ""),
+    );
+  }, [classroomSearch, classrooms]);
   const channels = channelsQuery.data ?? [];
   const posts = postsQuery.data?.content ?? [];
   const purchases = purchasesQuery.data ?? [];
@@ -688,6 +712,8 @@ export default function AdminDashboardPage() {
       return;
     }
     setSelectedClassroomId(item.id);
+    setIsClassroomEditing(false);
+    setIsClassroomDeleteConfirmOpen(false);
     setClassroomForm({
       name: item.name ?? "",
       type: item.type ?? "WEEKDAY",
@@ -963,6 +989,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => createClassroom(classroomForm),
     onSuccess: () => {
       notifySuccess("분반을 생성했습니다.");
+      setIsClassroomCreateModalOpen(false);
       setClassroomForm(emptyClassroomForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
     },
@@ -972,6 +999,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => updateClassroom({ id: selectedClassroomId ?? 0 }, classroomForm),
     onSuccess: () => {
       notifySuccess("분반을 수정했습니다.");
+      setIsClassroomEditing(false);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
       if (selectedClassroomId) {
         queryClient.invalidateQueries({
@@ -986,6 +1014,8 @@ export default function AdminDashboardPage() {
     onSuccess: () => {
       notifySuccess("분반을 삭제했습니다.");
       setSelectedClassroomId(null);
+      setIsClassroomEditing(false);
+      setIsClassroomDeleteConfirmOpen(false);
       setClassroomForm(emptyClassroomForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
     },
@@ -1140,7 +1170,13 @@ export default function AdminDashboardPage() {
   if (!isAdmin) {
     return (
       <Main>
-        <AdminContent $compact={activeMenu === "users" || activeMenu === "departments"}>
+        <AdminContent
+          $compact={
+            activeMenu === "users" ||
+            activeMenu === "departments" ||
+            activeMenu === "classrooms"
+          }
+        >
           <StatePanel>
             <LoadingSpinner label="관리자 권한 확인 중" />
           </StatePanel>
@@ -1201,7 +1237,13 @@ export default function AdminDashboardPage() {
       </Sidebar>
 
       <Main>
-        <AdminContent $compact={activeMenu === "users" || activeMenu === "departments"}>
+        <AdminContent
+          $compact={
+            activeMenu === "users" ||
+            activeMenu === "departments" ||
+            activeMenu === "classrooms"
+          }
+        >
           <AccountText>{user?.email}</AccountText>
           <PageHeader>
             <Title>{currentTitle}</Title>
@@ -1329,8 +1371,11 @@ export default function AdminDashboardPage() {
           ) : null}
           {activeMenu === "classrooms" ? (
             <AdminClassroomsSection
-              classrooms={classrooms}
+              classrooms={filteredClassrooms}
               selectedClassroomId={selectedClassroomId}
+              isClassroomEditing={isClassroomEditing}
+              isClassroomCreateModalOpen={isClassroomCreateModalOpen}
+              isClassroomDeleteConfirmOpen={isClassroomDeleteConfirmOpen}
               classroomSearch={classroomSearch}
               classroomForm={classroomForm}
               classroomsQuery={classroomsQuery}
@@ -1339,6 +1384,9 @@ export default function AdminDashboardPage() {
               updateClassroomMutation={updateClassroomMutation}
               deleteClassroomMutation={deleteClassroomMutation}
               setSelectedClassroomId={setSelectedClassroomId}
+              setIsClassroomEditing={setIsClassroomEditing}
+              setIsClassroomCreateModalOpen={setIsClassroomCreateModalOpen}
+              setIsClassroomDeleteConfirmOpen={setIsClassroomDeleteConfirmOpen}
               setClassroomSearch={setClassroomSearch}
               setClassroomForm={setClassroomForm}
               selectClassroom={selectClassroom}

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -103,9 +103,9 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "lessons", label: "수업 관리" },
   { key: "channels", label: "채널 관리" },
   { key: "posts", label: "게시글 관리" },
-  { key: "purchases", label: "결제 요청 관리" },
-  { key: "absenceRequests", label: "결강 요청 관리" },
   { key: "lessonExchange", label: "수업 교환 요청 관리" },
+  { key: "absenceRequests", label: "결강 요청 관리" },
+  { key: "purchases", label: "결제 요청 관리" },
 ];
 
 const fallbackPermissions: PermissionDefinitionDto[] = [
@@ -429,7 +429,7 @@ export default function AdminDashboardPage() {
     placeholderData: (previousData) => previousData,
   });
   const pendingPurchasesQuery = useQuery({
-    queryKey: queryKeys.admin.purchaseRequests("PENDING"),
+    queryKey: queryKeys.admin.purchaseRequests({ status: "PENDING" }),
     queryFn: () => getAllPurchaseRequests({ status: "PENDING" }),
     enabled: isAdmin,
   });
@@ -478,8 +478,15 @@ export default function AdminDashboardPage() {
     enabled: isAdmin,
   });
   const purchasesQuery = useQuery({
-    queryKey: queryKeys.admin.purchaseRequests(purchaseStatus || undefined),
-    queryFn: () => getAllPurchaseRequests(purchaseStatus ? { status: purchaseStatus } : undefined),
+    queryKey: queryKeys.admin.purchaseRequests({
+      status: purchaseStatus || undefined,
+      keyword: purchaseSearch.trim() || undefined,
+    }),
+    queryFn: () =>
+      getAllPurchaseRequests({
+        status: purchaseStatus || undefined,
+        keyword: purchaseSearch.trim() || undefined,
+      }),
     enabled: isAdmin,
   });
   const vendorsQuery = useQuery({
@@ -691,11 +698,10 @@ export default function AdminDashboardPage() {
     pendingLessonExchangeRequestsQuery.data?.totalElements ?? 0;
   const requestSummaries = [
     {
-      label: "대기 중인 결제 요청",
-      count: pendingPurchaseCount,
-      description: `${pendingPurchaseCount}건의 검토가 필요합니다.`,
-      menu: "purchases" as const,
-      onClick: () => setPurchaseStatus("PENDING"),
+      label: "대기 중인 수업 교환 요청",
+      count: pendingLessonExchangeRequestCount,
+      description: `${pendingLessonExchangeRequestCount}건의 검토가 필요합니다.`,
+      menu: "lessonExchange" as const,
     },
     {
       label: "대기 중인 결강 요청",
@@ -704,10 +710,11 @@ export default function AdminDashboardPage() {
       menu: "absenceRequests" as const,
     },
     {
-      label: "대기 중인 수업 교환 요청",
-      count: pendingLessonExchangeRequestCount,
-      description: `${pendingLessonExchangeRequestCount}건의 검토가 필요합니다.`,
-      menu: "lessonExchange" as const,
+      label: "대기 중인 결제 요청",
+      count: pendingPurchaseCount,
+      description: `${pendingPurchaseCount}건의 검토가 필요합니다.`,
+      menu: "purchases" as const,
+      onClick: () => setPurchaseStatus("PENDING"),
     },
   ];
 
@@ -1269,7 +1276,8 @@ export default function AdminDashboardPage() {
             activeMenu === "posts" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
-            activeMenu === "purchases"
+            activeMenu === "purchases" ||
+            activeMenu === "absenceRequests"
           }
         >
           <StatePanel>
@@ -1339,7 +1347,8 @@ export default function AdminDashboardPage() {
             activeMenu === "posts" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
-            activeMenu === "purchases"
+            activeMenu === "purchases" ||
+            activeMenu === "absenceRequests"
           }
         >
           <AccountText>{user?.email}</AccountText>
@@ -1504,8 +1513,8 @@ export default function AdminDashboardPage() {
             />
           ) : null}
           {activeMenu === "lessons" ? <AdminLessonManagementSection /> : null}
-          {activeMenu === "absenceRequests" ? <AdminAbsenceRequestsSection /> : null}
           {activeMenu === "lessonExchange" ? <AdminLessonExchangeSection /> : null}
+          {activeMenu === "absenceRequests" ? <AdminAbsenceRequestsSection /> : null}
           {activeMenu === "purchases" ? (
             <AdminPurchasesSection
               classrooms={classrooms}

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -108,6 +108,12 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "purchases", label: "결제 요청 관리" },
 ];
 
+const ADMIN_ACTIVE_MENU_STORAGE_KEY = "admin-active-menu";
+
+function isAdminMenu(value: string | null): value is AdminMenu {
+  return Boolean(value && navigationItems.some((item) => item.key === value));
+}
+
 const fallbackPermissions: PermissionDefinitionDto[] = [
   {
     permissionCode: "user:manage:*",
@@ -363,7 +369,14 @@ export default function AdminDashboardPage() {
   const queryClient = useQueryClient();
   const { status, user, signOut } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
-  const [activeMenu, setActiveMenu] = useState<AdminMenu>("dashboard");
+  const [activeMenu, setActiveMenu] = useState<AdminMenu>(() => {
+    if (typeof window === "undefined") {
+      return "dashboard";
+    }
+
+    const storedMenu = window.localStorage.getItem(ADMIN_ACTIVE_MENU_STORAGE_KEY);
+    return isAdminMenu(storedMenu) ? storedMenu : "dashboard";
+  });
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<number | null>(null);
   const [selectedPost, setSelectedPost] = useState<{ channelId: number; postId: number } | null>(
@@ -405,6 +418,32 @@ export default function AdminDashboardPage() {
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
   const [reviewNote, setReviewNote] = useState("");
+
+  function resetTransientPanels() {
+    setSelectedUserId(null);
+    setSelectedChannelId(null);
+    setSelectedPost(null);
+    setSelectedDepartmentId(null);
+    setSelectedClassroomId(null);
+    setSelectedPurchaseId(null);
+    setIsUserEditing(false);
+    setIsChannelEditing(false);
+    setIsPostEditing(false);
+    setIsDepartmentEditing(false);
+    setIsClassroomEditing(false);
+    setIsUserDeleteConfirmOpen(false);
+    setIsChannelDeleteConfirmOpen(false);
+    setIsDepartmentDeleteConfirmOpen(false);
+    setIsClassroomDeleteConfirmOpen(false);
+    setPostEdit(emptyPostEdit);
+    setReviewNote("");
+  }
+
+  function handleActiveMenuChange(menu: AdminMenu) {
+    resetTransientPanels();
+    setActiveMenu(menu);
+    window.localStorage.setItem(ADMIN_ACTIVE_MENU_STORAGE_KEY, menu);
+  }
 
   useEffect(() => {
     if (status === "unauthenticated" || (status === "authenticated" && user?.role !== "ADMIN")) {
@@ -1328,7 +1367,7 @@ export default function AdminDashboardPage() {
               key={item.key}
               type="button"
               $active={activeMenu === item.key}
-              onClick={() => setActiveMenu(item.key)}
+              onClick={() => handleActiveMenuChange(item.key)}
             >
               {item.label}
             </SidebarItem>
@@ -1368,7 +1407,7 @@ export default function AdminDashboardPage() {
               pendingPurchasesQuery={pendingPurchasesQuery}
               pendingAbsenceRequestsQuery={pendingAbsenceRequestsQuery}
               pendingLessonExchangeRequestsQuery={pendingLessonExchangeRequestsQuery}
-              setActiveMenu={setActiveMenu}
+              setActiveMenu={handleActiveMenuChange}
             />
           ) : null}
           {activeMenu === "users" ? (

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -383,6 +383,9 @@ export default function AdminDashboardPage() {
   const [isUserEditing, setIsUserEditing] = useState(false);
   const [isUserCreateModalOpen, setIsUserCreateModalOpen] = useState(false);
   const [isUserDeleteConfirmOpen, setIsUserDeleteConfirmOpen] = useState(false);
+  const [isChannelEditing, setIsChannelEditing] = useState(false);
+  const [isChannelCreateModalOpen, setIsChannelCreateModalOpen] = useState(false);
+  const [isChannelDeleteConfirmOpen, setIsChannelDeleteConfirmOpen] = useState(false);
   const [isDepartmentEditing, setIsDepartmentEditing] = useState(false);
   const [isDepartmentCreateModalOpen, setIsDepartmentCreateModalOpen] = useState(false);
   const [isDepartmentDeleteConfirmOpen, setIsDepartmentDeleteConfirmOpen] = useState(false);
@@ -567,7 +570,30 @@ export default function AdminDashboardPage() {
       collator.compare(first.name ?? "", second.name ?? ""),
     );
   }, [classroomSearch, classrooms]);
-  const channels = channelsQuery.data ?? [];
+  const channels = useMemo(() => channelsQuery.data ?? [], [channelsQuery.data]);
+  const filteredChannels = useMemo(() => {
+    const keyword = channelSearch.trim().toLowerCase();
+    const collator = new Intl.Collator(["ko-KR", "en-US"], {
+      numeric: true,
+      sensitivity: "base",
+    });
+    const searchedChannels = keyword
+      ? channels.filter((item) =>
+          [
+            item.name,
+            item.description,
+            item.channelType,
+            item.bindingType,
+            item.refId ? String(item.refId) : "",
+            item.id ? String(item.id) : "",
+          ].some((value) => value?.toLowerCase().includes(keyword)),
+        )
+      : channels;
+
+    return [...searchedChannels].sort((first, second) =>
+      collator.compare(first.name ?? "", second.name ?? ""),
+    );
+  }, [channelSearch, channels]);
   const posts = postsQuery.data?.content ?? [];
   const purchases = purchasesQuery.data ?? [];
   const registry = permissionRegistryQuery.data?.length
@@ -665,6 +691,8 @@ export default function AdminDashboardPage() {
       return;
     }
     setSelectedChannelId(item.id);
+    setIsChannelEditing(false);
+    setIsChannelDeleteConfirmOpen(false);
     setChannelForm({
       name: item.name ?? "",
       description: item.description ?? "",
@@ -802,6 +830,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => createChannel(mapChannelFormToPayload(channelForm)),
     onSuccess: () => {
       notifySuccess("채널을 생성했습니다.");
+      setIsChannelCreateModalOpen(false);
       setChannelForm(emptyChannelForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
     },
@@ -812,6 +841,7 @@ export default function AdminDashboardPage() {
       updateChannel({ id: selectedChannelId ?? 0 }, mapChannelFormToPayload(channelForm)),
     onSuccess: () => {
       notifySuccess("채널을 수정했습니다.");
+      setIsChannelEditing(false);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
       if (selectedChannelId) {
         queryClient.invalidateQueries({
@@ -826,6 +856,8 @@ export default function AdminDashboardPage() {
     onSuccess: () => {
       notifySuccess("채널을 삭제했습니다.");
       setSelectedChannelId(null);
+      setIsChannelEditing(false);
+      setIsChannelDeleteConfirmOpen(false);
       setChannelForm(emptyChannelForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.channels() });
     },
@@ -1173,6 +1205,7 @@ export default function AdminDashboardPage() {
         <AdminContent
           $compact={
             activeMenu === "users" ||
+            activeMenu === "channels" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms"
           }
@@ -1240,6 +1273,7 @@ export default function AdminDashboardPage() {
         <AdminContent
           $compact={
             activeMenu === "users" ||
+            activeMenu === "channels" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms"
           }
@@ -1298,8 +1332,11 @@ export default function AdminDashboardPage() {
           ) : null}
           {activeMenu === "channels" ? (
             <AdminChannelsSection
-              channels={channels}
+              channels={filteredChannels}
               selectedChannelId={selectedChannelId}
+              isChannelEditing={isChannelEditing}
+              isChannelCreateModalOpen={isChannelCreateModalOpen}
+              isChannelDeleteConfirmOpen={isChannelDeleteConfirmOpen}
               channelSearch={channelSearch}
               channelForm={channelForm}
               channelsQuery={channelsQuery}
@@ -1308,6 +1345,9 @@ export default function AdminDashboardPage() {
               updateChannelMutation={updateChannelMutation}
               deleteChannelMutation={deleteChannelMutation}
               setSelectedChannelId={setSelectedChannelId}
+              setIsChannelEditing={setIsChannelEditing}
+              setIsChannelCreateModalOpen={setIsChannelCreateModalOpen}
+              setIsChannelDeleteConfirmOpen={setIsChannelDeleteConfirmOpen}
               setChannelSearch={setChannelSearch}
               setChannelForm={setChannelForm}
               selectChannel={selectChannel}

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -43,10 +43,12 @@ import {
   updateClassroom,
 } from "@/api/classroom/classroom.api";
 import {
+  addDepartmentPermission,
   createDepartment,
   deleteDepartment,
   getDepartmentDetail,
   getDepartments,
+  removeDepartmentPermission,
   updateDepartment,
 } from "@/api/department/department.api";
 import {
@@ -367,6 +369,7 @@ export default function AdminDashboardPage() {
   const [selectedClassroomId, setSelectedClassroomId] = useState<number | null>(null);
   const [selectedPurchaseId, setSelectedPurchaseId] = useState<number | null>(null);
   const [userSearch, setUserSearch] = useState("");
+  const [departmentSearch, setDepartmentSearch] = useState("");
   const [channelSearch, setChannelSearch] = useState("");
   const [postTitleSearch, setPostTitleSearch] = useState("");
   const [classroomSearch, setClassroomSearch] = useState("");
@@ -380,6 +383,9 @@ export default function AdminDashboardPage() {
   const [isUserEditing, setIsUserEditing] = useState(false);
   const [isUserCreateModalOpen, setIsUserCreateModalOpen] = useState(false);
   const [isUserDeleteConfirmOpen, setIsUserDeleteConfirmOpen] = useState(false);
+  const [isDepartmentEditing, setIsDepartmentEditing] = useState(false);
+  const [isDepartmentCreateModalOpen, setIsDepartmentCreateModalOpen] = useState(false);
+  const [isDepartmentDeleteConfirmOpen, setIsDepartmentDeleteConfirmOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
@@ -514,7 +520,28 @@ export default function AdminDashboardPage() {
       ),
     );
   }, [userSearch, users]);
-  const departments = departmentsQuery.data?.departments ?? [];
+  const departments = useMemo(
+    () => departmentsQuery.data?.departments ?? [],
+    [departmentsQuery.data?.departments],
+  );
+  const filteredDepartments = useMemo(() => {
+    const keyword = departmentSearch.trim().toLowerCase();
+    const collator = new Intl.Collator(["ko-KR", "en-US"], {
+      numeric: true,
+      sensitivity: "base",
+    });
+    const searchedDepartments = keyword
+      ? departments.filter((item) =>
+          [item.name, item.description, item.id ? String(item.id) : ""].some((value) =>
+            value?.toLowerCase().includes(keyword),
+          ),
+        )
+      : departments;
+
+    return [...searchedDepartments].sort((first, second) =>
+      collator.compare(first.name ?? "", second.name ?? ""),
+    );
+  }, [departmentSearch, departments]);
   const classrooms = classroomsQuery.data?.content ?? [];
   const channels = channelsQuery.data ?? [];
   const posts = postsQuery.data?.content ?? [];
@@ -648,6 +675,8 @@ export default function AdminDashboardPage() {
       return;
     }
     setSelectedDepartmentId(item.id);
+    setIsDepartmentEditing(false);
+    setIsDepartmentDeleteConfirmOpen(false);
     setDepartmentForm({
       name: item.name ?? "",
       description: item.description ?? "",
@@ -670,6 +699,11 @@ export default function AdminDashboardPage() {
     queryClient.invalidateQueries({ queryKey: ["admin"] });
   };
 
+  function invalidateDepartmentMembershipQueries() {
+    queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
+    queryClient.invalidateQueries({ queryKey: ["admin", "departments", "detail"] });
+  }
+
   const createUserMutation = useMutation({
     mutationFn: () => createUser(mapCreateUserFormToPayload(userForm)),
     onSuccess: () => {
@@ -677,6 +711,7 @@ export default function AdminDashboardPage() {
       setIsUserCreateModalOpen(false);
       setUserForm(emptyUserForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+      invalidateDepartmentMembershipQueries();
     },
     onError: (error) => notifyError(getErrorMessage(error, "사용자 생성에 실패했습니다.")),
   });
@@ -687,6 +722,7 @@ export default function AdminDashboardPage() {
       notifySuccess("사용자를 수정했습니다.");
       setIsUserEditing(false);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+      invalidateDepartmentMembershipQueries();
       if (selectedUserId) {
         queryClient.invalidateQueries({ queryKey: queryKeys.admin.userDetail(selectedUserId) });
       }
@@ -702,6 +738,7 @@ export default function AdminDashboardPage() {
       setIsUserDeleteConfirmOpen(false);
       setUserForm(emptyUserForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.users(0, 50) });
+      invalidateDepartmentMembershipQueries();
     },
     onError: (error) => notifyError(getErrorMessage(error, "사용자 삭제에 실패했습니다.")),
   });
@@ -854,6 +891,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => createDepartment(departmentForm),
     onSuccess: () => {
       notifySuccess("부서를 생성했습니다.");
+      setIsDepartmentCreateModalOpen(false);
       setDepartmentForm(emptyDepartmentForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
     },
@@ -863,6 +901,7 @@ export default function AdminDashboardPage() {
     mutationFn: () => updateDepartment({ id: selectedDepartmentId ?? 0 }, departmentForm),
     onSuccess: () => {
       notifySuccess("부서를 수정했습니다.");
+      setIsDepartmentEditing(false);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
       if (selectedDepartmentId) {
         queryClient.invalidateQueries({
@@ -877,6 +916,8 @@ export default function AdminDashboardPage() {
     onSuccess: () => {
       notifySuccess("부서를 삭제했습니다.");
       setSelectedDepartmentId(null);
+      setIsDepartmentEditing(false);
+      setIsDepartmentDeleteConfirmOpen(false);
       setDepartmentForm(emptyDepartmentForm);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.departments() });
     },
@@ -887,6 +928,35 @@ export default function AdminDashboardPage() {
           "부서 삭제에 실패했습니다. 할당된 역할이나 멤버가 있으면 삭제할 수 없습니다.",
         ),
       ),
+  });
+  const addDepartmentPermissionMutation = useMutation({
+    mutationFn: () =>
+      addDepartmentPermission(
+        { id: selectedDepartmentId ?? 0 },
+        { permissionCode: generatedPermissionCode },
+      ),
+    onSuccess: () => {
+      notifySuccess("부서 권한을 추가했습니다.");
+      if (selectedDepartmentId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.departmentDetail(selectedDepartmentId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "부서 권한 추가에 실패했습니다.")),
+  });
+  const removeDepartmentPermissionMutation = useMutation({
+    mutationFn: (permissionCode: string) =>
+      removeDepartmentPermission({ id: selectedDepartmentId ?? 0 }, { permissionCode }),
+    onSuccess: () => {
+      notifySuccess("부서 권한을 제거했습니다.");
+      if (selectedDepartmentId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.departmentDetail(selectedDepartmentId),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "부서 권한 제거에 실패했습니다.")),
   });
 
   const createClassroomMutation = useMutation({
@@ -1070,7 +1140,7 @@ export default function AdminDashboardPage() {
   if (!isAdmin) {
     return (
       <Main>
-        <AdminContent $compact={activeMenu === "users"}>
+        <AdminContent $compact={activeMenu === "users" || activeMenu === "departments"}>
           <StatePanel>
             <LoadingSpinner label="관리자 권한 확인 중" />
           </StatePanel>
@@ -1131,7 +1201,7 @@ export default function AdminDashboardPage() {
       </Sidebar>
 
       <Main>
-        <AdminContent $compact={activeMenu === "users"}>
+        <AdminContent $compact={activeMenu === "users" || activeMenu === "departments"}>
           <AccountText>{user?.email}</AccountText>
           <PageHeader>
             <Title>{currentTitle}</Title>
@@ -1229,16 +1299,30 @@ export default function AdminDashboardPage() {
           ) : null}
           {activeMenu === "departments" ? (
             <AdminDepartmentsSection
-              departments={departments}
+              departments={filteredDepartments}
               selectedDepartmentId={selectedDepartmentId}
+              isDepartmentEditing={isDepartmentEditing}
+              isDepartmentCreateModalOpen={isDepartmentCreateModalOpen}
+              isDepartmentDeleteConfirmOpen={isDepartmentDeleteConfirmOpen}
+              departmentSearch={departmentSearch}
               departmentForm={departmentForm}
+              permissionForm={permissionForm}
+              permissionOptions={permissionOptions}
+              availableActions={availableActions}
               departmentsQuery={departmentsQuery}
               departmentDetailQuery={departmentDetailQuery}
               createDepartmentMutation={createDepartmentMutation}
               updateDepartmentMutation={updateDepartmentMutation}
               deleteDepartmentMutation={deleteDepartmentMutation}
+              addDepartmentPermissionMutation={addDepartmentPermissionMutation}
+              removeDepartmentPermissionMutation={removeDepartmentPermissionMutation}
               setSelectedDepartmentId={setSelectedDepartmentId}
+              setIsDepartmentEditing={setIsDepartmentEditing}
+              setIsDepartmentCreateModalOpen={setIsDepartmentCreateModalOpen}
+              setIsDepartmentDeleteConfirmOpen={setIsDepartmentDeleteConfirmOpen}
+              setDepartmentSearch={setDepartmentSearch}
               setDepartmentForm={setDepartmentForm}
+              setPermissionForm={setPermissionForm}
               selectDepartment={selectDepartment}
               emptyDepartmentForm={emptyDepartmentForm}
             />

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -372,6 +372,8 @@ export default function AdminDashboardPage() {
   const [departmentSearch, setDepartmentSearch] = useState("");
   const [channelSearch, setChannelSearch] = useState("");
   const [postTitleSearch, setPostTitleSearch] = useState("");
+  const [postChannelTypeFilter, setPostChannelTypeFilter] = useState("all");
+  const [postScopeFilter, setPostScopeFilter] = useState("all");
   const [classroomSearch, setClassroomSearch] = useState("");
   const [purchaseStatus, setPurchaseStatus] = useState<PurchaseRequestStatus | "">("");
   const [userForm, setUserForm] = useState<UserFormState>(emptyUserForm);
@@ -392,6 +394,7 @@ export default function AdminDashboardPage() {
   const [isClassroomEditing, setIsClassroomEditing] = useState(false);
   const [isClassroomCreateModalOpen, setIsClassroomCreateModalOpen] = useState(false);
   const [isClassroomDeleteConfirmOpen, setIsClassroomDeleteConfirmOpen] = useState(false);
+  const [isPostCreateModalOpen, setIsPostCreateModalOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
   const [purchaseCreate, setPurchaseCreate] = useState<PurchaseCreateState>(emptyPurchaseCreate);
   const [permissionForm, setPermissionForm] = useState<PermissionFormState>(emptyPermissionForm);
@@ -440,8 +443,32 @@ export default function AdminDashboardPage() {
     enabled: isAdmin,
   });
   const postsQuery = useQuery({
-    queryKey: queryKeys.admin.posts(0, 50),
-    queryFn: () => getPosts({ page: 0, size: 50, title: postTitleSearch || undefined }),
+    queryKey: [
+      "admin",
+      "posts",
+      {
+        page: 0,
+        size: 50,
+        title: postTitleSearch || undefined,
+        channelType: postChannelTypeFilter === "all" ? undefined : postChannelTypeFilter,
+        scope: postScopeFilter,
+      },
+    ],
+    queryFn: () =>
+      getPosts({
+        page: 0,
+        size: 50,
+        title: postTitleSearch || undefined,
+        channelType: postChannelTypeFilter === "all" ? undefined : postChannelTypeFilter,
+        classroomId:
+          postChannelTypeFilter === "CLASSROOM" && postScopeFilter !== "all"
+            ? (toNumber(postScopeFilter) ?? undefined)
+            : undefined,
+        departmentId:
+          postChannelTypeFilter === "DEPARTMENT" && postScopeFilter !== "all"
+            ? (toNumber(postScopeFilter) ?? undefined)
+            : undefined,
+      }),
     enabled: isAdmin,
   });
   const purchasesQuery = useQuery({
@@ -879,8 +906,9 @@ export default function AdminDashboardPage() {
       ),
     onSuccess: () => {
       notifySuccess("게시글을 작성했습니다.");
+      setIsPostCreateModalOpen(false);
       setPostCreate(emptyPostCreate);
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
     },
     onError: (error) => notifyError(getErrorMessage(error, "게시글 작성에 실패했습니다.")),
   });
@@ -906,7 +934,7 @@ export default function AdminDashboardPage() {
     onSuccess: (updatedPost) => {
       notifySuccess("게시글을 수정했습니다.");
       setIsPostEditing(false);
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
       if (selectedPost) {
         queryClient.setQueryData(
           queryKeys.admin.postDetail(selectedPost.channelId, selectedPost.postId),
@@ -926,7 +954,7 @@ export default function AdminDashboardPage() {
       setSelectedPost(null);
       setIsPostEditing(false);
       setPostEdit(emptyPostEdit);
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
     },
     onError: (error) => notifyError(getErrorMessage(error, "게시글 삭제에 실패했습니다.")),
   });
@@ -935,7 +963,7 @@ export default function AdminDashboardPage() {
       pinPost(selectedPost ?? { channelId: 0, postId: 0 }, { isPinned }),
     onSuccess: () => {
       notifySuccess("게시글 고정 상태를 변경했습니다.");
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.posts(0, 50) });
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
       if (selectedPost) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.admin.postDetail(selectedPost.channelId, selectedPost.postId),
@@ -1206,6 +1234,7 @@ export default function AdminDashboardPage() {
           $compact={
             activeMenu === "users" ||
             activeMenu === "channels" ||
+            activeMenu === "posts" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms"
           }
@@ -1274,6 +1303,7 @@ export default function AdminDashboardPage() {
           $compact={
             activeMenu === "users" ||
             activeMenu === "channels" ||
+            activeMenu === "posts" ||
             activeMenu === "departments" ||
             activeMenu === "classrooms"
           }
@@ -1362,9 +1392,12 @@ export default function AdminDashboardPage() {
               posts={posts}
               selectedPost={selectedPost}
               postTitleSearch={postTitleSearch}
+              postChannelTypeFilter={postChannelTypeFilter}
+              postScopeFilter={postScopeFilter}
               postCreate={postCreate}
               postEdit={postEdit}
               isPostEditing={isPostEditing}
+              isPostCreateModalOpen={isPostCreateModalOpen}
               postsQuery={postsQuery}
               postDetailQuery={postDetailQuery}
               createPostMutation={createPostMutation}
@@ -1372,9 +1405,12 @@ export default function AdminDashboardPage() {
               pinPostMutation={pinPostMutation}
               deletePostMutation={deletePostMutation}
               setPostTitleSearch={setPostTitleSearch}
+              setPostChannelTypeFilter={setPostChannelTypeFilter}
+              setPostScopeFilter={setPostScopeFilter}
               setPostCreate={setPostCreate}
               setPostEdit={setPostEdit}
               setIsPostEditing={setIsPostEditing}
+              setIsPostCreateModalOpen={setIsPostCreateModalOpen}
               selectPost={selectPost}
               closePostDetail={closePostDetail}
             />

--- a/components/admin/AdminDashboardSectionParts.tsx
+++ b/components/admin/AdminDashboardSectionParts.tsx
@@ -257,6 +257,7 @@ export const StatePanel = styled.div<{ $compact?: boolean }>`
 export const DataStateBox = styled.div<{ $compact?: boolean }>`
   display: flex;
   width: 100%;
+  height: 100%;
   min-height: ${({ $compact }) => ($compact ? "0" : "16rem")};
   margin-bottom: ${({ $compact }) => ($compact ? "0" : spacing.space12)};
 `;

--- a/components/admin/AdminDashboardSectionParts.tsx
+++ b/components/admin/AdminDashboardSectionParts.tsx
@@ -69,7 +69,7 @@ export const TwoColumnGrid = styled.div`
 
 export const StatsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: ${spacing.space12};
 
   @media (min-width: 120rem) {
@@ -81,6 +81,29 @@ export const StatsGrid = styled.div`
   }
 `;
 
+export const DashboardStack = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+  }
+`;
+
+export const RequestSummaryGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 export const StatCard = styled.section`
   min-height: 5.125rem;
   padding: 1rem 0.875rem;
@@ -89,7 +112,6 @@ export const StatCard = styled.section`
   border-radius: ${radii.radius12};
 
   @media (min-width: 120rem) {
-    min-height: 8.25rem;
     padding: 1.5rem;
   }
 `;
@@ -113,7 +135,11 @@ export const StatValue = styled.p`
 export const DashboardGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: ${spacing.space16};
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+  }
 
   @media (max-width: ${layout.breakpointTablet}) {
     grid-template-columns: 1fr;
@@ -172,19 +198,26 @@ export const ActionGrid = styled.div`
   }
 `;
 
-export const SupportGrid = styled(ActionGrid)`
-  max-width: 41rem;
+export const SingleActionGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: ${spacing.space12};
 `;
 
 export const ActionCardButton = styled.button`
   min-height: 4.25rem;
   border: 1px solid #e1e5e3;
   border-radius: 0.5rem;
-  padding: 1rem;
+  padding: ${spacing.space16};
   background-color: ${colors.white};
   font-family: inherit;
   text-align: left;
   cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 5rem;
+    padding: 1.5rem;
+  }
 
   &:hover {
     border-color: ${colors.point};
@@ -199,9 +232,9 @@ export const ActionTitle = styled.p<{ $accent?: boolean }>`
   line-height: ${typography.lineHeight130};
 `;
 
-export const ActionDescription = styled.p`
+export const ActionDescription = styled.p<{ $alert?: boolean }>`
   margin: 0;
-  color: #64706c;
+  color: ${({ $alert }) => ($alert ? "#d86a63" : "#64706c")};
   font-size: ${typography.fontSize13};
   line-height: ${typography.lineHeight130};
 `;
@@ -212,7 +245,8 @@ export const StatePanel = styled.div<{ $compact?: boolean }>`
   justify-content: center;
   width: 100%;
   min-height: ${({ $compact }) => ($compact ? "5.5rem" : "8rem")};
-  padding: ${({ $compact }) => ($compact ? `${spacing.space8} ${spacing.space12}` : spacing.space20)};
+  padding: ${({ $compact }) =>
+    $compact ? `${spacing.space8} ${spacing.space12}` : spacing.space20};
   background-color: ${colors.white};
   border: 1px solid #e6e9e7;
   border-radius: ${radii.radius12};

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -66,14 +66,18 @@ export type PostCreateState = {
   contentHtml: string;
 };
 
-export type PurchaseCreateState = {
-  title: string;
-  content: string;
-  classroomId: string;
+export type PurchaseCreateItemState = {
+  id: string;
   itemName: string;
   itemQuantity: string;
   itemReason: string;
   itemPaymentType: "PREPAID" | "ACTUAL";
+};
+
+export type PurchaseCreateState = {
+  title: string;
+  classroomId: string;
+  items: PurchaseCreateItemState[];
 };
 
 export type PermissionFormState = {

--- a/components/admin/AdminMainDashboardSection.tsx
+++ b/components/admin/AdminMainDashboardSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { Dispatch, SetStateAction } from "react";
-import type { PurchaseRequestStatus } from "@/api/request/request.dto";
 import type { AdminMenu } from "@/components/admin/AdminDashboardTypes";
 import {
   ActionCardButton,
@@ -10,13 +9,15 @@ import {
   ActionTitle,
   DataState,
   DashboardGrid,
+  DashboardStack,
+  RequestSummaryGrid,
   SectionCard,
   SectionTitle,
+  SingleActionGrid,
   StatCard,
   StatLabel,
   StatsGrid,
   StatValue,
-  SupportGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
 
 type QueryState = {
@@ -29,30 +30,136 @@ type StatItem = {
   value: number;
 };
 
+type RequestSummaryItem = {
+  label: string;
+  description: string;
+  count: number;
+  menu: AdminMenu;
+  onClick?: () => void;
+};
+
+type ManagementGroup = {
+  title: string;
+  columns?: "single" | "double";
+  actions: {
+    title: string;
+    description: string;
+    menu: AdminMenu;
+  }[];
+};
+
 type AdminMainDashboardSectionProps = {
   stats: StatItem[];
+  requestSummaries: RequestSummaryItem[];
   usersQuery: QueryState;
   departmentsQuery: QueryState;
   classroomsQuery: QueryState;
   pendingPurchasesQuery: QueryState;
+  pendingAbsenceRequestsQuery: QueryState;
+  pendingLessonExchangeRequestsQuery: QueryState;
   setActiveMenu: Dispatch<SetStateAction<AdminMenu>>;
-  setPurchaseStatus: Dispatch<SetStateAction<PurchaseRequestStatus | "">>;
 };
 
 export function AdminMainDashboardSection({
   stats,
+  requestSummaries,
   usersQuery,
   departmentsQuery,
   classroomsQuery,
   pendingPurchasesQuery,
+  pendingAbsenceRequestsQuery,
+  pendingLessonExchangeRequestsQuery,
   setActiveMenu,
-  setPurchaseStatus,
 }: AdminMainDashboardSectionProps) {
+  const isDashboardLoading =
+    usersQuery.isLoading ||
+    departmentsQuery.isLoading ||
+    classroomsQuery.isLoading ||
+    pendingPurchasesQuery.isLoading ||
+    pendingAbsenceRequestsQuery.isLoading ||
+    pendingLessonExchangeRequestsQuery.isLoading;
+  const isDashboardError =
+    usersQuery.isError ||
+    departmentsQuery.isError ||
+    classroomsQuery.isError ||
+    pendingPurchasesQuery.isError ||
+    pendingAbsenceRequestsQuery.isError ||
+    pendingLessonExchangeRequestsQuery.isError;
+
+  const managementGroups: ManagementGroup[] = [
+    {
+      title: "사용자 및 소속 관리",
+      actions: [
+        {
+          title: "사용자 관리",
+          description: "사이트 내 가입된 계정 관리",
+          menu: "users",
+        },
+        {
+          title: "부서 관리",
+          description: "기관 산하 부서 조직 관리",
+          menu: "departments",
+        },
+        {
+          title: "분반 관리",
+          description: "기관 내 수업 분반 관리",
+          menu: "classrooms",
+        },
+      ],
+    },
+    {
+      title: "교육 운영",
+      columns: "single",
+      actions: [
+        {
+          title: "수업 관리",
+          description: "반별 시간표와 수업 정보 관리",
+          menu: "lessons",
+        },
+      ],
+    },
+    {
+      title: "게시판 관리",
+      actions: [
+        {
+          title: "채널 관리",
+          description: "게시물 분류를 위한 채널 관리",
+          menu: "channels",
+        },
+        {
+          title: "게시글 관리",
+          description: "모든 채널의 게시물 관리",
+          menu: "posts",
+        },
+      ],
+    },
+    {
+      title: "요청 관리",
+      actions: [
+        {
+          title: "결제 요청 관리",
+          description: "물품 구매 요청 처리",
+          menu: "purchases",
+        },
+        {
+          title: "결강 요청 관리",
+          description: "결강 요청 승인/반려 처리",
+          menu: "absenceRequests",
+        },
+        {
+          title: "수업 교환 요청 관리",
+          description: "수업 교환 요청 승인/반려 처리",
+          menu: "lessonExchange",
+        },
+      ],
+    },
+  ];
+
   return (
-    <>
+    <DashboardStack>
       <DataState
-        isLoading={usersQuery.isLoading || departmentsQuery.isLoading || classroomsQuery.isLoading || pendingPurchasesQuery.isLoading}
-        isError={usersQuery.isError || departmentsQuery.isError || classroomsQuery.isError || pendingPurchasesQuery.isError}
+        isLoading={isDashboardLoading}
+        isError={isDashboardError}
         isEmpty={false}
         loadingLabel="관리자 데이터 불러오는 중"
         errorLabel="대시보드 데이터를 불러오지 못했습니다."
@@ -68,59 +175,49 @@ export function AdminMainDashboardSection({
         </StatsGrid>
       </DataState>
 
+      <RequestSummaryGrid>
+        {requestSummaries.map((item) => {
+          const hasPendingRequests = item.count > 0;
+
+          return (
+            <ActionCardButton
+              key={item.label}
+              type="button"
+              onClick={() => {
+                item.onClick?.();
+                setActiveMenu(item.menu);
+              }}
+            >
+              <ActionTitle $accent>{item.label}</ActionTitle>
+              <ActionDescription $alert={hasPendingRequests}>{item.description}</ActionDescription>
+            </ActionCardButton>
+          );
+        })}
+      </RequestSummaryGrid>
+
       <DashboardGrid>
-        <SectionCard>
-          <SectionTitle>사용자 및 권한 관리</SectionTitle>
-          <ActionGrid>
-            <ActionCardButton type="button" onClick={() => setActiveMenu("users")}>
-              <ActionTitle>사용자 관리</ActionTitle>
-              <ActionDescription>전체 사용자 및 권한 조회/수정</ActionDescription>
-            </ActionCardButton>
-            <ActionCardButton type="button" onClick={() => setActiveMenu("departments")}>
-              <ActionTitle>부서 관리</ActionTitle>
-              <ActionDescription>기관 산하 부서 조직 구성</ActionDescription>
-            </ActionCardButton>
-          </ActionGrid>
-        </SectionCard>
+        {managementGroups.map((group) => {
+          const GridComponent = group.columns === "single" ? SingleActionGrid : ActionGrid;
 
-        <SectionCard>
-          <SectionTitle>게시판 및 교육 운영</SectionTitle>
-          <ActionGrid>
-            <ActionCardButton type="button" onClick={() => setActiveMenu("channels")}>
-              <ActionTitle>채널 관리</ActionTitle>
-              <ActionDescription>소통 채널 및 게시판 설정</ActionDescription>
-            </ActionCardButton>
-            <ActionCardButton type="button" onClick={() => setActiveMenu("posts")}>
-              <ActionTitle>게시글 관리</ActionTitle>
-              <ActionDescription>모든 채널의 게시물 모니터링</ActionDescription>
-            </ActionCardButton>
-            <ActionCardButton type="button" onClick={() => setActiveMenu("classrooms")}>
-              <ActionTitle>분반 관리</ActionTitle>
-              <ActionDescription>분반 및 교육 과정 운영</ActionDescription>
-            </ActionCardButton>
-          </ActionGrid>
-        </SectionCard>
+          return (
+            <SectionCard key={group.title}>
+              <SectionTitle>{group.title}</SectionTitle>
+              <GridComponent>
+                {group.actions.map((action) => (
+                  <ActionCardButton
+                    key={action.title}
+                    type="button"
+                    onClick={() => setActiveMenu(action.menu)}
+                  >
+                    <ActionTitle>{action.title}</ActionTitle>
+                    <ActionDescription>{action.description}</ActionDescription>
+                  </ActionCardButton>
+                ))}
+              </GridComponent>
+            </SectionCard>
+          );
+        })}
       </DashboardGrid>
-
-      <SectionCard>
-        <SectionTitle>결재 및 행정 지원</SectionTitle>
-        <SupportGrid>
-          <ActionCardButton type="button" onClick={() => setActiveMenu("purchases")}>
-            <ActionTitle>전체 구매 요청</ActionTitle>
-            <ActionDescription>물품 구매 요청 이력 확인</ActionDescription>
-          </ActionCardButton>
-          <ActionCardButton
-            type="button"
-            onClick={() => {
-              setPurchaseStatus("PENDING");
-              setActiveMenu("purchases");
-            }}
-          >
-            <ActionTitle $accent>승인 대기 중</ActionTitle>
-            <ActionDescription>검토가 필요한 신규 구매 요청</ActionDescription>
-          </ActionCardButton>
-        </SupportGrid>
-      </SectionCard>
-    </>
+    </DashboardStack>
   );
 }

--- a/components/admin/AdminMainDashboardSection.tsx
+++ b/components/admin/AdminMainDashboardSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
 import type { AdminMenu } from "@/components/admin/AdminDashboardTypes";
 import {
   ActionCardButton,
@@ -57,7 +56,7 @@ type AdminMainDashboardSectionProps = {
   pendingPurchasesQuery: QueryState;
   pendingAbsenceRequestsQuery: QueryState;
   pendingLessonExchangeRequestsQuery: QueryState;
-  setActiveMenu: Dispatch<SetStateAction<AdminMenu>>;
+  setActiveMenu: (menu: AdminMenu) => void;
 };
 
 export function AdminMainDashboardSection({

--- a/components/admin/AdminMainDashboardSection.tsx
+++ b/components/admin/AdminMainDashboardSection.tsx
@@ -137,9 +137,9 @@ export function AdminMainDashboardSection({
       title: "요청 관리",
       actions: [
         {
-          title: "결제 요청 관리",
-          description: "물품 구매 요청 처리",
-          menu: "purchases",
+          title: "수업 교환 요청 관리",
+          description: "수업 교환 요청 승인/반려 처리",
+          menu: "lessonExchange",
         },
         {
           title: "결강 요청 관리",
@@ -147,9 +147,9 @@ export function AdminMainDashboardSection({
           menu: "absenceRequests",
         },
         {
-          title: "수업 교환 요청 관리",
-          description: "수업 교환 요청 승인/반려 처리",
-          menu: "lessonExchange",
+          title: "결제 요청 관리",
+          description: "물품 구매 요청 처리",
+          menu: "purchases",
         },
       ],
     },

--- a/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel.tsx
@@ -1,20 +1,23 @@
 "use client";
 
+import { useState } from "react";
 import styled from "styled-components";
-import { formatAbsenceDate } from "@/components/admin/absence-requests/absenceRequestConstants";
-import { AbsenceStatusBadge } from "@/components/admin/absence-requests/AbsenceStatusBadge";
+import {
+  formatAbsenceDate,
+  formatAbsenceStatus,
+} from "@/components/admin/absence-requests/absenceRequestConstants";
 import type { AdminAbsenceRequestsViewModel } from "@/components/admin/absence-requests/useAdminAbsenceRequests";
 import {
   ButtonRow,
   DangerButton,
   DataState,
   FormGrid,
-  PrimaryButton,
-  SectionCard,
-  SectionTitle,
+  List,
+  ListItem,
+  SmallButton,
   TextArea,
 } from "@/components/admin/AdminDashboardSectionParts";
-import { spacing, typography } from "@/styles/tokens";
+import { colors, radii, spacing, typography } from "@/styles/tokens";
 
 type AdminAbsenceRequestsDetailPanelProps = Pick<
   AdminAbsenceRequestsViewModel,
@@ -34,10 +37,25 @@ export function AdminAbsenceRequestsDetailPanel({
   handleReject,
   isActionPending,
 }: AdminAbsenceRequestsDetailPanelProps) {
-  return (
-    <SectionCard>
-      <SectionTitle>결강 요청 상세/처리</SectionTitle>
+  const [confirmAction, setConfirmAction] = useState<"approve" | "reject" | null>(null);
+  const [isRejecting, setIsRejecting] = useState(false);
 
+  function runConfirmedAction() {
+    if (confirmAction === "approve") {
+      handleApprove();
+      setConfirmAction(null);
+      return;
+    }
+
+    if (confirmAction === "reject") {
+      handleReject();
+      setConfirmAction(null);
+      setIsRejecting(false);
+    }
+  }
+
+  return (
+    <DetailPanelContent>
       <DataState
         isLoading={false}
         isError={false}
@@ -46,129 +64,166 @@ export function AdminAbsenceRequestsDetailPanel({
         errorLabel=""
         emptyLabel="결강 요청을 선택하세요."
       >
-        <DetailStack>
-          <DetailFields>
-            <DetailField $fullWidth>
-              <DetailFieldLabel>제목</DetailFieldLabel>
-              <DetailFieldValue>{selectedAbsence?.title ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>분반</DetailFieldLabel>
-              <DetailFieldValue>{selectedAbsence?.classroomName ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>수업일</DetailFieldLabel>
-              <DetailFieldValue>{formatAbsenceDate(selectedAbsence?.lessonDate)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>요청자</DetailFieldLabel>
-              <DetailFieldValue>{selectedAbsence?.requestedByName ?? "-"}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>상태</DetailFieldLabel>
-              <DetailFieldValue>
-                <AbsenceStatusBadge status={selectedAbsence?.status} />
-              </DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>만료 시각</DetailFieldLabel>
-              <DetailFieldValue>{formatAbsenceDate(selectedAbsence?.expiresAt)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>요청일</DetailFieldLabel>
-              <DetailFieldValue>{formatAbsenceDate(selectedAbsence?.createdAt)}</DetailFieldValue>
-            </DetailField>
-            <DetailField>
-              <DetailFieldLabel>처리일</DetailFieldLabel>
-              <DetailFieldValue>{formatAbsenceDate(selectedAbsence?.approvalAt)}</DetailFieldValue>
-            </DetailField>
-          </DetailFields>
+        <PanelContent>
+          <DetailBlock>
+            <DetailBlockTitle>요청 정보</DetailBlockTitle>
+            <List>
+              <ListItem>
+                <span>제목</span>
+                <span>{selectedAbsence?.title ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>요청자</span>
+                <span>{selectedAbsence?.requestedByName ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>분반</span>
+                <span>{selectedAbsence?.classroomName ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>수업 일자</span>
+                <span>{formatAbsenceDate(selectedAbsence?.lessonDate)}</span>
+              </ListItem>
+              <ListItem>
+                <span>요청 일자</span>
+                <span>{formatAbsenceDate(selectedAbsence?.createdAt)}</span>
+              </ListItem>
+              <ListItem>
+                <span>상태</span>
+                <span>{formatAbsenceStatus(selectedAbsence?.status)}</span>
+              </ListItem>
+            </List>
+          </DetailBlock>
 
-          <ReasonSection>
-            <CompactDivider />
-
-            <DetailField $fullWidth $compact>
-              <DetailFieldLabel>사유</DetailFieldLabel>
-              <DetailTextBox>{selectedAbsence?.reason?.trim() || "-"}</DetailTextBox>
-            </DetailField>
-
+          <DetailBlock>
+            <DetailBlockTitle>사유</DetailBlockTitle>
+            <DetailTextBox>{selectedAbsence?.reason?.trim() || "-"}</DetailTextBox>
             {selectedAbsence?.status === "REJECTED" ? (
-              <DetailField $fullWidth $compact>
-                <DetailFieldLabel>거절 사유</DetailFieldLabel>
+              <DetailBlock>
+                <DetailBlockTitle>거절 사유</DetailBlockTitle>
                 <DetailNoteBox>{selectedAbsence.note?.trim() || "-"}</DetailNoteBox>
-              </DetailField>
+              </DetailBlock>
             ) : null}
+          </DetailBlock>
 
-            <CompactDivider />
-          </ReasonSection>
-
-          <ActionSection>
-            <DetailFieldLabel>처리</DetailFieldLabel>
-            {selectedAbsence?.approvalAt ? (
-              <ProcessedBadge>처리 완료</ProcessedBadge>
-            ) : (
+          {!selectedAbsence?.approvalAt ? (
+            <ActionBlock>
               <FormGrid onSubmit={(event) => event.preventDefault()}>
-                <RejectNoteTextArea
-                  value={rejectNote}
-                  placeholder="거절 사유를 입력해 주세요."
-                  disabled={isActionPending}
-                  onChange={(event) => setRejectNote(event.target.value)}
-                />
+                {isRejecting ? (
+                  <RejectNoteTextArea
+                    value={rejectNote}
+                    placeholder="거절 사유를 입력해 주세요."
+                    disabled={isActionPending}
+                    onChange={(event) => setRejectNote(event.target.value)}
+                    autoFocus
+                  />
+                ) : null}
                 <ButtonRow>
-                  <PrimaryButton type="button" disabled={isActionPending} onClick={handleApprove}>
-                    승인
-                  </PrimaryButton>
-                  <DangerButton
-                    type="button"
-                    disabled={isActionPending || !rejectNote.trim()}
-                    onClick={handleReject}
-                  >
-                    거절
-                  </DangerButton>
+                  {isRejecting ? (
+                    <>
+                      <DangerButton
+                        type="button"
+                        disabled={isActionPending || !rejectNote.trim()}
+                        onClick={() => setConfirmAction("reject")}
+                      >
+                        확인
+                      </DangerButton>
+                      <SmallButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => {
+                          setIsRejecting(false);
+                          setRejectNote("");
+                        }}
+                      >
+                        취소
+                      </SmallButton>
+                    </>
+                  ) : (
+                    <>
+                      <AbsenceActionButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => setConfirmAction("approve")}
+                      >
+                        승인
+                      </AbsenceActionButton>
+                      <DangerButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => setIsRejecting(true)}
+                      >
+                        거절
+                      </DangerButton>
+                    </>
+                  )}
                 </ButtonRow>
               </FormGrid>
-            )}
-          </ActionSection>
-        </DetailStack>
+            </ActionBlock>
+          ) : null}
+        </PanelContent>
       </DataState>
-    </SectionCard>
+
+      {confirmAction ? (
+        <ModalBackdrop onMouseDown={() => setConfirmAction(null)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="absence-action-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="absence-action-confirm-title">결강 요청 처리</ConfirmTitle>
+            <ConfirmMessage>
+              {confirmAction === "approve" ? "승인하시겠습니까?" : "거절하시겠습니까?"}
+            </ConfirmMessage>
+            <ButtonRow>
+              <AbsenceActionButton type="button" disabled={isActionPending} onClick={runConfirmedAction}>
+                확인
+              </AbsenceActionButton>
+              <SmallButton
+                type="button"
+                disabled={isActionPending}
+                onClick={() => setConfirmAction(null)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </DetailPanelContent>
   );
 }
 
-function ProcessedBadge({ children }: { children: string }) {
-  return <ProcessedBadgeBox>{children}</ProcessedBadgeBox>;
-}
-
-const DetailStack = styled.div`
-  display: grid;
-  gap: ${spacing.space20};
-`;
-
-const DetailFields = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: ${spacing.space16};
-`;
-
-const DetailField = styled.div<{ $fullWidth?: boolean; $compact?: boolean }>`
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? spacing.space4 : spacing.space8)};
+const DetailPanelContent = styled.div`
   min-width: 0;
-  grid-column: ${({ $fullWidth }) => ($fullWidth ? "1 / -1" : "auto")};
 `;
 
-const DetailFieldLabel = styled.span`
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const ActionBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
   color: #64706c;
   font-size: ${typography.fontSize13};
   font-weight: 800;
   line-height: ${typography.lineHeight130};
-`;
-
-const DetailFieldValue = styled.div`
-  color: #1f2b28;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight150};
-  word-break: break-word;
 `;
 
 const DetailTextBox = styled.div`
@@ -189,42 +244,79 @@ const DetailNoteBox = styled(DetailTextBox)`
   color: #1f2b28;
 `;
 
-const CompactDivider = styled.hr`
-  width: 100%;
-  margin: ${spacing.space8} 0;
-  border: 0;
-  border-top: 1px solid #e6e9e7;
-`;
-
-const ReasonSection = styled.section`
-  display: grid;
-  gap: ${spacing.space8};
-  margin: 0;
-`;
-
-const ActionSection = styled.section`
-  display: grid;
-  gap: ${spacing.space12};
-  margin-top: -${spacing.space12};
-`;
-
 const RejectNoteTextArea = styled(TextArea)`
+  min-height: 6rem;
   resize: none;
   font-weight: 500;
 `;
 
-const ProcessedBadgeBox = styled.span`
+const AbsenceActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: fit-content;
-  min-width: 3.25rem;
-  padding: 0.25rem 0.625rem;
-  border-radius: 999px;
-  background: #dcf4ea;
-  color: #3da75c;
-  font-size: ${typography.fontSize13};
-  font-weight: 700;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
   line-height: ${typography.lineHeight130};
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ConfirmDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 24rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
 `;

--- a/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel.tsx
@@ -11,7 +11,6 @@ import {
   FormGrid,
   PrimaryButton,
   SectionCard,
-  SectionDescription,
   SectionTitle,
   TextArea,
 } from "@/components/admin/AdminDashboardSectionParts";
@@ -37,10 +36,7 @@ export function AdminAbsenceRequestsDetailPanel({
 }: AdminAbsenceRequestsDetailPanelProps) {
   return (
     <SectionCard>
-      <SectionTitle>결석 요청 상세/처리</SectionTitle>
-      <SectionDescription>
-        선택한 결석 요청의 상세 정보를 확인하고 승인 또는 반려 처리를 수행합니다.
-      </SectionDescription>
+      <SectionTitle>결강 요청 상세/처리</SectionTitle>
 
       <DataState
         isLoading={false}
@@ -48,7 +44,7 @@ export function AdminAbsenceRequestsDetailPanel({
         isEmpty={!selectedAbsence}
         loadingLabel=""
         errorLabel=""
-        emptyLabel="결석 요청을 선택하세요."
+        emptyLabel="결강 요청을 선택하세요."
       >
         <DetailStack>
           <DetailFields>

--- a/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
@@ -62,7 +62,7 @@ export function AdminAbsenceRequestsListPanel({
 
   return (
     <SectionCard>
-      <SectionTitle>결석 요청 목록</SectionTitle>
+      <SectionTitle>결강 요청 목록</SectionTitle>
       <ControlRow
         as="form"
         onSubmit={(event) => {
@@ -92,52 +92,52 @@ export function AdminAbsenceRequestsListPanel({
         <TableViewport>
           {isLoading ? (
             <ListOverlay>
-              <LoadingSpinner label="결석 요청 목록 불러오는 중" />
+              <LoadingSpinner label="결강 요청 목록 불러오는 중" />
             </ListOverlay>
           ) : null}
           {isError ? (
             <ListOverlay role="alert">
-              <ListOverlayMessage>결석 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
+              <ListOverlayMessage>결강 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
             </ListOverlay>
           ) : null}
           {isEmpty ? (
             <ListOverlay>
-              <ListOverlayMessage>결석 요청이 없습니다.</ListOverlayMessage>
+              <ListOverlayMessage>결강 요청이 없습니다.</ListOverlayMessage>
             </ListOverlay>
           ) : null}
 
           <AbsenceListTable>
-          <thead>
-            <tr>
-              <th>제목</th>
-              <th>분반</th>
-              <th>요청자</th>
-              <th>상태</th>
-              <th>일자</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sortedRequests.map((item) => (
-              <AbsenceTableRow
-                key={item.id ?? `${item.title}-${item.createdAt}`}
-                $selected={item.id === selectedAbsenceId}
-                onClick={() => selectAbsence(item)}
-              >
-                <td>{item.title ?? "-"}</td>
-                <td>{item.classroomName ?? "-"}</td>
-                <td>{item.requestedByName ?? "-"}</td>
-                <td>
-                  <AbsenceStatusBadge status={item.status} />
-                </td>
-                <td>
-                  <ScheduleCell>
-                    <ScheduleLine>수업일 {formatAbsenceDate(item.lessonDate)}</ScheduleLine>
-                    <ScheduleLine $muted>요청일 {formatAbsenceDate(item.createdAt)}</ScheduleLine>
-                  </ScheduleCell>
-                </td>
-              </AbsenceTableRow>
-            ))}
-          </tbody>
+            <thead>
+              <tr>
+                <th>제목</th>
+                <th>분반</th>
+                <th>요청자</th>
+                <th>상태</th>
+                <th>일자</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRequests.map((item) => (
+                <AbsenceTableRow
+                  key={item.id ?? `${item.title}-${item.createdAt}`}
+                  $selected={item.id === selectedAbsenceId}
+                  onClick={() => selectAbsence(item)}
+                >
+                  <td>{item.title ?? "-"}</td>
+                  <td>{item.classroomName ?? "-"}</td>
+                  <td>{item.requestedByName ?? "-"}</td>
+                  <td>
+                    <AbsenceStatusBadge status={item.status} />
+                  </td>
+                  <td>
+                    <ScheduleCell>
+                      <ScheduleLine>수업일 {formatAbsenceDate(item.lessonDate)}</ScheduleLine>
+                      <ScheduleLine $muted>요청일 {formatAbsenceDate(item.createdAt)}</ScheduleLine>
+                    </ScheduleCell>
+                  </td>
+                </AbsenceTableRow>
+              ))}
+            </tbody>
           </AbsenceListTable>
         </TableViewport>
 
@@ -171,8 +171,8 @@ const ListTableArea = styled.div`
   display: flex;
   flex-direction: column;
   min-height: calc(
-    ${ABSENCE_TABLE_HEADER_HEIGHT} +
-      ${ABSENCE_ITEMS_PER_PAGE} * ${ABSENCE_TABLE_ROW_HEIGHT} + 2.75rem
+    ${ABSENCE_TABLE_HEADER_HEIGHT} + ${ABSENCE_ITEMS_PER_PAGE} * ${ABSENCE_TABLE_ROW_HEIGHT} +
+      2.75rem
   );
 `;
 

--- a/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsListPanel.tsx
@@ -1,68 +1,101 @@
 "use client";
 
+import { type MouseEvent } from "react";
 import styled from "styled-components";
+import { AdminAbsenceRequestsDetailPanel } from "@/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel";
 import {
-  ABSENCE_ITEMS_PER_PAGE,
   ABSENCE_STATUS_OPTIONS,
   formatAbsenceDate,
+  formatAbsenceStatus,
   type AbsenceStatusFilter,
 } from "@/components/admin/absence-requests/absenceRequestConstants";
-import { AbsenceStatusBadge } from "@/components/admin/absence-requests/AbsenceStatusBadge";
 import type { AdminAbsenceRequestsViewModel } from "@/components/admin/absence-requests/useAdminAbsenceRequests";
 import {
   ControlRow,
+  DataState,
   SectionCard,
+  SectionHeaderRow,
   SectionTitle,
   Select,
-  SmallButton,
   Table,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
-import LoadingSpinner from "@/components/common/LoadingSpinner";
-import { colors, spacing, typography } from "@/styles/tokens";
-
-const ABSENCE_TABLE_HEADER_HEIGHT = "2.5rem";
-const ABSENCE_TABLE_ROW_HEIGHT = "3.75rem";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 type AdminAbsenceRequestsListPanelProps = Pick<
   AdminAbsenceRequestsViewModel,
   | "statusFilter"
   | "keywordInput"
-  | "setKeywordInput"
+  | "handleKeywordInputChange"
   | "handleSearch"
   | "handleStatusFilterChange"
   | "absenceRequestsQuery"
   | "sortedRequests"
   | "selectedAbsenceId"
+  | "selectedAbsence"
   | "selectAbsence"
+  | "resetSelection"
   | "currentPage"
   | "totalPages"
   | "goToPrevPage"
   | "goToNextPage"
+  | "goToPage"
+  | "rejectNote"
+  | "setRejectNote"
+  | "handleApprove"
+  | "handleReject"
+  | "isActionPending"
 >;
 
 export function AdminAbsenceRequestsListPanel({
   statusFilter,
   keywordInput,
-  setKeywordInput,
+  handleKeywordInputChange,
   handleSearch,
   handleStatusFilterChange,
   absenceRequestsQuery,
   sortedRequests,
   selectedAbsenceId,
+  selectedAbsence,
   selectAbsence,
+  resetSelection,
   currentPage,
   totalPages,
   goToPrevPage,
   goToNextPage,
+  goToPage,
+  rejectNote,
+  setRejectNote,
+  handleApprove,
+  handleReject,
+  isActionPending,
 }: AdminAbsenceRequestsListPanelProps) {
   const isLoading = absenceRequestsQuery.isLoading;
   const isError = absenceRequestsQuery.isError;
   const isEmpty = !isLoading && !isError && sortedRequests.length === 0;
+  const isDetailOpen = selectedAbsenceId !== null;
+
+  function handleListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedRequestRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedRequestRow) {
+      resetSelection();
+    }
+  }
 
   return (
-    <SectionCard>
-      <SectionTitle>결강 요청 목록</SectionTitle>
+    <AbsenceListSection $isPanelOpen={isDetailOpen} onClick={handleListSectionClick}>
+      <SectionHeaderRow>
+        <SectionTitle>결강 요청 목록</SectionTitle>
+        <HeaderHeightSpacer aria-hidden="true" />
+      </SectionHeaderRow>
+
       <ControlRow
         as="form"
         onSubmit={(event) => {
@@ -83,124 +116,134 @@ export function AdminAbsenceRequestsListPanel({
         <KeywordInput
           value={keywordInput}
           placeholder="검색어"
-          onChange={(event) => setKeywordInput(event.target.value)}
+          onChange={(event) => handleKeywordInputChange(event.target.value)}
         />
-        <SmallButton type="submit">검색</SmallButton>
       </ControlRow>
 
-      <ListTableArea>
-        <TableViewport>
-          {isLoading ? (
-            <ListOverlay>
-              <LoadingSpinner label="결강 요청 목록 불러오는 중" />
-            </ListOverlay>
-          ) : null}
-          {isError ? (
-            <ListOverlay role="alert">
-              <ListOverlayMessage>결강 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
-            </ListOverlay>
-          ) : null}
-          {isEmpty ? (
-            <ListOverlay>
-              <ListOverlayMessage>결강 요청이 없습니다.</ListOverlayMessage>
-            </ListOverlay>
-          ) : null}
-
+      <AbsenceListFrame>
+        <DataState
+          isLoading={isLoading}
+          isError={isError}
+          isEmpty={isEmpty}
+          loadingLabel="결강 요청 목록 불러오는 중"
+          errorLabel="결강 요청 목록을 불러오지 못했습니다."
+          emptyLabel="결강 요청이 없습니다."
+        >
           <AbsenceListTable>
             <thead>
               <tr>
                 <th>제목</th>
                 <th>분반</th>
+                <th>수업 예정 일자</th>
                 <th>요청자</th>
                 <th>상태</th>
-                <th>일자</th>
+                <th>작성 일자</th>
               </tr>
             </thead>
             <tbody>
               {sortedRequests.map((item) => (
-                <AbsenceTableRow
+                <tr
                   key={item.id ?? `${item.title}-${item.createdAt}`}
-                  $selected={item.id === selectedAbsenceId}
                   onClick={() => selectAbsence(item)}
                 >
                   <td>{item.title ?? "-"}</td>
                   <td>{item.classroomName ?? "-"}</td>
+                  <td>{formatAbsenceDate(item.lessonDate)}</td>
                   <td>{item.requestedByName ?? "-"}</td>
-                  <td>
-                    <AbsenceStatusBadge status={item.status} />
-                  </td>
-                  <td>
-                    <ScheduleCell>
-                      <ScheduleLine>수업일 {formatAbsenceDate(item.lessonDate)}</ScheduleLine>
-                      <ScheduleLine $muted>요청일 {formatAbsenceDate(item.createdAt)}</ScheduleLine>
-                    </ScheduleCell>
-                  </td>
-                </AbsenceTableRow>
+                  <td>{formatAbsenceStatus(item.status)}</td>
+                  <td>{formatAbsenceDate(item.createdAt)}</td>
+                </tr>
               ))}
             </tbody>
           </AbsenceListTable>
-        </TableViewport>
+        </DataState>
+      </AbsenceListFrame>
 
-        <PaginationNav aria-label="페이지 이동">
-          <PageArrowButton
-            type="button"
-            aria-label="이전 페이지"
-            disabled={currentPage <= 1 || absenceRequestsQuery.isFetching}
-            onClick={goToPrevPage}
-          >
-            ‹
-          </PageArrowButton>
-          <PageIndicator>
-            {currentPage} / {totalPages}
-          </PageIndicator>
-          <PageArrowButton
-            type="button"
-            aria-label="다음 페이지"
-            disabled={currentPage >= totalPages || absenceRequestsQuery.isFetching}
-            onClick={goToNextPage}
-          >
-            ›
-          </PageArrowButton>
-        </PaginationNav>
-      </ListTableArea>
-    </SectionCard>
+      <PaginationNav aria-label="페이지 이동">
+        <PageArrowButton
+          type="button"
+          aria-label="이전 페이지"
+          disabled={currentPage <= 1 || absenceRequestsQuery.isFetching}
+          onClick={goToPrevPage}
+        >
+          ◀
+        </PageArrowButton>
+        {Array.from({ length: totalPages }, (_, index) => {
+          const pageNumber = index + 1;
+
+          return (
+            <PageNumberButton
+              key={pageNumber}
+              type="button"
+              $isActive={pageNumber === currentPage}
+              aria-current={pageNumber === currentPage ? "page" : undefined}
+              onClick={() => goToPage(pageNumber)}
+            >
+              {pageNumber}
+            </PageNumberButton>
+          );
+        })}
+        <PageArrowButton
+          type="button"
+          aria-label="다음 페이지"
+          disabled={currentPage >= totalPages || absenceRequestsQuery.isFetching}
+          onClick={goToNextPage}
+        >
+          ▶
+        </PageArrowButton>
+      </PaginationNav>
+
+      {isDetailOpen ? (
+        <>
+          <PanelBackdrop aria-hidden="true" />
+          <SlidePanel aria-label="결강 요청 상세/처리" onClick={(event) => event.stopPropagation()}>
+            <PanelHeader>
+              <ClosePanelButton
+                type="button"
+                aria-label="결강 요청 상세 닫기"
+                onClick={resetSelection}
+              >
+                <CloseIcon aria-hidden="true" />
+              </ClosePanelButton>
+              <SectionTitle>결강 요청 상세/처리</SectionTitle>
+            </PanelHeader>
+            <AdminAbsenceRequestsDetailPanel
+              selectedAbsence={selectedAbsence}
+              rejectNote={rejectNote}
+              setRejectNote={setRejectNote}
+              handleApprove={handleApprove}
+              handleReject={handleReject}
+              isActionPending={isActionPending}
+            />
+          </SlidePanel>
+        </>
+      ) : null}
+    </AbsenceListSection>
   );
 }
 
-const ListTableArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  min-height: calc(
-    ${ABSENCE_TABLE_HEADER_HEIGHT} + ${ABSENCE_ITEMS_PER_PAGE} * ${ABSENCE_TABLE_ROW_HEIGHT} +
-      2.75rem
-  );
-`;
-
-const TableViewport = styled.div`
+const AbsenceListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
   position: relative;
-  flex: 1 1 auto;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
 `;
 
-const ListOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgb(255 255 255 / 72%);
+const HeaderHeightSpacer = styled.span`
+  display: inline-flex;
+  width: 0;
+  min-height: 2.25rem;
 `;
 
-const ListOverlayMessage = styled.p`
-  margin: 0;
-  color: #64706c;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight130};
-`;
+const AbsenceListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
 
-const AbsenceTableRow = styled.tr<{ $selected: boolean }>`
-  height: ${ABSENCE_TABLE_ROW_HEIGHT};
-  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : "transparent")};
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
 `;
 
 const AbsenceListTable = styled(Table)`
@@ -208,94 +251,162 @@ const AbsenceListTable = styled(Table)`
   td {
     vertical-align: middle;
   }
-
-  thead tr {
-    height: ${ABSENCE_TABLE_HEADER_HEIGHT};
-  }
-
-  tbody tr {
-    height: ${ABSENCE_TABLE_ROW_HEIGHT};
-  }
-
-  th:last-child,
-  td:last-child {
-    width: 1%;
-    white-space: nowrap;
-  }
-`;
-
-const ScheduleCell = styled.div`
-  display: grid;
-  gap: ${spacing.space4};
-`;
-
-const ScheduleLine = styled.span<{ $muted?: boolean }>`
-  color: ${({ $muted }) => ($muted ? "#64706c" : "#050505")};
-  font-size: ${typography.fontSize13};
-  font-weight: 500;
-  line-height: ${typography.lineHeight130};
 `;
 
 const StatusSelect = styled(Select)`
-  max-width: 10rem;
+  width: 9.5rem;
+  min-width: 9.5rem;
+  max-width: 9.5rem;
+  flex: 0 0 9.5rem;
+  height: 2.375rem;
+  min-height: 2.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  appearance: none;
 `;
 
 const KeywordInput = styled(TextInput)`
-  max-width: 16rem;
+  flex: 1 1 auto;
+  max-width: none;
 `;
 
 const PaginationNav = styled.nav`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: ${spacing.space8};
-  margin-top: auto;
-  padding-top: ${spacing.space12};
-  flex-shrink: 0;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
 `;
 
 const PageArrowButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid #e6e9e7;
-  border-radius: 999px;
-  background: ${colors.white};
-  color: #64706c;
-  font-family: inherit;
-  font-size: 1.125rem;
-  line-height: 1;
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
   cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    background-color 0.15s ease,
-    color 0.15s ease,
-    opacity 0.15s ease;
-
-  &:not(:disabled):hover {
-    border-color: #88cd5a;
-    background: #f5fff0;
-    color: #5eb63a;
-  }
 
   &:disabled {
-    cursor: not-allowed;
-    opacity: 0.35;
+    opacity: 0.3;
+    cursor: default;
   }
 `;
 
-const PageIndicator = styled.span`
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeAbsencePanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeAbsencePanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideAbsencePanelIn 0.22s ease-out both;
+
+  @keyframes slideAbsencePanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 3.75rem;
-  padding: 0.375rem 0.625rem;
-  border-radius: 999px;
-  background: #f4f6f5;
-  color: #64706c;
-  font-size: ${typography.fontSize13};
-  font-weight: 800;
-  line-height: ${typography.lineHeight130};
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
 `;

--- a/components/admin/absence-requests/AdminAbsenceRequestsSection.tsx
+++ b/components/admin/absence-requests/AdminAbsenceRequestsSection.tsx
@@ -1,38 +1,34 @@
 "use client";
 
-import { AdminAbsenceRequestsDetailPanel } from "@/components/admin/absence-requests/AdminAbsenceRequestsDetailPanel";
 import { AdminAbsenceRequestsListPanel } from "@/components/admin/absence-requests/AdminAbsenceRequestsListPanel";
 import { useAdminAbsenceRequests } from "@/components/admin/absence-requests/useAdminAbsenceRequests";
-import { TwoColumnGrid } from "@/components/admin/AdminDashboardSectionParts";
 
 export function AdminAbsenceRequestsSection() {
   const absenceRequests = useAdminAbsenceRequests();
 
   return (
-    <TwoColumnGrid>
-      <AdminAbsenceRequestsListPanel
-        statusFilter={absenceRequests.statusFilter}
-        keywordInput={absenceRequests.keywordInput}
-        setKeywordInput={absenceRequests.setKeywordInput}
-        handleSearch={absenceRequests.handleSearch}
-        handleStatusFilterChange={absenceRequests.handleStatusFilterChange}
-        absenceRequestsQuery={absenceRequests.absenceRequestsQuery}
-        sortedRequests={absenceRequests.sortedRequests}
-        selectedAbsenceId={absenceRequests.selectedAbsenceId}
-        selectAbsence={absenceRequests.selectAbsence}
-        currentPage={absenceRequests.currentPage}
-        totalPages={absenceRequests.totalPages}
-        goToPrevPage={absenceRequests.goToPrevPage}
-        goToNextPage={absenceRequests.goToNextPage}
-      />
-      <AdminAbsenceRequestsDetailPanel
-        selectedAbsence={absenceRequests.selectedAbsence}
-        rejectNote={absenceRequests.rejectNote}
-        setRejectNote={absenceRequests.setRejectNote}
-        handleApprove={absenceRequests.handleApprove}
-        handleReject={absenceRequests.handleReject}
-        isActionPending={absenceRequests.isActionPending}
-      />
-    </TwoColumnGrid>
+    <AdminAbsenceRequestsListPanel
+      statusFilter={absenceRequests.statusFilter}
+      keywordInput={absenceRequests.keywordInput}
+      handleKeywordInputChange={absenceRequests.handleKeywordInputChange}
+      handleSearch={absenceRequests.handleSearch}
+      handleStatusFilterChange={absenceRequests.handleStatusFilterChange}
+      absenceRequestsQuery={absenceRequests.absenceRequestsQuery}
+      sortedRequests={absenceRequests.sortedRequests}
+      selectedAbsenceId={absenceRequests.selectedAbsenceId}
+      selectedAbsence={absenceRequests.selectedAbsence}
+      selectAbsence={absenceRequests.selectAbsence}
+      resetSelection={absenceRequests.resetSelection}
+      currentPage={absenceRequests.currentPage}
+      totalPages={absenceRequests.totalPages}
+      goToPrevPage={absenceRequests.goToPrevPage}
+      goToNextPage={absenceRequests.goToNextPage}
+      goToPage={absenceRequests.goToPage}
+      rejectNote={absenceRequests.rejectNote}
+      setRejectNote={absenceRequests.setRejectNote}
+      handleApprove={absenceRequests.handleApprove}
+      handleReject={absenceRequests.handleReject}
+      isActionPending={absenceRequests.isActionPending}
+    />
   );
 }

--- a/components/admin/absence-requests/absenceRequestConstants.ts
+++ b/components/admin/absence-requests/absenceRequestConstants.ts
@@ -1,7 +1,7 @@
 import type { AbsenceRequestStatus } from "@/api/request/request.dto";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
-export const ABSENCE_ITEMS_PER_PAGE = 8;
+export const ABSENCE_ITEMS_PER_PAGE = 11;
 
 export const ABSENCE_STATUS_OPTIONS = [
   { value: "", label: "전체" },

--- a/components/admin/absence-requests/useAdminAbsenceRequests.ts
+++ b/components/admin/absence-requests/useAdminAbsenceRequests.ts
@@ -41,7 +41,6 @@ export function useAdminAbsenceRequests() {
     },
   });
 
-  const absenceRequests = absenceRequestsQuery.data?.content ?? [];
   const totalPages = Math.max(1, absenceRequestsQuery.data?.totalPages ?? 1);
   const currentPage = page <= totalPages ? page : totalPages;
 
@@ -79,13 +78,16 @@ export function useAdminAbsenceRequests() {
   });
 
   const sortedRequests = useMemo(
-    () =>
-      [...absenceRequests].sort((a, b) => {
+    () => {
+      const absenceRequests = absenceRequestsQuery.data?.content ?? [];
+
+      return [...absenceRequests].sort((a, b) => {
         const aTime = new Date(a.createdAt ?? a.lessonDate ?? 0).getTime();
         const bTime = new Date(b.createdAt ?? b.lessonDate ?? 0).getTime();
         return bTime - aTime;
-      }),
-    [absenceRequests],
+      });
+    },
+    [absenceRequestsQuery.data?.content],
   );
 
   const selectedAbsence = useMemo(
@@ -100,6 +102,13 @@ export function useAdminAbsenceRequests() {
 
   const handleSearch = () => {
     setKeyword(keywordInput);
+    setPage(1);
+    resetSelection();
+  };
+
+  const handleKeywordInputChange = (value: string) => {
+    setKeywordInput(value);
+    setKeyword(value);
     setPage(1);
     resetSelection();
   };
@@ -126,6 +135,11 @@ export function useAdminAbsenceRequests() {
     resetSelection();
   };
 
+  const goToPage = (nextPage: number) => {
+    setPage(Math.min(totalPages, Math.max(1, nextPage)));
+    resetSelection();
+  };
+
   const handleApprove = () => {
     const requestId = selectedAbsence?.id;
     if (!requestId || approveMutation.isPending) return;
@@ -148,7 +162,7 @@ export function useAdminAbsenceRequests() {
   return {
     statusFilter,
     keywordInput,
-    setKeywordInput,
+    handleKeywordInputChange,
     handleSearch,
     handleStatusFilterChange,
     absenceRequestsQuery,
@@ -156,10 +170,12 @@ export function useAdminAbsenceRequests() {
     selectedAbsenceId,
     selectedAbsence,
     selectAbsence,
+    resetSelection,
     currentPage,
     totalPages,
     goToPrevPage,
     goToNextPage,
+    goToPage,
     rejectNote,
     setRejectNote,
     handleApprove,

--- a/components/admin/channels/AdminChannelsSection.tsx
+++ b/components/admin/channels/AdminChannelsSection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
-import type { ChannelListItemDto } from "@/api/channel/channel.dto";
+import { useState } from "react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+import styled from "styled-components";
+import type { ChannelAccessLevel, ChannelListItemDto } from "@/api/channel/channel.dto";
 import type { ChannelFormState } from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
@@ -11,21 +13,20 @@ import {
   DataState,
   FormGrid,
   Label,
-  MetaGrid,
-  MetaItem,
-  PrimaryButton,
+  List,
+  ListItem,
   SectionCard,
-  SectionDescription,
   SectionHeaderRow,
   SectionTitle,
-  Select,
   SmallButton,
   Table,
   TextInput,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-type QueryState<TData> = {
+const CHANNELS_PER_PAGE = 11;
+
+type QueryState<TData = unknown> = {
   data?: TData;
   isLoading: boolean;
   isError: boolean;
@@ -39,23 +40,36 @@ type VoidMutationAction = {
 type AdminChannelsSectionProps = {
   channels: ChannelListItemDto[];
   selectedChannelId: number | null;
+  isChannelEditing: boolean;
+  isChannelCreateModalOpen: boolean;
+  isChannelDeleteConfirmOpen: boolean;
   channelSearch: string;
   channelForm: ChannelFormState;
-  channelsQuery: QueryState<unknown>;
+  channelsQuery: QueryState;
   channelDetailQuery: QueryState<ChannelListItemDto>;
   createChannelMutation: VoidMutationAction;
   updateChannelMutation: VoidMutationAction;
   deleteChannelMutation: VoidMutationAction;
   setSelectedChannelId: Dispatch<SetStateAction<number | null>>;
+  setIsChannelEditing: Dispatch<SetStateAction<boolean>>;
+  setIsChannelCreateModalOpen: Dispatch<SetStateAction<boolean>>;
+  setIsChannelDeleteConfirmOpen: Dispatch<SetStateAction<boolean>>;
   setChannelSearch: Dispatch<SetStateAction<string>>;
   setChannelForm: Dispatch<SetStateAction<ChannelFormState>>;
   selectChannel: (item: ChannelListItemDto) => void;
   emptyChannelForm: ChannelFormState;
 };
 
+function formatChannelStatus(isActive?: boolean) {
+  return isActive === false ? "비활성" : "활성";
+}
+
 export function AdminChannelsSection({
   channels,
   selectedChannelId,
+  isChannelEditing,
+  isChannelCreateModalOpen,
+  isChannelDeleteConfirmOpen,
   channelSearch,
   channelForm,
   channelsQuery,
@@ -64,161 +78,725 @@ export function AdminChannelsSection({
   updateChannelMutation,
   deleteChannelMutation,
   setSelectedChannelId,
+  setIsChannelEditing,
+  setIsChannelCreateModalOpen,
+  setIsChannelDeleteConfirmOpen,
   setChannelSearch,
   setChannelForm,
   selectChannel,
   emptyChannelForm,
 }: AdminChannelsSectionProps) {
+  const isDetailOpen = selectedChannelId !== null;
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const totalPages = Math.max(1, Math.ceil(channels.length / CHANNELS_PER_PAGE));
+  const requestedPage = pagination.search === channelSearch ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedChannels = channels.slice(
+    (safeCurrentPage - 1) * CHANNELS_PER_PAGE,
+    safeCurrentPage * CHANNELS_PER_PAGE,
+  );
+
+  function closeChannelDetail() {
+    setSelectedChannelId(null);
+    setIsChannelEditing(false);
+    setIsChannelDeleteConfirmOpen(false);
+  }
+
+  function openCreateModal() {
+    setSelectedChannelId(null);
+    setIsChannelEditing(false);
+    setChannelForm(emptyChannelForm);
+    setIsChannelCreateModalOpen(true);
+  }
+
+  function closeCreateModal() {
+    if (createChannelMutation.isPending) {
+      return;
+    }
+
+    setIsChannelCreateModalOpen(false);
+    setChannelForm(emptyChannelForm);
+  }
+
+  function cancelEditing() {
+    const detail = channelDetailQuery.data;
+
+    setChannelForm({
+      name: detail?.name ?? channelForm.name,
+      description: detail?.description ?? channelForm.description,
+      accessLevel: detail?.accessLevel ?? channelForm.accessLevel,
+      allowGuestRead: detail?.allowGuestRead ?? channelForm.allowGuestRead,
+      isDefault: detail?.isDefault ?? channelForm.isDefault,
+      isActive: detail?.isActive ?? channelForm.isActive,
+    });
+    setIsChannelEditing(false);
+  }
+
+  function handleChannelListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedChannelRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedChannelRow) {
+      closeChannelDetail();
+    }
+  }
+
   return (
-    <TwoColumnGrid>
-      <SectionCard>
+    <>
+      <ChannelListSection $isPanelOpen={isDetailOpen} onClick={handleChannelListSectionClick}>
         <SectionHeaderRow>
           <SectionTitle>채널 목록</SectionTitle>
-          <SmallButton
-            type="button"
-            onClick={() => {
-              setSelectedChannelId(null);
-              setChannelForm(emptyChannelForm);
-            }}
-          >
+          <SmallButton type="button" onClick={openCreateModal}>
             신규 개설
           </SmallButton>
         </SectionHeaderRow>
+
         <ControlRow>
           <TextInput
             value={channelSearch}
             onChange={(event) => setChannelSearch(event.target.value)}
-            placeholder="채널명 검색"
+            placeholder="채널명, 유형, 설명, ID 검색"
           />
         </ControlRow>
-        <DataState
-          isLoading={channelsQuery.isLoading}
-          isError={channelsQuery.isError}
-          isEmpty={channels.length === 0}
-          loadingLabel="채널 목록 불러오는 중"
-          errorLabel="채널 목록을 불러오지 못했습니다."
-          emptyLabel="채널이 없습니다."
-        >
-          <Table>
-            <thead>
-              <tr>
-                <th>이름</th>
-                <th>유형</th>
-                <th>연결</th>
-                <th>상태</th>
-              </tr>
-            </thead>
-            <tbody>
-              {channels.map((item) => (
-                <tr key={item.id} onClick={() => selectChannel(item)}>
-                  <td>{item.name}</td>
-                  <td>{item.channelType}</td>
-                  <td>{item.refId ?? "-"}</td>
-                  <td>{item.isActive ? "활성" : "비활성"}</td>
+
+        <ChannelListFrame>
+          <DataState
+            isLoading={channelsQuery.isLoading}
+            isError={channelsQuery.isError}
+            isEmpty={channels.length === 0}
+            loadingLabel="채널 목록 불러오는 중"
+            errorLabel="채널 목록을 불러오지 못했습니다."
+            emptyLabel="채널이 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>이름</th>
+                  <th>유형</th>
+                  <th>연결</th>
+                  <th>상태</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </DataState>
-      </SectionCard>
-      <SectionCard>
-        <SectionTitle>{selectedChannelId ? "채널 상세/수정" : "채널 생성"}</SectionTitle>
-        <MetaGrid>
-          <MetaItem>유형: {channelDetailQuery.data?.channelType ?? "-"}</MetaItem>
-          <MetaItem>바인딩: {channelDetailQuery.data?.bindingType ?? "-"}</MetaItem>
-          <MetaItem>연결 대상: {channelDetailQuery.data?.refId ?? "-"}</MetaItem>
-        </MetaGrid>
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (selectedChannelId) {
-              updateChannelMutation.mutate();
-            } else {
-              createChannelMutation.mutate();
+              </thead>
+              <tbody>
+                {pagedChannels.map((item) => (
+                  <tr key={item.id} onClick={() => selectChannel(item)}>
+                    <td>{item.name ?? "-"}</td>
+                    <td>{item.channelType ?? "-"}</td>
+                    <td>{item.refId ?? "-"}</td>
+                    <td>{formatChannelStatus(item.isActive)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </ChannelListFrame>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({ page: Math.max(1, safeCurrentPage - 1), search: channelSearch })
             }
-          }}
-        >
-          <Label>
-            이름
-            <TextInput
-              value={channelForm.name}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, name: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            설명
-            <TextInput
-              value={channelForm.description}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, description: event.target.value }))
-              }
-            />
-          </Label>
-          <Label>
-            접근 수준
-            <Select
-              value={channelForm.accessLevel}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, accessLevel: event.target.value }))
-              }
+          >
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: channelSearch })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: channelSearch,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
+        {isDetailOpen ? (
+          <>
+            <PanelBackdrop aria-hidden="true" />
+            <SlidePanel aria-label="채널 상세/수정" onClick={(event) => event.stopPropagation()}>
+              <PanelHeader>
+                <ClosePanelButton
+                  type="button"
+                  aria-label="채널 상세 닫기"
+                  onClick={closeChannelDetail}
+                >
+                  <CloseIcon aria-hidden="true" />
+                </ClosePanelButton>
+                <SectionTitle>{isChannelEditing ? "채널 수정" : "채널 상세"}</SectionTitle>
+              </PanelHeader>
+
+              <DataState
+                isLoading={channelDetailQuery.isLoading}
+                isError={channelDetailQuery.isError}
+                isEmpty={!selectedChannelId}
+                loadingLabel="채널 상세 불러오는 중"
+                errorLabel="채널 상세를 불러오지 못했습니다."
+                emptyLabel="채널을 선택하세요."
+              >
+                <PanelContent>
+                  <DetailFormView>
+                    <ChannelFields
+                      form={channelForm}
+                      disabled={!isChannelEditing || updateChannelMutation.isPending}
+                      setChannelForm={setChannelForm}
+                    />
+                  </DetailFormView>
+
+                  <DetailBlock>
+                    <DetailBlockTitle>채널 정보</DetailBlockTitle>
+                    <List>
+                      <ListItem>
+                        <span>유형</span>
+                        <span>{channelDetailQuery.data?.channelType ?? "-"}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>바인딩</span>
+                        <span>{channelDetailQuery.data?.bindingType ?? "-"}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>연결 대상</span>
+                        <span>{channelDetailQuery.data?.refId ?? "-"}</span>
+                      </ListItem>
+                    </List>
+                  </DetailBlock>
+
+                  <ButtonRow>
+                    {isChannelEditing ? (
+                      <>
+                        <ChannelActionButton
+                          type="button"
+                          onClick={() => updateChannelMutation.mutate()}
+                          disabled={updateChannelMutation.isPending || !channelForm.name.trim()}
+                        >
+                          저장
+                        </ChannelActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={updateChannelMutation.isPending}
+                          onClick={cancelEditing}
+                        >
+                          취소
+                        </SmallButton>
+                      </>
+                    ) : (
+                      <>
+                        <ChannelActionButton
+                          type="button"
+                          disabled={!selectedChannelId}
+                          onClick={() => setIsChannelEditing(true)}
+                        >
+                          수정
+                        </ChannelActionButton>
+                        <DangerButton
+                          type="button"
+                          disabled={deleteChannelMutation.isPending}
+                          onClick={() => setIsChannelDeleteConfirmOpen(true)}
+                        >
+                          삭제
+                        </DangerButton>
+                      </>
+                    )}
+                  </ButtonRow>
+                </PanelContent>
+              </DataState>
+            </SlidePanel>
+          </>
+        ) : null}
+      </ChannelListSection>
+
+      {isChannelCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="channel-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="channel-create-modal-title">채널 생성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createChannelMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createChannelMutation.mutate();
+              }}
             >
-              <option value="CLOSED">CLOSED</option>
-              <option value="READ_ONLY">READ_ONLY</option>
-              <option value="READ_COMMENT">READ_COMMENT</option>
-              <option value="READ_WRITE">READ_WRITE</option>
-            </Select>
-          </Label>
-          <CheckLabel>
-            <input
-              type="checkbox"
-              checked={channelForm.allowGuestRead}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, allowGuestRead: event.target.checked }))
-              }
-            />{" "}
-            게스트 읽기
-          </CheckLabel>
-          <CheckLabel>
-            <input
-              type="checkbox"
-              checked={channelForm.isDefault}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, isDefault: event.target.checked }))
-              }
-            />{" "}
-            기본 채널
-          </CheckLabel>
-          <CheckLabel>
-            <input
-              type="checkbox"
-              checked={channelForm.isActive}
-              onChange={(event) =>
-                setChannelForm((current) => ({ ...current, isActive: event.target.checked }))
-              }
-            />{" "}
-            활성
-          </CheckLabel>
-          <ButtonRow>
-            <PrimaryButton
-              disabled={createChannelMutation.isPending || updateChannelMutation.isPending}
-            >
-              {selectedChannelId ? "수정" : "생성"}
-            </PrimaryButton>
-            {selectedChannelId ? (
+              <ChannelFields
+                form={channelForm}
+                disabled={createChannelMutation.isPending}
+                setChannelForm={setChannelForm}
+              />
+              <ButtonRow>
+                <ChannelActionButton
+                  type="submit"
+                  disabled={createChannelMutation.isPending || !channelForm.name.trim()}
+                >
+                  생성
+                </ChannelActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createChannelMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isChannelDeleteConfirmOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsChannelDeleteConfirmOpen(false)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="channel-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="channel-delete-confirm-title">채널 삭제</ConfirmTitle>
+            <ConfirmMessage>삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
               <DangerButton
                 type="button"
                 disabled={deleteChannelMutation.isPending}
                 onClick={() => deleteChannelMutation.mutate()}
               >
-                삭제
+                확인
               </DangerButton>
-            ) : null}
-          </ButtonRow>
-        </FormGrid>
-      </SectionCard>
-    </TwoColumnGrid>
+              <SmallButton
+                type="button"
+                disabled={deleteChannelMutation.isPending}
+                onClick={() => setIsChannelDeleteConfirmOpen(false)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </>
   );
 }
+
+type ChannelFieldsProps = {
+  form: ChannelFormState;
+  disabled: boolean;
+  setChannelForm: Dispatch<SetStateAction<ChannelFormState>>;
+};
+
+function ChannelFields({ form, disabled, setChannelForm }: ChannelFieldsProps) {
+  return (
+    <>
+      <Label>
+        이름
+        <TextInput
+          value={form.name}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({ ...current, name: event.target.value }))
+          }
+          required
+        />
+      </Label>
+      <Label>
+        설명
+        <TextInput
+          value={form.description}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({ ...current, description: event.target.value }))
+          }
+        />
+      </Label>
+      <Label>
+        접근 수준
+        <ChannelSelect
+          value={form.accessLevel}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({
+              ...current,
+              accessLevel: event.target.value as ChannelAccessLevel,
+            }))
+          }
+        >
+          <option value="CLOSED">CLOSED</option>
+          <option value="READ_ONLY">READ_ONLY</option>
+          <option value="READ_COMMENT">READ_COMMENT</option>
+          <option value="READ_WRITE">READ_WRITE</option>
+        </ChannelSelect>
+      </Label>
+      <CheckLabel>
+        <input
+          type="checkbox"
+          checked={form.allowGuestRead}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({ ...current, allowGuestRead: event.target.checked }))
+          }
+        />{" "}
+        게스트 읽기
+      </CheckLabel>
+      <CheckLabel>
+        <input
+          type="checkbox"
+          checked={form.isDefault}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({ ...current, isDefault: event.target.checked }))
+          }
+        />{" "}
+        기본 채널
+      </CheckLabel>
+      <CheckLabel>
+        <input
+          type="checkbox"
+          checked={form.isActive}
+          disabled={disabled}
+          onChange={(event) =>
+            setChannelForm((current) => ({ ...current, isActive: event.target.checked }))
+          }
+        />{" "}
+        활성
+      </CheckLabel>
+    </>
+  );
+}
+
+const ChannelListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const ChannelListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeChannelPanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeChannelPanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideChannelPanelIn 0.22s ease-out both;
+
+  @keyframes slideChannelPanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const DetailFormView = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ChannelSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 32rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(ModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const ChannelActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.375rem;
+    padding: 0 ${spacing.space16};
+    font-size: ${typography.fontSize14};
+  }
+`;

--- a/components/admin/classes/AdminClassroomsSection.tsx
+++ b/components/admin/classes/AdminClassroomsSection.tsx
@@ -123,9 +123,6 @@ export function AdminClassroomsSection({
       </SectionCard>
       <SectionCard>
         <SectionTitle>{selectedClassroomId ? "분반 상세/수정" : "분반 생성"}</SectionTitle>
-        <SectionDescription>
-          분반 이름, 유형, 설명을 생성하거나 수정하고 삭제할 수 있습니다.
-        </SectionDescription>
         {classroomDetailQuery.isLoading ? (
           <InlineStatus>분반 상세를 불러오는 중입니다.</InlineStatus>
         ) : null}

--- a/components/admin/classes/AdminClassroomsSection.tsx
+++ b/components/admin/classes/AdminClassroomsSection.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
-import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
+import { useState } from "react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+import styled from "styled-components";
+import type {
+  ClassroomDetailResponseDto,
+  ClassroomListItemDto,
+  ClassroomType,
+} from "@/api/classroom/classroom.dto";
 import type { ClassroomFormState } from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
@@ -9,22 +15,20 @@ import {
   DangerButton,
   DataState,
   FormGrid,
-  InlineStatus,
   Label,
-  PrimaryButton,
   SectionCard,
-  SectionDescription,
   SectionHeaderRow,
   SectionTitle,
-  Select,
   SmallButton,
-  StableListArea,
   Table,
   TextInput,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
-type QueryState = {
+const CLASSROOMS_PER_PAGE = 11;
+
+type QueryState<TData = unknown> = {
+  data?: TData;
   isLoading: boolean;
   isError: boolean;
 };
@@ -37,23 +41,44 @@ type VoidMutationAction = {
 type AdminClassroomsSectionProps = {
   classrooms: ClassroomListItemDto[];
   selectedClassroomId: number | null;
+  isClassroomEditing: boolean;
+  isClassroomCreateModalOpen: boolean;
+  isClassroomDeleteConfirmOpen: boolean;
   classroomSearch: string;
   classroomForm: ClassroomFormState;
   classroomsQuery: QueryState;
-  classroomDetailQuery: QueryState;
+  classroomDetailQuery: QueryState<ClassroomDetailResponseDto>;
   createClassroomMutation: VoidMutationAction;
   updateClassroomMutation: VoidMutationAction;
   deleteClassroomMutation: VoidMutationAction;
   setSelectedClassroomId: Dispatch<SetStateAction<number | null>>;
+  setIsClassroomEditing: Dispatch<SetStateAction<boolean>>;
+  setIsClassroomCreateModalOpen: Dispatch<SetStateAction<boolean>>;
+  setIsClassroomDeleteConfirmOpen: Dispatch<SetStateAction<boolean>>;
   setClassroomSearch: Dispatch<SetStateAction<string>>;
   setClassroomForm: Dispatch<SetStateAction<ClassroomFormState>>;
   selectClassroom: (item: ClassroomListItemDto) => void;
   emptyClassroomForm: ClassroomFormState;
 };
 
+function getClassroomTypeLabel(type?: ClassroomType) {
+  if (type === "WEEKDAY") {
+    return "평일";
+  }
+
+  if (type === "WEEKEND") {
+    return "주말";
+  }
+
+  return type || "-";
+}
+
 export function AdminClassroomsSection({
   classrooms,
   selectedClassroomId,
+  isClassroomEditing,
+  isClassroomCreateModalOpen,
+  isClassroomDeleteConfirmOpen,
   classroomSearch,
   classroomForm,
   classroomsQuery,
@@ -62,34 +87,90 @@ export function AdminClassroomsSection({
   updateClassroomMutation,
   deleteClassroomMutation,
   setSelectedClassroomId,
+  setIsClassroomEditing,
+  setIsClassroomCreateModalOpen,
+  setIsClassroomDeleteConfirmOpen,
   setClassroomSearch,
   setClassroomForm,
   selectClassroom,
   emptyClassroomForm,
 }: AdminClassroomsSectionProps) {
+  const isDetailOpen = selectedClassroomId !== null;
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const totalPages = Math.max(1, Math.ceil(classrooms.length / CLASSROOMS_PER_PAGE));
+  const requestedPage = pagination.search === classroomSearch ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedClassrooms = classrooms.slice(
+    (safeCurrentPage - 1) * CLASSROOMS_PER_PAGE,
+    safeCurrentPage * CLASSROOMS_PER_PAGE,
+  );
+
+  function closeClassroomDetail() {
+    setSelectedClassroomId(null);
+    setIsClassroomEditing(false);
+    setIsClassroomDeleteConfirmOpen(false);
+  }
+
+  function openCreateModal() {
+    setSelectedClassroomId(null);
+    setIsClassroomEditing(false);
+    setClassroomForm(emptyClassroomForm);
+    setIsClassroomCreateModalOpen(true);
+  }
+
+  function closeCreateModal() {
+    if (createClassroomMutation.isPending) {
+      return;
+    }
+
+    setIsClassroomCreateModalOpen(false);
+    setClassroomForm(emptyClassroomForm);
+  }
+
+  function cancelEditing() {
+    const detail = classroomDetailQuery.data;
+
+    setClassroomForm({
+      name: detail?.name ?? classroomForm.name,
+      type: detail?.type ?? classroomForm.type,
+      description: detail?.description ?? classroomForm.description,
+    });
+    setIsClassroomEditing(false);
+  }
+
+  function handleClassroomListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedClassroomRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedClassroomRow) {
+      closeClassroomDetail();
+    }
+  }
+
   return (
-    <TwoColumnGrid>
-      <SectionCard>
+    <>
+      <ClassroomListSection $isPanelOpen={isDetailOpen} onClick={handleClassroomListSectionClick}>
         <SectionHeaderRow>
           <SectionTitle>분반 목록</SectionTitle>
-          <SmallButton
-            type="button"
-            onClick={() => {
-              setSelectedClassroomId(null);
-              setClassroomForm(emptyClassroomForm);
-            }}
-          >
+          <SmallButton type="button" onClick={openCreateModal}>
             신규 개설
           </SmallButton>
         </SectionHeaderRow>
+
         <ControlRow>
           <TextInput
             value={classroomSearch}
             onChange={(event) => setClassroomSearch(event.target.value)}
-            placeholder="분반명 검색"
+            placeholder="분반명, 유형, 설명, ID 검색"
           />
         </ControlRow>
-        <StableListArea>
+
+        <ClassroomListFrame>
           <DataState
             isLoading={classroomsQuery.isLoading}
             isError={classroomsQuery.isError}
@@ -99,6 +180,12 @@ export function AdminClassroomsSection({
             emptyLabel="분반이 없습니다."
           >
             <Table>
+              <colgroup>
+                <col style={{ width: "3.9rem" }} />
+                <col style={{ width: "9.8rem" }} />
+                <col style={{ width: "12.25rem" }} />
+                <col />
+              </colgroup>
               <thead>
                 <tr>
                   <th>ID</th>
@@ -108,83 +195,550 @@ export function AdminClassroomsSection({
                 </tr>
               </thead>
               <tbody>
-                {classrooms.map((item) => (
+                {pagedClassrooms.map((item) => (
                   <tr key={item.id} onClick={() => selectClassroom(item)}>
-                    <td>{item.id}</td>
-                    <td>{item.name}</td>
-                    <td>{item.type}</td>
-                    <td>{item.description}</td>
+                    <td>{item.id ?? "-"}</td>
+                    <td>{item.name ?? "-"}</td>
+                    <td>{getClassroomTypeLabel(item.type)}</td>
+                    <td>{item.description ?? "-"}</td>
                   </tr>
                 ))}
               </tbody>
             </Table>
           </DataState>
-        </StableListArea>
-      </SectionCard>
-      <SectionCard>
-        <SectionTitle>{selectedClassroomId ? "분반 상세/수정" : "분반 생성"}</SectionTitle>
-        {classroomDetailQuery.isLoading ? (
-          <InlineStatus>분반 상세를 불러오는 중입니다.</InlineStatus>
-        ) : null}
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (selectedClassroomId) {
-              updateClassroomMutation.mutate();
-            } else {
-              createClassroomMutation.mutate();
+        </ClassroomListFrame>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({ page: Math.max(1, safeCurrentPage - 1), search: classroomSearch })
             }
-          }}
-        >
-          <Label>
-            이름
-            <TextInput
-              value={classroomForm.name}
-              onChange={(event) =>
-                setClassroomForm((current) => ({ ...current, name: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            유형
-            <Select
-              value={classroomForm.type}
-              onChange={(event) =>
-                setClassroomForm((current) => ({ ...current, type: event.target.value }))
-              }
+          >
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: classroomSearch })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: classroomSearch,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
+        {isDetailOpen ? (
+          <>
+            <PanelBackdrop aria-hidden="true" />
+            <SlidePanel aria-label="분반 상세/수정" onClick={(event) => event.stopPropagation()}>
+              <PanelHeader>
+                <ClosePanelButton
+                  type="button"
+                  aria-label="분반 상세 닫기"
+                  onClick={closeClassroomDetail}
+                >
+                  <CloseIcon aria-hidden="true" />
+                </ClosePanelButton>
+                <SectionTitle>{isClassroomEditing ? "분반 수정" : "분반 상세"}</SectionTitle>
+              </PanelHeader>
+
+              <DataState
+                isLoading={classroomDetailQuery.isLoading}
+                isError={classroomDetailQuery.isError}
+                isEmpty={!selectedClassroomId}
+                loadingLabel="분반 상세 불러오는 중"
+                errorLabel="분반 상세를 불러오지 못했습니다."
+                emptyLabel="분반을 선택하세요."
+              >
+                <PanelContent>
+                  <DetailFormView>
+                    <ClassroomFields
+                      form={classroomForm}
+                      disabled={!isClassroomEditing || updateClassroomMutation.isPending}
+                      setClassroomForm={setClassroomForm}
+                    />
+                  </DetailFormView>
+
+                  <ButtonRow>
+                    {isClassroomEditing ? (
+                      <>
+                        <ClassroomActionButton
+                          type="button"
+                          onClick={() => updateClassroomMutation.mutate()}
+                          disabled={updateClassroomMutation.isPending || !classroomForm.name.trim()}
+                        >
+                          저장
+                        </ClassroomActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={updateClassroomMutation.isPending}
+                          onClick={cancelEditing}
+                        >
+                          취소
+                        </SmallButton>
+                      </>
+                    ) : (
+                      <>
+                        <ClassroomActionButton
+                          type="button"
+                          disabled={!selectedClassroomId}
+                          onClick={() => setIsClassroomEditing(true)}
+                        >
+                          수정
+                        </ClassroomActionButton>
+                        <DangerButton
+                          type="button"
+                          disabled={deleteClassroomMutation.isPending}
+                          onClick={() => setIsClassroomDeleteConfirmOpen(true)}
+                        >
+                          삭제
+                        </DangerButton>
+                      </>
+                    )}
+                  </ButtonRow>
+                </PanelContent>
+              </DataState>
+            </SlidePanel>
+          </>
+        ) : null}
+      </ClassroomListSection>
+
+      {isClassroomCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="classroom-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="classroom-create-modal-title">분반 생성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createClassroomMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createClassroomMutation.mutate();
+              }}
             >
-              <option value="WEEKDAY">WEEKDAY</option>
-              <option value="WEEKEND">WEEKEND</option>
-            </Select>
-          </Label>
-          <Label>
-            설명
-            <TextInput
-              value={classroomForm.description}
-              onChange={(event) =>
-                setClassroomForm((current) => ({ ...current, description: event.target.value }))
-              }
-            />
-          </Label>
-          <ButtonRow>
-            <PrimaryButton
-              disabled={createClassroomMutation.isPending || updateClassroomMutation.isPending}
-            >
-              {selectedClassroomId ? "수정" : "생성"}
-            </PrimaryButton>
-            {selectedClassroomId ? (
+              <ClassroomFields
+                form={classroomForm}
+                disabled={createClassroomMutation.isPending}
+                setClassroomForm={setClassroomForm}
+              />
+              <ButtonRow>
+                <ClassroomActionButton
+                  type="submit"
+                  disabled={createClassroomMutation.isPending || !classroomForm.name.trim()}
+                >
+                  생성
+                </ClassroomActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createClassroomMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isClassroomDeleteConfirmOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsClassroomDeleteConfirmOpen(false)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="classroom-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="classroom-delete-confirm-title">분반 삭제</ConfirmTitle>
+            <ConfirmMessage>삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
               <DangerButton
                 type="button"
                 disabled={deleteClassroomMutation.isPending}
                 onClick={() => deleteClassroomMutation.mutate()}
               >
-                삭제
+                확인
               </DangerButton>
-            ) : null}
-          </ButtonRow>
-        </FormGrid>
-      </SectionCard>
-    </TwoColumnGrid>
+              <SmallButton
+                type="button"
+                disabled={deleteClassroomMutation.isPending}
+                onClick={() => setIsClassroomDeleteConfirmOpen(false)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </>
   );
 }
+
+type ClassroomFieldsProps = {
+  form: ClassroomFormState;
+  disabled: boolean;
+  setClassroomForm: Dispatch<SetStateAction<ClassroomFormState>>;
+};
+
+function ClassroomFields({ form, disabled, setClassroomForm }: ClassroomFieldsProps) {
+  return (
+    <>
+      <Label>
+        이름
+        <TextInput
+          value={form.name}
+          disabled={disabled}
+          onChange={(event) =>
+            setClassroomForm((current) => ({ ...current, name: event.target.value }))
+          }
+          required
+        />
+      </Label>
+      <Label>
+        유형
+        <ClassroomSelect
+          value={form.type}
+          disabled={disabled}
+          onChange={(event) =>
+            setClassroomForm((current) => ({
+              ...current,
+              type: event.target.value as ClassroomType,
+            }))
+          }
+        >
+          <option value="WEEKDAY">평일</option>
+          <option value="WEEKEND">주말</option>
+        </ClassroomSelect>
+      </Label>
+      <Label>
+        설명
+        <TextInput
+          value={form.description}
+          disabled={disabled}
+          onChange={(event) =>
+            setClassroomForm((current) => ({ ...current, description: event.target.value }))
+          }
+        />
+      </Label>
+    </>
+  );
+}
+
+const ClassroomListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const ClassroomListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeClassroomPanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeClassroomPanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideClassroomPanelIn 0.22s ease-out both;
+
+  @keyframes slideClassroomPanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const DetailFormView = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const ClassroomSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 32rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(ModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const ClassroomActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.375rem;
+    padding: 0 ${spacing.space16};
+    font-size: ${typography.fontSize14};
+  }
+`;

--- a/components/admin/departments/AdminDepartmentsSection.tsx
+++ b/components/admin/departments/AdminDepartmentsSection.tsx
@@ -1,32 +1,37 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+import styled from "styled-components";
 import type {
   DepartmentDetailResponseDto,
   DepartmentListItemDto,
+  PermissionResponseDto,
 } from "@/api/department/department.dto";
-import type { DepartmentFormState } from "@/components/admin/AdminDashboardTypes";
+import type { PermissionDefinitionDto } from "@/api/user/user.dto";
+import type {
+  DepartmentFormState,
+  PermissionFormState,
+} from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
+  ControlRow,
   DangerButton,
   DataState,
-  Divider,
   FormGrid,
   Label,
   List,
   ListItem,
-  MetaGrid,
-  MetaItem,
-  PrimaryButton,
   SectionCard,
-  SectionDescription,
   SectionHeaderRow,
   SectionTitle,
   SmallButton,
   Table,
   TextInput,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+const DEPARTMENTS_PER_PAGE = 11;
 
 type QueryState<TData> = {
   data?: TData;
@@ -39,17 +44,72 @@ type VoidMutationAction = {
   mutate: () => void;
 };
 
+type ValueMutationAction<TVariables> = {
+  isPending: boolean;
+  mutate: (variables: TVariables) => void;
+};
+
+function getPermissionActions(permissionOptions: PermissionDefinitionDto[], resourceType: string) {
+  return permissionOptions
+    .filter((option) => option.resourceCode === resourceType)
+    .map((option) => option.actionCode)
+    .filter(
+      (value, index, array): value is string => Boolean(value) && array.indexOf(value) === index,
+    );
+}
+
+function getPermissionDefinition(
+  permissionOptions: PermissionDefinitionDto[],
+  resourceType: string,
+  actionType: string,
+) {
+  return permissionOptions.find(
+    (option) => option.resourceCode === resourceType && option.actionCode === actionType,
+  );
+}
+
+function getDefaultPermissionScope(definition?: PermissionDefinitionDto) {
+  const canUseGlobal = definition?.globalAllowed ?? definition?.scope !== "TARGET_ONLY";
+
+  return canUseGlobal ? "GLOBAL" : "TARGET";
+}
+
+function getPermissionCode(permission: PermissionResponseDto) {
+  return permission.code ?? permission.name ?? "";
+}
+
+function getPermissionDescription(permission: PermissionResponseDto) {
+  const code = getPermissionCode(permission);
+  const description = permission.name ?? "";
+
+  return description && description !== code ? description : "";
+}
+
 type AdminDepartmentsSectionProps = {
   departments: DepartmentListItemDto[];
   selectedDepartmentId: number | null;
+  isDepartmentEditing: boolean;
+  isDepartmentCreateModalOpen: boolean;
+  isDepartmentDeleteConfirmOpen: boolean;
+  departmentSearch: string;
   departmentForm: DepartmentFormState;
+  permissionForm: PermissionFormState;
+  permissionOptions: PermissionDefinitionDto[];
+  availableActions: string[];
   departmentsQuery: QueryState<unknown>;
   departmentDetailQuery: QueryState<DepartmentDetailResponseDto>;
   createDepartmentMutation: VoidMutationAction;
   updateDepartmentMutation: VoidMutationAction;
   deleteDepartmentMutation: VoidMutationAction;
+  addDepartmentPermissionMutation: VoidMutationAction;
+  removeDepartmentPermissionMutation: ValueMutationAction<string>;
   setSelectedDepartmentId: Dispatch<SetStateAction<number | null>>;
+  setIsDepartmentEditing: Dispatch<SetStateAction<boolean>>;
+  setIsDepartmentCreateModalOpen: Dispatch<SetStateAction<boolean>>;
+  setIsDepartmentDeleteConfirmOpen: Dispatch<SetStateAction<boolean>>;
+  setDepartmentSearch: Dispatch<SetStateAction<string>>;
   setDepartmentForm: Dispatch<SetStateAction<DepartmentFormState>>;
+  setPermissionForm: Dispatch<SetStateAction<PermissionFormState>>;
   selectDepartment: (item: DepartmentListItemDto) => void;
   emptyDepartmentForm: DepartmentFormState;
 };
@@ -57,133 +117,888 @@ type AdminDepartmentsSectionProps = {
 export function AdminDepartmentsSection({
   departments,
   selectedDepartmentId,
+  isDepartmentEditing,
+  isDepartmentCreateModalOpen,
+  isDepartmentDeleteConfirmOpen,
+  departmentSearch,
   departmentForm,
+  permissionForm,
+  permissionOptions,
+  availableActions,
   departmentsQuery,
   departmentDetailQuery,
   createDepartmentMutation,
   updateDepartmentMutation,
   deleteDepartmentMutation,
+  addDepartmentPermissionMutation,
+  removeDepartmentPermissionMutation,
   setSelectedDepartmentId,
+  setIsDepartmentEditing,
+  setIsDepartmentCreateModalOpen,
+  setIsDepartmentDeleteConfirmOpen,
+  setDepartmentSearch,
   setDepartmentForm,
+  setPermissionForm,
   selectDepartment,
   emptyDepartmentForm,
 }: AdminDepartmentsSectionProps) {
+  const isDetailOpen = selectedDepartmentId !== null;
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const totalPages = Math.max(1, Math.ceil(departments.length / DEPARTMENTS_PER_PAGE));
+  const requestedPage = pagination.search === departmentSearch ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedDepartments = departments.slice(
+    (safeCurrentPage - 1) * DEPARTMENTS_PER_PAGE,
+    safeCurrentPage * DEPARTMENTS_PER_PAGE,
+  );
+  const permissionResources = Array.from(
+    new Set(permissionOptions.map((option) => option.resourceCode).filter(Boolean)),
+  );
+
+  function closeDepartmentDetail() {
+    setSelectedDepartmentId(null);
+    setIsDepartmentEditing(false);
+    setIsDepartmentDeleteConfirmOpen(false);
+  }
+
+  function openCreateModal() {
+    setSelectedDepartmentId(null);
+    setIsDepartmentEditing(false);
+    setDepartmentForm(emptyDepartmentForm);
+    setIsDepartmentCreateModalOpen(true);
+  }
+
+  function closeCreateModal() {
+    if (createDepartmentMutation.isPending) {
+      return;
+    }
+
+    setIsDepartmentCreateModalOpen(false);
+    setDepartmentForm(emptyDepartmentForm);
+  }
+
+  function cancelEditing() {
+    const detail = departmentDetailQuery.data;
+
+    setDepartmentForm({
+      name: detail?.name ?? departmentForm.name,
+      description: detail?.description ?? departmentForm.description,
+    });
+    setIsDepartmentEditing(false);
+  }
+
+  function handleDepartmentListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedDepartmentRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedDepartmentRow) {
+      closeDepartmentDetail();
+    }
+  }
+
   return (
-    <TwoColumnGrid>
-      <SectionCard>
+    <>
+      <DepartmentListSection $isPanelOpen={isDetailOpen} onClick={handleDepartmentListSectionClick}>
         <SectionHeaderRow>
           <SectionTitle>부서 목록</SectionTitle>
-          <SmallButton
-            type="button"
-            onClick={() => {
-              setSelectedDepartmentId(null);
-              setDepartmentForm(emptyDepartmentForm);
-            }}
-          >
+          <SmallButton type="button" onClick={openCreateModal}>
             신규 개설
           </SmallButton>
         </SectionHeaderRow>
-        <DataState
-          isLoading={departmentsQuery.isLoading}
-          isError={departmentsQuery.isError}
-          isEmpty={departments.length === 0}
-          loadingLabel="부서 목록 불러오는 중"
-          errorLabel="부서 목록을 불러오지 못했습니다."
-          emptyLabel="부서가 없습니다."
-        >
-          <Table>
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>이름</th>
-                <th>설명</th>
-              </tr>
-            </thead>
-            <tbody>
-              {departments.map((item) => (
-                <tr key={item.id} onClick={() => selectDepartment(item)}>
-                  <td>{item.id}</td>
-                  <td>{item.name}</td>
-                  <td>{item.description}</td>
+
+        <ControlRow>
+          <TextInput
+            value={departmentSearch}
+            onChange={(event) => setDepartmentSearch(event.target.value)}
+            placeholder="부서명, 설명, ID 검색"
+          />
+        </ControlRow>
+
+        <DepartmentListFrame>
+          <DataState
+            isLoading={departmentsQuery.isLoading}
+            isError={departmentsQuery.isError}
+            isEmpty={departments.length === 0}
+            loadingLabel="부서 목록 불러오는 중"
+            errorLabel="부서 목록을 불러오지 못했습니다."
+            emptyLabel="부서가 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>이름</th>
+                  <th>설명</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </DataState>
-      </SectionCard>
-      <SectionCard>
-        <SectionTitle>{selectedDepartmentId ? "부서 상세/수정" : "부서 생성"}</SectionTitle>
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (selectedDepartmentId) {
-              updateDepartmentMutation.mutate();
-            } else {
-              createDepartmentMutation.mutate();
+              </thead>
+              <tbody>
+                {pagedDepartments.map((item) => (
+                  <tr key={item.id} onClick={() => selectDepartment(item)}>
+                    <td>{item.id ?? "-"}</td>
+                    <td>{item.name ?? "-"}</td>
+                    <td>{item.description ?? "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </DepartmentListFrame>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({ page: Math.max(1, safeCurrentPage - 1), search: departmentSearch })
             }
-          }}
-        >
-          <Label>
-            이름
-            <TextInput
-              value={departmentForm.name}
-              onChange={(event) =>
-                setDepartmentForm((current) => ({ ...current, name: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            설명
-            <TextInput
-              value={departmentForm.description}
-              onChange={(event) =>
-                setDepartmentForm((current) => ({ ...current, description: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <ButtonRow>
-            <PrimaryButton
-              disabled={createDepartmentMutation.isPending || updateDepartmentMutation.isPending}
+          >
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: departmentSearch })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: departmentSearch,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
+        {isDetailOpen ? (
+          <>
+            <PanelBackdrop aria-hidden="true" />
+            <SlidePanel aria-label="부서 상세/수정" onClick={(event) => event.stopPropagation()}>
+              <PanelHeader>
+                <ClosePanelButton
+                  type="button"
+                  aria-label="부서 상세 닫기"
+                  onClick={closeDepartmentDetail}
+                >
+                  <CloseIcon aria-hidden="true" />
+                </ClosePanelButton>
+                <SectionTitle>{isDepartmentEditing ? "부서 수정" : "부서 상세"}</SectionTitle>
+              </PanelHeader>
+
+              <DataState
+                isLoading={departmentDetailQuery.isLoading}
+                isError={departmentDetailQuery.isError}
+                isEmpty={!selectedDepartmentId}
+                loadingLabel="부서 상세 불러오는 중"
+                errorLabel="부서 상세를 불러오지 못했습니다."
+                emptyLabel="부서를 선택하세요."
+              >
+                <PanelContent>
+                  <DetailFormView>
+                    <DepartmentFields
+                      form={departmentForm}
+                      disabled={!isDepartmentEditing || updateDepartmentMutation.isPending}
+                      setDepartmentForm={setDepartmentForm}
+                    />
+                  </DetailFormView>
+
+                  <DetailBlock>
+                    <DetailBlockTitle>소속 사용자</DetailBlockTitle>
+                    <List>
+                      {departmentDetailQuery.data?.users?.length ? (
+                        departmentDetailQuery.data.users.map((item) => (
+                          <ListItem key={item.id ?? item.email}>
+                            <span>{item.name ?? item.nickname ?? item.email ?? "-"}</span>
+                            <span>{item.role ?? "-"}</span>
+                          </ListItem>
+                        ))
+                      ) : (
+                        <EmptyListItem>소속 사용자가 없습니다.</EmptyListItem>
+                      )}
+                    </List>
+                  </DetailBlock>
+
+                  <DetailBlock>
+                    <DetailBlockTitle>부서 권한</DetailBlockTitle>
+                    <List>
+                      {departmentDetailQuery.data?.permissions?.length ? (
+                        departmentDetailQuery.data.permissions.map((permission) => {
+                          const code = getPermissionCode(permission);
+
+                          return (
+                            <ListItem key={code}>
+                              <PermissionItemContent>
+                                <PermissionCode>{code || "-"}</PermissionCode>
+                                {getPermissionDescription(permission) ? (
+                                  <PermissionDescription>
+                                    {getPermissionDescription(permission)}
+                                  </PermissionDescription>
+                                ) : null}
+                              </PermissionItemContent>
+                              {code ? (
+                                <SmallButton
+                                  type="button"
+                                  disabled={removeDepartmentPermissionMutation.isPending}
+                                  onClick={() => removeDepartmentPermissionMutation.mutate(code)}
+                                >
+                                  제거
+                                </SmallButton>
+                              ) : null}
+                            </ListItem>
+                          );
+                        })
+                      ) : (
+                        <EmptyListItem>부서 권한이 없습니다.</EmptyListItem>
+                      )}
+                    </List>
+
+                    {isDepartmentEditing ? (
+                      <PermissionAddForm
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          addDepartmentPermissionMutation.mutate();
+                        }}
+                      >
+                        <PermissionAddHeader>
+                          <PermissionAddTitle>부서 권한 추가</PermissionAddTitle>
+                        </PermissionAddHeader>
+                        <Label>
+                          리소스
+                          <DepartmentSelect
+                            value={permissionForm.resourceType}
+                            onChange={(event) => {
+                              const resourceType = event.target.value;
+                              const actions = getPermissionActions(permissionOptions, resourceType);
+                              const actionType = actions[0] ?? "";
+                              const definition = getPermissionDefinition(
+                                permissionOptions,
+                                resourceType,
+                                actionType,
+                              );
+                              const scope = getDefaultPermissionScope(definition);
+
+                              setPermissionForm((current) => ({
+                                ...current,
+                                resourceType,
+                                actionType,
+                                scope,
+                                target: scope === "GLOBAL" ? "" : current.target,
+                              }));
+                            }}
+                          >
+                            {permissionResources.map((resource) => (
+                              <option key={resource} value={resource}>
+                                {resource}
+                              </option>
+                            ))}
+                          </DepartmentSelect>
+                        </Label>
+                        <Label>
+                          액션
+                          <DepartmentSelect
+                            value={permissionForm.actionType}
+                            disabled={availableActions.length === 0}
+                            onChange={(event) => {
+                              const actionType = event.target.value;
+                              const definition = getPermissionDefinition(
+                                permissionOptions,
+                                permissionForm.resourceType,
+                                actionType,
+                              );
+                              const scope = getDefaultPermissionScope(definition);
+
+                              setPermissionForm((current) => ({
+                                ...current,
+                                actionType,
+                                scope,
+                                target: scope === "GLOBAL" ? "" : current.target,
+                              }));
+                            }}
+                          >
+                            {availableActions.map((action) => (
+                              <option key={action} value={action}>
+                                {action}
+                              </option>
+                            ))}
+                          </DepartmentSelect>
+                        </Label>
+                        <Label>
+                          범위
+                          <DepartmentSelect
+                            value={permissionForm.scope}
+                            onChange={(event) =>
+                              setPermissionForm((current) => ({
+                                ...current,
+                                scope: event.target.value as PermissionFormState["scope"],
+                                target: event.target.value === "GLOBAL" ? "" : current.target,
+                              }))
+                            }
+                          >
+                            <option value="GLOBAL">전체 권한</option>
+                            <option value="TARGET">특정 대상 권한</option>
+                          </DepartmentSelect>
+                        </Label>
+                        <Label>
+                          대상 ID
+                          <TextInput
+                            value={permissionForm.target}
+                            disabled={permissionForm.scope === "GLOBAL"}
+                            onChange={(event) =>
+                              setPermissionForm((current) => ({
+                                ...current,
+                                target: event.target.value,
+                              }))
+                            }
+                          />
+                        </Label>
+                        <DepartmentActionButton
+                          type="submit"
+                          disabled={
+                            !selectedDepartmentId ||
+                            addDepartmentPermissionMutation.isPending ||
+                            !permissionForm.resourceType ||
+                            !permissionForm.actionType ||
+                            (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
+                          }
+                        >
+                          권한 추가
+                        </DepartmentActionButton>
+                      </PermissionAddForm>
+                    ) : null}
+                  </DetailBlock>
+
+                  <ButtonRow>
+                    {isDepartmentEditing ? (
+                      <>
+                        <DepartmentActionButton
+                          type="button"
+                          onClick={() => updateDepartmentMutation.mutate()}
+                          disabled={
+                            updateDepartmentMutation.isPending || !departmentForm.name.trim()
+                          }
+                        >
+                          저장
+                        </DepartmentActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={updateDepartmentMutation.isPending}
+                          onClick={cancelEditing}
+                        >
+                          취소
+                        </SmallButton>
+                      </>
+                    ) : (
+                      <>
+                        <DepartmentActionButton
+                          type="button"
+                          disabled={!selectedDepartmentId}
+                          onClick={() => setIsDepartmentEditing(true)}
+                        >
+                          수정
+                        </DepartmentActionButton>
+                        <DangerButton
+                          type="button"
+                          disabled={deleteDepartmentMutation.isPending}
+                          onClick={() => setIsDepartmentDeleteConfirmOpen(true)}
+                        >
+                          삭제
+                        </DangerButton>
+                      </>
+                    )}
+                  </ButtonRow>
+                </PanelContent>
+              </DataState>
+            </SlidePanel>
+          </>
+        ) : null}
+      </DepartmentListSection>
+
+      {isDepartmentCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="department-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="department-create-modal-title">부서 생성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createDepartmentMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createDepartmentMutation.mutate();
+              }}
             >
-              {selectedDepartmentId ? "수정" : "생성"}
-            </PrimaryButton>
-            {selectedDepartmentId ? (
+              <DepartmentFields
+                form={departmentForm}
+                disabled={createDepartmentMutation.isPending}
+                setDepartmentForm={setDepartmentForm}
+              />
+              <ButtonRow>
+                <DepartmentActionButton
+                  type="submit"
+                  disabled={createDepartmentMutation.isPending || !departmentForm.name.trim()}
+                >
+                  생성
+                </DepartmentActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createDepartmentMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isDepartmentDeleteConfirmOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsDepartmentDeleteConfirmOpen(false)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="department-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="department-delete-confirm-title">부서 삭제</ConfirmTitle>
+            <ConfirmMessage>삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
               <DangerButton
                 type="button"
                 disabled={deleteDepartmentMutation.isPending}
                 onClick={() => deleteDepartmentMutation.mutate()}
               >
-                삭제
+                확인
               </DangerButton>
-            ) : null}
-          </ButtonRow>
-        </FormGrid>
-        <Divider />
-        <SectionTitle>소속 사용자/권한</SectionTitle>
-        <DataState
-          isLoading={departmentDetailQuery.isLoading}
-          isError={departmentDetailQuery.isError}
-          isEmpty={!selectedDepartmentId}
-          loadingLabel="부서 상세 불러오는 중"
-          errorLabel="부서 상세를 불러오지 못했습니다."
-          emptyLabel="부서를 선택하세요."
-        >
-          <MetaGrid>
-            <MetaItem>사용자 {departmentDetailQuery.data?.users?.length ?? 0}명</MetaItem>
-            <MetaItem>권한 {departmentDetailQuery.data?.permissions?.length ?? 0}개</MetaItem>
-          </MetaGrid>
-          <List>
-            {departmentDetailQuery.data?.users?.map((item) => (
-              <ListItem key={item.id}>
-                <span>{item.name ?? item.email}</span>
-                <span>{item.role}</span>
-              </ListItem>
-            ))}
-          </List>
-        </DataState>
-      </SectionCard>
-    </TwoColumnGrid>
+              <SmallButton
+                type="button"
+                disabled={deleteDepartmentMutation.isPending}
+                onClick={() => setIsDepartmentDeleteConfirmOpen(false)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </>
   );
 }
+
+type DepartmentFieldsProps = {
+  form: DepartmentFormState;
+  disabled: boolean;
+  setDepartmentForm: Dispatch<SetStateAction<DepartmentFormState>>;
+};
+
+function DepartmentFields({ form, disabled, setDepartmentForm }: DepartmentFieldsProps) {
+  return (
+    <>
+      <Label>
+        이름
+        <TextInput
+          value={form.name}
+          disabled={disabled}
+          onChange={(event) =>
+            setDepartmentForm((current) => ({ ...current, name: event.target.value }))
+          }
+          required
+        />
+      </Label>
+      <Label>
+        설명
+        <TextInput
+          value={form.description}
+          disabled={disabled}
+          onChange={(event) =>
+            setDepartmentForm((current) => ({ ...current, description: event.target.value }))
+          }
+          required
+        />
+      </Label>
+    </>
+  );
+}
+
+const DepartmentListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const DepartmentListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeDepartmentPanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeDepartmentPanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideDepartmentPanelIn 0.22s ease-out both;
+
+  @keyframes slideDepartmentPanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const DetailFormView = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const EmptyListItem = styled.li`
+  display: flex;
+  align-items: center;
+  min-height: 2.375rem;
+  padding: ${spacing.space8};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+`;
+
+const PermissionAddForm = styled(FormGrid)`
+  margin-top: ${spacing.space12};
+`;
+
+const PermissionAddHeader = styled.div`
+  padding-top: ${spacing.space12};
+  border-top: 1px solid #e6e9e7;
+`;
+
+const PermissionAddTitle = styled.h4`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize16};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const PermissionItemContent = styled.span`
+  display: grid;
+  gap: ${spacing.space4};
+  min-width: 0;
+`;
+
+const PermissionCode = styled.span`
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  word-break: break-word;
+`;
+
+const PermissionDescription = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  word-break: keep-all;
+`;
+
+const DepartmentSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 32rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(ModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const DepartmentActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.375rem;
+    padding: 0 ${spacing.space16};
+    font-size: ${typography.fontSize14};
+  }
+`;

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
@@ -1,16 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import styled from "styled-components";
-import { LessonExchangeDetailFieldItems } from "@/components/admin/lesson-exchange/LessonExchangeDetailFieldItems";
 import {
-  LESSON_EXCHANGE_BASIC_DETAIL_FIELDS,
-  LESSON_EXCHANGE_PROCESSING_META_FIELDS,
-} from "@/components/admin/lesson-exchange/lessonExchangeDetailFields";
-import {
-  getLessonExchangeDetailActionState,
+  canProcessLessonExchangeRequest,
+  formatLessonExchangeDate,
+  formatLessonExchangeStatus,
   getLessonExchangeRejectionNote,
-  hasLessonExchangeSupplementalContent,
-  shouldShowLessonExchangeProcessingMeta,
 } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
 import type { AdminLessonExchangeRequestsViewModel } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
 import {
@@ -18,13 +14,12 @@ import {
   DangerButton,
   DataState,
   FormGrid,
-  PrimaryButton,
-  SectionCard,
-  SectionDescription,
-  SectionTitle,
+  List,
+  ListItem,
+  SmallButton,
   TextArea,
 } from "@/components/admin/AdminDashboardSectionParts";
-import { spacing, typography } from "@/styles/tokens";
+import { colors, radii, spacing, typography } from "@/styles/tokens";
 
 type AdminLessonExchangeRequestsDetailPanelProps = {
   viewModel: AdminLessonExchangeRequestsViewModel;
@@ -42,19 +37,30 @@ export function AdminLessonExchangeRequestsDetailPanel({
     handleReject,
     isActionPending,
   } = viewModel;
-
+  const [confirmAction, setConfirmAction] = useState<"approve" | "reject" | null>(null);
+  const [isRejecting, setIsRejecting] = useState(false);
   const detail = lessonExchangeDetailQuery.data;
   const isLoading = selectedRequestId !== null && lessonExchangeDetailQuery.isLoading;
   const isError = selectedRequestId !== null && lessonExchangeDetailQuery.isError;
-  const actionState = getLessonExchangeDetailActionState(detail);
+  const canProcess = canProcessLessonExchangeRequest(detail);
   const rejectionNote = getLessonExchangeRejectionNote(detail);
-  const showProcessingMeta = shouldShowLessonExchangeProcessingMeta(detail);
-  const hasSupplementalContent = hasLessonExchangeSupplementalContent(detail);
+
+  function runConfirmedAction() {
+    if (confirmAction === "approve") {
+      handleApprove();
+      setConfirmAction(null);
+      return;
+    }
+
+    if (confirmAction === "reject") {
+      handleReject();
+      setConfirmAction(null);
+      setIsRejecting(false);
+    }
+  }
 
   return (
-    <SectionCard>
-      <SectionTitle>수업 교환 요청 상세</SectionTitle>
-
+    <DetailPanelContent>
       <DataState
         isLoading={isLoading}
         isError={isError}
@@ -63,101 +69,172 @@ export function AdminLessonExchangeRequestsDetailPanel({
         errorLabel="수업 교환 요청 상세를 불러오지 못했습니다."
         emptyLabel="수업 교환 요청을 선택하세요."
       >
-        <DetailStack>
-          <DetailFields>
-            <LessonExchangeDetailFieldItems
-              fields={LESSON_EXCHANGE_BASIC_DETAIL_FIELDS}
-              detail={detail}
-            />
-          </DetailFields>
+        <PanelContent>
+          <DetailBlock>
+            <DetailBlockTitle>요청 정보</DetailBlockTitle>
+            <List>
+              <ListItem>
+                <span>제목</span>
+                <span>{detail?.title ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>요청자</span>
+                <span>{detail?.requestedByName ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>분반</span>
+                <span>{detail?.classroomName ?? "-"}</span>
+              </ListItem>
+              <ListItem>
+                <span>수업 일자</span>
+                <span>{formatLessonExchangeDate(detail?.lessonDate)}</span>
+              </ListItem>
+              <ListItem>
+                <span>요청 일자</span>
+                <span>{formatLessonExchangeDate(detail?.createdAt)}</span>
+              </ListItem>
+              <ListItem>
+                <span>만료 일자</span>
+                <span>{formatLessonExchangeDate(detail?.expiresAt)}</span>
+              </ListItem>
+              <ListItem>
+                <span>상태</span>
+                <span>{formatLessonExchangeStatus(detail?.status)}</span>
+              </ListItem>
+            </List>
+          </DetailBlock>
 
-          <DetailLowerBlock>
-            <ContentSection>
-              <DetailField $fullWidth $compact>
-                <DetailFieldLabel>내용</DetailFieldLabel>
-                <DetailTextBox>{detail?.content?.trim() || "-"}</DetailTextBox>
-              </DetailField>
+          <DetailBlock>
+            <DetailBlockTitle>내용</DetailBlockTitle>
+            <DetailTextBox>{detail?.content?.trim() || "-"}</DetailTextBox>
+            {rejectionNote ? (
+              <DetailBlock>
+                <DetailBlockTitle>반려 사유</DetailBlockTitle>
+                <DetailNoteBox>{rejectionNote}</DetailNoteBox>
+              </DetailBlock>
+            ) : null}
+          </DetailBlock>
 
-              {hasSupplementalContent ? (
-                <SupplementalSection>
-                  <CompactDivider />
-
-                  {rejectionNote ? (
-                    <DetailField $fullWidth $compact>
-                      <DetailFieldLabel>반려 사유</DetailFieldLabel>
-                      <DetailNoteBox>{rejectionNote}</DetailNoteBox>
-                    </DetailField>
-                  ) : null}
-
-                  {showProcessingMeta ? (
-                    <ProcessingMetaFields>
-                      <LessonExchangeDetailFieldItems
-                        fields={LESSON_EXCHANGE_PROCESSING_META_FIELDS}
-                        detail={detail}
-                      />
-                    </ProcessingMetaFields>
-                  ) : null}
-                </SupplementalSection>
-              ) : null}
-            </ContentSection>
-
-            {hasSupplementalContent ? <CompactDivider /> : null}
-
-            <ActionSection>
-              <DetailFieldLabel>처리</DetailFieldLabel>
-              {actionState === "expired" ? (
-                <UnavailableBadge>만료된 요청으로 처리불가</UnavailableBadge>
-              ) : null}
-              {actionState === "processed" ? <ProcessedBadge>처리 완료</ProcessedBadge> : null}
-              {actionState === "actionable" ? (
-                <FormGrid onSubmit={(event) => event.preventDefault()}>
+          {canProcess ? (
+            <ActionBlock>
+              <FormGrid onSubmit={(event) => event.preventDefault()}>
+                {isRejecting ? (
                   <RejectNoteTextArea
                     value={rejectNote}
                     placeholder="반려 사유를 입력해 주세요."
                     disabled={isActionPending}
                     onChange={(event) => setRejectNote(event.target.value)}
+                    autoFocus
                   />
-                  <ButtonRow>
-                    <PrimaryButton type="button" disabled={isActionPending} onClick={handleApprove}>
-                      승인
-                    </PrimaryButton>
-                    <DangerButton
-                      type="button"
-                      disabled={isActionPending || !rejectNote.trim()}
-                      onClick={handleReject}
-                    >
-                      반려
-                    </DangerButton>
-                  </ButtonRow>
-                </FormGrid>
-              ) : null}
-            </ActionSection>
-          </DetailLowerBlock>
-        </DetailStack>
+                ) : null}
+                <ButtonRow>
+                  {isRejecting ? (
+                    <>
+                      <DangerButton
+                        type="button"
+                        disabled={isActionPending || !rejectNote.trim()}
+                        onClick={() => setConfirmAction("reject")}
+                      >
+                        확인
+                      </DangerButton>
+                      <SmallButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => {
+                          setIsRejecting(false);
+                          setRejectNote("");
+                        }}
+                      >
+                        취소
+                      </SmallButton>
+                    </>
+                  ) : (
+                    <>
+                      <LessonExchangeActionButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => setConfirmAction("approve")}
+                      >
+                        승인
+                      </LessonExchangeActionButton>
+                      <DangerButton
+                        type="button"
+                        disabled={isActionPending}
+                        onClick={() => setIsRejecting(true)}
+                      >
+                        반려
+                      </DangerButton>
+                    </>
+                  )}
+                </ButtonRow>
+              </FormGrid>
+            </ActionBlock>
+          ) : null}
+        </PanelContent>
       </DataState>
-    </SectionCard>
+
+      {confirmAction ? (
+        <ModalBackdrop onMouseDown={() => setConfirmAction(null)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="lesson-exchange-action-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="lesson-exchange-action-confirm-title">
+              수업 교환 요청 처리
+            </ConfirmTitle>
+            <ConfirmMessage>
+              {confirmAction === "approve" ? "승인하시겠습니까?" : "반려하시겠습니까?"}
+            </ConfirmMessage>
+            <ButtonRow>
+              <LessonExchangeActionButton
+                type="button"
+                disabled={isActionPending}
+                onClick={runConfirmedAction}
+              >
+                확인
+              </LessonExchangeActionButton>
+              <SmallButton
+                type="button"
+                disabled={isActionPending}
+                onClick={() => setConfirmAction(null)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </DetailPanelContent>
   );
 }
 
-const DetailStack = styled.div`
-  display: grid;
-  gap: ${spacing.space20};
-`;
-
-const DetailFields = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: ${spacing.space16};
-`;
-
-const DetailField = styled.div<{ $fullWidth?: boolean; $compact?: boolean }>`
-  display: grid;
-  gap: ${({ $compact }) => ($compact ? spacing.space4 : spacing.space8)};
+const DetailPanelContent = styled.div`
   min-width: 0;
-  grid-column: ${({ $fullWidth }) => ($fullWidth ? "1 / -1" : "auto")};
 `;
 
-const DetailFieldLabel = styled.span`
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const ActionBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
   color: #64706c;
   font-size: ${typography.fontSize13};
   font-weight: 800;
@@ -181,73 +258,79 @@ const DetailNoteBox = styled(DetailTextBox)`
   background: #fff7f6;
 `;
 
-const CompactDivider = styled.hr`
-  width: 100%;
-  margin: 0;
-  border: 0;
-  border-top: 1px solid #e6e9e7;
-`;
-
-const DetailLowerBlock = styled.div`
-  display: grid;
-  gap: ${spacing.space16};
-`;
-
-const ContentSection = styled.section`
-  display: grid;
-  gap: ${spacing.space12};
-  margin: 0;
-`;
-
-const SupplementalSection = styled.div`
-  display: grid;
-  gap: ${spacing.space12};
-`;
-
-const ProcessingMetaFields = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: ${spacing.space16};
-`;
-
-const ActionSection = styled.section`
-  display: grid;
-  gap: ${spacing.space12};
-`;
-
 const RejectNoteTextArea = styled(TextArea)`
+  min-height: 6rem;
   resize: none;
   font-weight: 500;
 `;
 
-const UnavailableBadge = styled.span`
+const LessonExchangeActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: fit-content;
-  min-width: 3.25rem;
-  padding: 0.25rem 0.625rem;
-  border-radius: 999px;
-  background: #fff3e0;
-  color: #b45f06;
-  font-size: ${typography.fontSize13};
-  font-weight: 700;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
   line-height: ${typography.lineHeight130};
   white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;
 
-const ProcessedBadge = styled.span`
-  display: inline-flex;
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: fit-content;
-  min-width: 3.25rem;
-  padding: 0.25rem 0.625rem;
-  border-radius: 999px;
-  background: #dcf4ea;
-  color: #3da75c;
-  font-size: ${typography.fontSize13};
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ConfirmDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 24rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
   font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
-  white-space: nowrap;
 `;

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel.tsx
@@ -53,10 +53,7 @@ export function AdminLessonExchangeRequestsDetailPanel({
 
   return (
     <SectionCard>
-      <SectionTitle>수업 교환 요청 상세/처리</SectionTitle>
-      <SectionDescription>
-        선택한 수업 교환 요청의 상세 정보를 확인하고 승인 또는 반려 처리를 수행합니다.
-      </SectionDescription>
+      <SectionTitle>수업 교환 요청 상세</SectionTitle>
 
       <DataState
         isLoading={isLoading}
@@ -68,7 +65,10 @@ export function AdminLessonExchangeRequestsDetailPanel({
       >
         <DetailStack>
           <DetailFields>
-            <LessonExchangeDetailFieldItems fields={LESSON_EXCHANGE_BASIC_DETAIL_FIELDS} detail={detail} />
+            <LessonExchangeDetailFieldItems
+              fields={LESSON_EXCHANGE_BASIC_DETAIL_FIELDS}
+              detail={detail}
+            />
           </DetailFields>
 
           <DetailLowerBlock>

--- a/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel.tsx
@@ -1,27 +1,26 @@
 "use client";
 
+import { type MouseEvent } from "react";
 import styled from "styled-components";
+import { AdminLessonExchangeRequestsDetailPanel } from "@/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel";
 import {
-  LESSON_EXCHANGE_ITEMS_PER_PAGE,
+  formatLessonExchangeDate,
+  formatLessonExchangeStatus,
   LESSON_EXCHANGE_STATUS_OPTIONS,
   type LessonExchangeStatusFilter,
 } from "@/components/admin/lesson-exchange/lessonExchangeRequestConstants";
-import { LessonExchangeStatusBadge } from "@/components/admin/lesson-exchange/LessonExchangeStatusBadge";
 import type { AdminLessonExchangeRequestsViewModel } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
 import {
   ControlRow,
+  DataState,
   SectionCard,
+  SectionHeaderRow,
   SectionTitle,
   Select,
-  SmallButton,
   Table,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
-import LoadingSpinner from "@/components/common/LoadingSpinner";
-import { colors, spacing, typography } from "@/styles/tokens";
-
-const TABLE_HEADER_HEIGHT = "2.5rem";
-const TABLE_ROW_HEIGHT = "3.75rem";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 type AdminLessonExchangeRequestsListPanelProps = {
   viewModel: AdminLessonExchangeRequestsViewModel;
@@ -33,25 +32,46 @@ export function AdminLessonExchangeRequestsListPanel({
   const {
     statusFilter,
     keywordInput,
-    setKeywordInput,
+    handleKeywordInputChange,
     handleSearch,
     handleStatusFilterChange,
     lessonExchangeRequestsQuery,
     sortedRequests,
     selectedRequestId,
     selectLessonExchangeRequest,
+    resetSelection,
     currentPage,
     totalPages,
     goToPrevPage,
     goToNextPage,
+    goToPage,
   } = viewModel;
   const isLoading = lessonExchangeRequestsQuery.isLoading;
   const isError = lessonExchangeRequestsQuery.isError;
   const isEmpty = !isLoading && !isError && sortedRequests.length === 0;
+  const isDetailOpen = selectedRequestId !== null;
+
+  function handleListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedRequestRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedRequestRow) {
+      resetSelection();
+    }
+  }
 
   return (
-    <SectionCard>
-      <SectionTitle>수업 교환 요청 목록</SectionTitle>
+    <LessonExchangeListSection $isPanelOpen={isDetailOpen} onClick={handleListSectionClick}>
+      <SectionHeaderRow>
+        <SectionTitle>수업 교환 요청 목록</SectionTitle>
+        <HeaderHeightSpacer aria-hidden="true" />
+      </SectionHeaderRow>
+
       <ControlRow
         as="form"
         onSubmit={(event) => {
@@ -74,116 +94,127 @@ export function AdminLessonExchangeRequestsListPanel({
         <KeywordInput
           value={keywordInput}
           placeholder="검색어"
-          onChange={(event) => setKeywordInput(event.target.value)}
+          onChange={(event) => handleKeywordInputChange(event.target.value)}
         />
-        <SmallButton type="submit">검색</SmallButton>
       </ControlRow>
 
-      <ListTableArea>
-        <TableViewport>
-          {isLoading ? (
-            <ListOverlay>
-              <LoadingSpinner label="수업 교환 요청 목록 불러오는 중" />
-            </ListOverlay>
-          ) : null}
-          {isError ? (
-            <ListOverlay role="alert">
-              <ListOverlayMessage>수업 교환 요청 목록을 불러오지 못했습니다.</ListOverlayMessage>
-            </ListOverlay>
-          ) : null}
-          {isEmpty ? (
-            <ListOverlay>
-              <ListOverlayMessage>수업 교환 요청이 없습니다.</ListOverlayMessage>
-            </ListOverlay>
-          ) : null}
-
+      <LessonExchangeListFrame>
+        <DataState
+          isLoading={isLoading}
+          isError={isError}
+          isEmpty={isEmpty}
+          loadingLabel="수업 교환 요청 목록 불러오는 중"
+          errorLabel="수업 교환 요청 목록을 불러오지 못했습니다."
+          emptyLabel="수업 교환 요청이 없습니다."
+        >
           <LessonExchangeListTable>
             <thead>
               <tr>
                 <th>제목</th>
                 <th>분반</th>
+                <th>수업 예정 일자</th>
                 <th>요청자</th>
                 <th>상태</th>
+                <th>작성 일자</th>
               </tr>
             </thead>
             <tbody>
               {sortedRequests.map((item) => (
-                <LessonExchangeTableRow
-                  key={item.id}
-                  $selected={item.id === selectedRequestId}
-                  onClick={() => selectLessonExchangeRequest(item)}
-                >
+                <tr key={item.id} onClick={() => selectLessonExchangeRequest(item)}>
                   <td>{item.title ?? "-"}</td>
                   <td>{item.classroomName ?? "-"}</td>
+                  <td>{formatLessonExchangeDate(item.lessonDate)}</td>
                   <td>{item.requestedByName ?? "-"}</td>
-                  <td>
-                    <LessonExchangeStatusBadge status={item.status} />
-                  </td>
-                </LessonExchangeTableRow>
+                  <td>{formatLessonExchangeStatus(item.status)}</td>
+                  <td>{formatLessonExchangeDate(item.createdAt)}</td>
+                </tr>
               ))}
             </tbody>
           </LessonExchangeListTable>
-        </TableViewport>
+        </DataState>
+      </LessonExchangeListFrame>
 
-        <PaginationNav aria-label="페이지 이동">
-          <PageArrowButton
-            type="button"
-            aria-label="이전 페이지"
-            disabled={currentPage <= 1 || lessonExchangeRequestsQuery.isFetching}
-            onClick={goToPrevPage}
+      <PaginationNav aria-label="페이지 이동">
+        <PageArrowButton
+          type="button"
+          aria-label="이전 페이지"
+          disabled={currentPage <= 1 || lessonExchangeRequestsQuery.isFetching}
+          onClick={goToPrevPage}
+        >
+          ◀
+        </PageArrowButton>
+        {Array.from({ length: totalPages }, (_, index) => {
+          const pageNumber = index + 1;
+
+          return (
+            <PageNumberButton
+              key={pageNumber}
+              type="button"
+              $isActive={pageNumber === currentPage}
+              aria-current={pageNumber === currentPage ? "page" : undefined}
+              onClick={() => goToPage(pageNumber)}
+            >
+              {pageNumber}
+            </PageNumberButton>
+          );
+        })}
+        <PageArrowButton
+          type="button"
+          aria-label="다음 페이지"
+          disabled={currentPage >= totalPages || lessonExchangeRequestsQuery.isFetching}
+          onClick={goToNextPage}
+        >
+          ▶
+        </PageArrowButton>
+      </PaginationNav>
+
+      {isDetailOpen ? (
+        <>
+          <PanelBackdrop aria-hidden="true" />
+          <SlidePanel
+            aria-label="수업 교환 요청 상세/처리"
+            onClick={(event) => event.stopPropagation()}
           >
-            ‹
-          </PageArrowButton>
-          <PageIndicator>
-            {currentPage} / {totalPages}
-          </PageIndicator>
-          <PageArrowButton
-            type="button"
-            aria-label="다음 페이지"
-            disabled={currentPage >= totalPages || lessonExchangeRequestsQuery.isFetching}
-            onClick={goToNextPage}
-          >
-            ›
-          </PageArrowButton>
-        </PaginationNav>
-      </ListTableArea>
-    </SectionCard>
+            <PanelHeader>
+              <ClosePanelButton
+                type="button"
+                aria-label="수업 교환 요청 상세 닫기"
+                onClick={resetSelection}
+              >
+                <CloseIcon aria-hidden="true" />
+              </ClosePanelButton>
+              <SectionTitle>수업 교환 요청 상세/처리</SectionTitle>
+            </PanelHeader>
+            <AdminLessonExchangeRequestsDetailPanel viewModel={viewModel} />
+          </SlidePanel>
+        </>
+      ) : null}
+    </LessonExchangeListSection>
   );
 }
 
-const ListTableArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  min-height: calc(
-    ${TABLE_HEADER_HEIGHT} + ${LESSON_EXCHANGE_ITEMS_PER_PAGE} * ${TABLE_ROW_HEIGHT} + 2.75rem
-  );
-`;
-
-const TableViewport = styled.div`
+const LessonExchangeListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
   position: relative;
-  flex: 1 1 auto;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
 `;
 
-const ListOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgb(255 255 255 / 72%);
+const HeaderHeightSpacer = styled.span`
+  display: inline-flex;
+  width: 0;
+  min-height: 2.25rem;
 `;
 
-const ListOverlayMessage = styled.p`
-  margin: 0;
-  color: #64706c;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight130};
-`;
+const LessonExchangeListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
 
-const LessonExchangeTableRow = styled.tr<{ $selected: boolean }>`
-  height: ${TABLE_ROW_HEIGHT};
-  background-color: ${({ $selected }) => ($selected ? colors.pointSoft : "transparent")};
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
 `;
 
 const LessonExchangeListTable = styled(Table)`
@@ -191,82 +222,162 @@ const LessonExchangeListTable = styled(Table)`
   td {
     vertical-align: middle;
   }
-
-  thead tr {
-    height: ${TABLE_HEADER_HEIGHT};
-  }
-
-  tbody tr {
-    height: ${TABLE_ROW_HEIGHT};
-  }
-
-  th:last-child,
-  td:last-child {
-    width: 1%;
-    white-space: nowrap;
-  }
 `;
 
 const StatusSelect = styled(Select)`
-  max-width: 10rem;
+  width: 9.5rem;
+  min-width: 9.5rem;
+  max-width: 9.5rem;
+  flex: 0 0 9.5rem;
+  height: 2.375rem;
+  min-height: 2.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  appearance: none;
 `;
 
 const KeywordInput = styled(TextInput)`
-  max-width: 16rem;
+  flex: 1 1 auto;
+  max-width: none;
 `;
 
 const PaginationNav = styled.nav`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: ${spacing.space8};
-  margin-top: auto;
-  padding-top: ${spacing.space12};
-  flex-shrink: 0;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
 `;
 
 const PageArrowButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid #e6e9e7;
-  border-radius: 999px;
-  background: ${colors.white};
-  color: #64706c;
-  font-family: inherit;
-  font-size: 1.125rem;
-  line-height: 1;
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
   cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    background-color 0.15s ease,
-    color 0.15s ease,
-    opacity 0.15s ease;
-
-  &:not(:disabled):hover {
-    border-color: #88cd5a;
-    background: #f5fff0;
-    color: #5eb63a;
-  }
 
   &:disabled {
-    cursor: not-allowed;
-    opacity: 0.35;
+    opacity: 0.3;
+    cursor: default;
   }
 `;
 
-const PageIndicator = styled.span`
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeLessonExchangePanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeLessonExchangePanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideLessonExchangePanelIn 0.22s ease-out both;
+
+  @keyframes slideLessonExchangePanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 3.75rem;
-  padding: 0.375rem 0.625rem;
-  border-radius: 999px;
-  background: #f4f6f5;
-  color: #64706c;
-  font-size: ${typography.fontSize13};
-  font-weight: 800;
-  line-height: ${typography.lineHeight130};
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
 `;

--- a/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
+++ b/components/admin/lesson-exchange/AdminLessonExchangeSection.tsx
@@ -1,17 +1,10 @@
 "use client";
 
-import { AdminLessonExchangeRequestsDetailPanel } from "@/components/admin/lesson-exchange/AdminLessonExchangeRequestsDetailPanel";
 import { AdminLessonExchangeRequestsListPanel } from "@/components/admin/lesson-exchange/AdminLessonExchangeRequestsListPanel";
 import { useAdminLessonExchangeRequests } from "@/components/admin/lesson-exchange/useAdminLessonExchangeRequests";
-import { TwoColumnGrid } from "@/components/admin/AdminDashboardSectionParts";
 
 export function AdminLessonExchangeSection() {
   const viewModel = useAdminLessonExchangeRequests();
 
-  return (
-    <TwoColumnGrid>
-      <AdminLessonExchangeRequestsListPanel viewModel={viewModel} />
-      <AdminLessonExchangeRequestsDetailPanel viewModel={viewModel} />
-    </TwoColumnGrid>
-  );
+  return <AdminLessonExchangeRequestsListPanel viewModel={viewModel} />;
 }

--- a/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
+++ b/components/admin/lesson-exchange/lessonExchangeRequestConstants.ts
@@ -13,7 +13,7 @@ const TERMINAL_LESSON_EXCHANGE_STATUSES: LessonExchangeRequestStatus[] = [
 
 export type LessonExchangeDetailActionState = "empty" | "actionable" | "processed" | "expired";
 
-export const LESSON_EXCHANGE_ITEMS_PER_PAGE = 8;
+export const LESSON_EXCHANGE_ITEMS_PER_PAGE = 11;
 
 export const LESSON_EXCHANGE_STATUS_OPTIONS = [
   { value: "", label: "전체" },

--- a/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
+++ b/components/admin/lesson-exchange/useAdminLessonExchangeRequests.ts
@@ -53,7 +53,6 @@ export function useAdminLessonExchangeRequests() {
     },
   });
 
-  const lessonExchangeRequests = lessonExchangeRequestsQuery.data?.content ?? [];
   const totalPages = Math.max(1, lessonExchangeRequestsQuery.data?.totalPages ?? 1);
   const currentPage = page <= totalPages ? page : totalPages;
 
@@ -102,13 +101,16 @@ export function useAdminLessonExchangeRequests() {
   });
 
   const sortedRequests = useMemo(
-    () =>
-      [...lessonExchangeRequests].sort((a, b) => {
+    () => {
+      const lessonExchangeRequests = lessonExchangeRequestsQuery.data?.content ?? [];
+
+      return [...lessonExchangeRequests].sort((a, b) => {
         const aTime = new Date(a.createdAt ?? 0).getTime();
         const bTime = new Date(b.createdAt ?? 0).getTime();
         return bTime - aTime;
-      }),
-    [lessonExchangeRequests],
+      });
+    },
+    [lessonExchangeRequestsQuery.data?.content],
   );
 
   const resetSelection = () => {
@@ -118,6 +120,13 @@ export function useAdminLessonExchangeRequests() {
 
   const handleSearch = () => {
     setKeyword(keywordInput);
+    setPage(1);
+    resetSelection();
+  };
+
+  const handleKeywordInputChange = (value: string) => {
+    setKeywordInput(value);
+    setKeyword(value);
     setPage(1);
     resetSelection();
   };
@@ -168,10 +177,15 @@ export function useAdminLessonExchangeRequests() {
     resetSelection();
   };
 
+  const goToPage = (nextPage: number) => {
+    setPage(Math.min(totalPages, Math.max(1, nextPage)));
+    resetSelection();
+  };
+
   return {
     statusFilter,
     keywordInput,
-    setKeywordInput,
+    handleKeywordInputChange,
     handleSearch,
     handleStatusFilterChange,
     lessonExchangeRequestsQuery,
@@ -179,10 +193,12 @@ export function useAdminLessonExchangeRequests() {
     selectedRequestId,
     lessonExchangeDetailQuery,
     selectLessonExchangeRequest,
+    resetSelection,
     currentPage,
     totalPages,
     goToPrevPage,
     goToNextPage,
+    goToPage,
     rejectNote,
     setRejectNote,
     handleApprove,

--- a/components/admin/lesson-management/AdminLessonScheduleTables.tsx
+++ b/components/admin/lesson-management/AdminLessonScheduleTables.tsx
@@ -25,7 +25,6 @@ import {
   SectionCard,
   SectionDescription,
   SectionTitle,
-  Select,
   SmallButton,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
@@ -483,7 +482,7 @@ export function AdminLessonScheduleTables() {
             <ModalBody>
               <Label>
                 담당 교사
-                <Select
+                <ScheduleSelect
                   value={cellForm.teacherId}
                   disabled={teachersQuery.isLoading || saveCellMutation.isPending}
                   onChange={(event) =>
@@ -500,7 +499,7 @@ export function AdminLessonScheduleTables() {
                       </option>
                     ) : null,
                   )}
-                </Select>
+                </ScheduleSelect>
               </Label>
 
               <DateFields>
@@ -1038,6 +1037,34 @@ const ModalDescription = styled.p`
 const ModalBody = styled.div`
   display: grid;
   gap: ${spacing.space12};
+`;
+
+const ScheduleSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
 `;
 
 const DateFields = styled.div`

--- a/components/admin/lesson-management/AdminLessonScheduleTables.tsx
+++ b/components/admin/lesson-management/AdminLessonScheduleTables.tsx
@@ -22,7 +22,6 @@ import {
   DataState,
   InlineStatus,
   Label,
-  PrimaryButton,
   SectionCard,
   SectionDescription,
   SectionTitle,
@@ -603,13 +602,13 @@ export function AdminLessonScheduleTables() {
 
             <ModalActions>
               <ButtonRow>
-                <PrimaryButton
+                <LessonActionButton
                   type="button"
                   disabled={saveCellMutation.isPending}
                   onClick={handleSaveCell}
                 >
                   {saveCellMutation.isPending ? "저장 중..." : "저장"}
-                </PrimaryButton>
+                </LessonActionButton>
                 <SmallButton
                   type="button"
                   disabled={saveCellMutation.isPending}
@@ -666,9 +665,9 @@ export function AdminLessonScheduleTables() {
                 <SmallButton type="button" onClick={() => setPeriodColors(DEFAULT_PERIOD_COLORS)}>
                   기본값
                 </SmallButton>
-                <PrimaryButton type="button" onClick={() => setIsColorSettingsOpen(false)}>
+                <LessonActionButton type="button" onClick={() => setIsColorSettingsOpen(false)}>
                   적용
-                </PrimaryButton>
+                </LessonActionButton>
               </ButtonRow>
             </ModalActions>
           </ColorModalDialog>
@@ -744,7 +743,9 @@ const IconButton = styled.button`
   position: absolute;
   top: -0.375rem;
   right: -0.375rem;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
   border: 0;
@@ -752,8 +753,10 @@ const IconButton = styled.button`
   background-color: transparent;
   color: #64706c;
   cursor: pointer;
+  line-height: 0;
 
   svg {
+    display: block;
     width: 1rem;
     height: 1rem;
   }
@@ -1082,6 +1085,38 @@ const TimeFields = styled.div`
 const ModalActions = styled.div`
   display: flex;
   justify-content: flex-end;
+`;
+
+const LessonActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.25rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;
 
 const ColorModalDialog = styled(ModalDialog)`

--- a/components/admin/lesson-management/AdminLessonScheduleTables.tsx
+++ b/components/admin/lesson-management/AdminLessonScheduleTables.tsx
@@ -430,8 +430,8 @@ export function AdminLessonScheduleTables() {
         </IconButton>
       </ScheduleHeaderRow>
       <SectionDescription>
-        분반 목록을 기준으로 주중/주말 시간표 행을 구성하고, 각 칸에는 1~3교시 과목과 담당 교사를
-        표시합니다.
+        사이트에 등록된 주중/주말 분반 목록을 기준으로 시간표의 행을 구성하고, 각 칸에는 요일별 담당
+        교사와 교시별 과목을 표시합니다.
       </SectionDescription>
       <DataState
         isLoading={classroomsQuery.isLoading || subjectsQuery.isLoading}
@@ -474,9 +474,7 @@ export function AdminLessonScheduleTables() {
                 <ModalTitle id="schedule-cell-modal-title">
                   {selectedCell.classroom.name ?? "분반"} {selectedCell.dayLabel}요일 시간표
                 </ModalTitle>
-                <ModalDescription>
-                  담당 교사는 한 칸의 1~3교시에 동일하게 적용됩니다.
-                </ModalDescription>
+                <ModalDescription>담당 교사는 1~3교시에 동일하게 적용됩니다.</ModalDescription>
               </div>
               <SmallButton type="button" onClick={closeModal}>
                 닫기

--- a/components/admin/posts/AdminPostsSection.tsx
+++ b/components/admin/posts/AdminPostsSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { Dispatch, MouseEvent, SetStateAction } from "react";
 import styled from "styled-components";
 import type { ChannelListItemDto } from "@/api/channel/channel.dto";
@@ -22,11 +22,9 @@ import {
   EditorFieldTitle,
   FormGrid,
   Label,
-  PrimaryButton,
   SectionCard,
-  SectionDescription,
+  SectionHeaderRow,
   SectionTitle,
-  Select,
   SmallButton,
   Table,
   TextInput,
@@ -34,8 +32,8 @@ import {
 import ToastEditorField from "@/components/admin/posts/ToastEditorField";
 import ToastViewerField from "@/components/admin/posts/ToastViewerField";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
-import Image from "next/image";
-import chevronRight from "@/assets/chevron_right.svg";
+
+const POSTS_PER_PAGE = 11;
 
 type QueryState<TData> = {
   data?: TData;
@@ -60,9 +58,12 @@ type AdminPostsSectionProps = {
   posts: PostSummaryResponseDto[];
   selectedPost: { channelId: number; postId: number } | null;
   postTitleSearch: string;
+  postChannelTypeFilter: string;
+  postScopeFilter: string;
   postCreate: PostCreateState;
   postEdit: PostEditState;
   isPostEditing: boolean;
+  isPostCreateModalOpen: boolean;
   postsQuery: QueryState<unknown>;
   postDetailQuery: QueryState<PostDetailResponseDto>;
   createPostMutation: VoidMutationAction;
@@ -70,9 +71,12 @@ type AdminPostsSectionProps = {
   pinPostMutation: ValueMutationAction<boolean>;
   deletePostMutation: VoidMutationAction;
   setPostTitleSearch: Dispatch<SetStateAction<string>>;
+  setPostChannelTypeFilter: Dispatch<SetStateAction<string>>;
+  setPostScopeFilter: Dispatch<SetStateAction<string>>;
   setPostCreate: Dispatch<SetStateAction<PostCreateState>>;
   setPostEdit: Dispatch<SetStateAction<PostEditState>>;
   setIsPostEditing: Dispatch<SetStateAction<boolean>>;
+  setIsPostCreateModalOpen: Dispatch<SetStateAction<boolean>>;
   selectPost: (item: PostSummaryResponseDto) => void;
   closePostDetail: () => void;
 };
@@ -84,9 +88,12 @@ export function AdminPostsSection({
   posts,
   selectedPost,
   postTitleSearch,
+  postChannelTypeFilter,
+  postScopeFilter,
   postCreate,
   postEdit,
   isPostEditing,
+  isPostCreateModalOpen,
   postsQuery,
   postDetailQuery,
   createPostMutation,
@@ -94,12 +101,17 @@ export function AdminPostsSection({
   pinPostMutation,
   deletePostMutation,
   setPostTitleSearch,
+  setPostChannelTypeFilter,
+  setPostScopeFilter,
   setPostCreate,
   setPostEdit,
   setIsPostEditing,
+  setIsPostCreateModalOpen,
   selectPost,
   closePostDetail,
 }: AdminPostsSectionProps) {
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const [isPostDeleteConfirmOpen, setIsPostDeleteConfirmOpen] = useState(false);
   const noticeChannelId =
     channels.find((channel) => channel.channelType === "NOTICE" && typeof channel.id === "number")
       ?.id ?? "";
@@ -143,7 +155,47 @@ export function AdminPostsSection({
     .filter((item): item is { targetId: string; channelId: string; label: string } =>
       Boolean(item),
     );
+  const postScopeOptions =
+    postChannelTypeFilter === "CLASSROOM"
+      ? [
+          { value: "all", label: "전체" },
+          ...classrooms
+            .filter((classroom) => typeof classroom.id === "number")
+            .map((classroom) => ({
+              value: String(classroom.id),
+              label: classroom.name ?? `분반 ${classroom.id}`,
+            })),
+        ]
+      : postChannelTypeFilter === "DEPARTMENT"
+        ? [
+            { value: "all", label: "전체" },
+            ...departments
+              .filter((department) => typeof department.id === "number")
+              .map((department) => ({
+                value: String(department.id),
+                label: department.name ?? `부서 ${department.id}`,
+              })),
+          ]
+        : [{ value: "all", label: "전체" }];
+  const isPostScopeDisabled =
+    postChannelTypeFilter === "all" || postChannelTypeFilter === "NOTICE";
   const postView = postDetailQuery.data ? mapPostDetailToEditState(postDetailQuery.data) : postEdit;
+  const paginationKey = `${postTitleSearch}|${postChannelTypeFilter}|${postScopeFilter}`;
+  const totalPages = Math.max(1, Math.ceil(posts.length / POSTS_PER_PAGE));
+  const requestedPage = pagination.search === paginationKey ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedPosts = posts.slice(
+    (safeCurrentPage - 1) * POSTS_PER_PAGE,
+    safeCurrentPage * POSTS_PER_PAGE,
+  );
+
+  function closeCreateModal() {
+    if (createPostMutation.isPending) {
+      return;
+    }
+
+    setIsPostCreateModalOpen(false);
+  }
 
   useEffect(() => {
     if (postCreate.channelScope === "NOTICE" && noticeChannelId) {
@@ -175,24 +227,41 @@ export function AdminPostsSection({
     const clickedPostRow = (event.target as HTMLElement).closest("tbody tr");
 
     if (isLeftVisibleArea && !clickedPostRow) {
+      setIsPostDeleteConfirmOpen(false);
       closePostDetail();
     }
   }
 
   return (
     <>
-      <SectionCard>
-        <SectionTitle>게시글 작성</SectionTitle>
+      {isPostCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <PostCreateModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="post-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="post-create-modal-title">게시글 작성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createPostMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
 
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            createPostMutation.mutate();
-          }}
-        >
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createPostMutation.mutate();
+              }}
+            >
           <Label>
             채널 구분
-            <Select
+            <PostSelect
               value={postCreate.channelScope}
               onChange={(event) =>
                 setPostCreate((current) => {
@@ -211,13 +280,13 @@ export function AdminPostsSection({
               <option value="NOTICE">공지</option>
               <option value="CLASSROOM">반별</option>
               <option value="DEPARTMENT">부서별</option>
-            </Select>
+            </PostSelect>
           </Label>
 
           {postCreate.channelScope === "CLASSROOM" ? (
             <Label>
               반/부서 선택
-              <Select
+              <PostSelect
                 value={postCreate.channelTargetId}
                 onChange={(event) => {
                   const selectedOption = classroomChannelOptions.find(
@@ -237,14 +306,14 @@ export function AdminPostsSection({
                     {option.label}
                   </option>
                 ))}
-              </Select>
+              </PostSelect>
             </Label>
           ) : null}
 
           {postCreate.channelScope === "DEPARTMENT" ? (
             <Label>
               반/부서 선택
-              <Select
+              <PostSelect
                 value={postCreate.channelTargetId}
                 onChange={(event) => {
                   const selectedOption = departmentChannelOptions.find(
@@ -264,7 +333,7 @@ export function AdminPostsSection({
                     {option.label}
                   </option>
                 ))}
-              </Select>
+              </PostSelect>
             </Label>
           ) : null}
 
@@ -284,7 +353,7 @@ export function AdminPostsSection({
 
           <Label>
             상태
-            <Select
+            <PostSelect
               value={postCreate.status}
               onChange={(event) =>
                 setPostCreate((current) => ({
@@ -295,7 +364,7 @@ export function AdminPostsSection({
             >
               <option value="PUBLISHED">PUBLISHED</option>
               <option value="DRAFT">DRAFT</option>
-            </Select>
+            </PostSelect>
           </Label>
 
           <Label>
@@ -352,22 +421,66 @@ export function AdminPostsSection({
             />
           </EditorField>
 
-          <PrimaryButton disabled={createPostMutation.isPending || !postCreate.channelId}>
-            게시글 작성
-          </PrimaryButton>
-        </FormGrid>
-      </SectionCard>
+              <ButtonRow>
+                <PostActionButton
+                  type="submit"
+                  disabled={createPostMutation.isPending || !postCreate.channelId}
+                >
+                  게시글 작성
+                </PostActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createPostMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </PostCreateModalDialog>
+        </ModalBackdrop>
+      ) : null}
 
       <PostListSection $isPanelOpen={Boolean(selectedPost)} onClick={handlePostListSectionClick}>
-        <SectionTitle>게시글 목록</SectionTitle>
+        <SectionHeaderRow>
+          <SectionTitle>게시글 목록</SectionTitle>
+          <SmallButton type="button" onClick={() => setIsPostCreateModalOpen(true)}>
+            게시글 작성
+          </SmallButton>
+        </SectionHeaderRow>
 
-        <ControlRow>
+        <PostControlRow>
+          <FilterSelect
+            value={postChannelTypeFilter}
+            aria-label="게시판 유형"
+            onChange={(event) => {
+              setPostChannelTypeFilter(event.target.value);
+              setPostScopeFilter("all");
+            }}
+          >
+            <option value="all">전체</option>
+            <option value="NOTICE">공지사항</option>
+            <option value="CLASSROOM">반별</option>
+            <option value="DEPARTMENT">부서별</option>
+          </FilterSelect>
+          <FilterSelect
+            value={postScopeFilter}
+            aria-label="게시판 선택"
+            disabled={isPostScopeDisabled}
+            onChange={(event) => setPostScopeFilter(event.target.value)}
+          >
+            {postScopeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </FilterSelect>
           <TextInput
             value={postTitleSearch}
             onChange={(event) => setPostTitleSearch(event.target.value)}
             placeholder="제목 검색"
           />
-        </ControlRow>
+        </PostControlRow>
 
         <PostListFrame>
           <DataState
@@ -389,7 +502,7 @@ export function AdminPostsSection({
                 </tr>
               </thead>
               <tbody>
-                {posts.map((item) => (
+                {pagedPosts.map((item) => (
                   <tr key={item.id} onClick={() => selectPost(item)}>
                     <td>{item.title}</td>
                     <td>{item.channelName ?? item.channelId}</td>
@@ -403,6 +516,47 @@ export function AdminPostsSection({
           </DataState>
         </PostListFrame>
 
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({ page: Math.max(1, safeCurrentPage - 1), search: paginationKey })
+            }
+          >
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: paginationKey })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: paginationKey,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
         {selectedPost ? (
           <>
             <PanelBackdrop aria-hidden="true" />
@@ -411,7 +565,10 @@ export function AdminPostsSection({
                 <ClosePanelButton
                   type="button"
                   aria-label="게시글 상세 닫기"
-                  onClick={closePostDetail}
+                  onClick={() => {
+                    setIsPostDeleteConfirmOpen(false);
+                    closePostDetail();
+                  }}
                 >
                   <CloseIcon aria-hidden="true" />
                 </ClosePanelButton>
@@ -426,181 +583,218 @@ export function AdminPostsSection({
                 errorLabel="게시글 상세를 불러오지 못했습니다."
                 emptyLabel="게시글을 선택하세요."
               >
-                {isPostEditing ? (
-                  <FormGrid
-                    onSubmit={(event) => {
-                      event.preventDefault();
-                      updatePostMutation.mutate();
-                    }}
-                  >
-                    <Label>
-                      제목
-                      <TextInput
-                        value={postEdit.title}
-                        onChange={(event) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            title: event.target.value,
-                          }))
-                        }
-                      />
-                    </Label>
+                <PanelContent>
+                  {isPostEditing ? (
+                    <FormGrid
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        updatePostMutation.mutate();
+                      }}
+                    >
+                      <Label>
+                        제목
+                        <TextInput
+                          value={postEdit.title}
+                          onChange={(event) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              title: event.target.value,
+                            }))
+                          }
+                        />
+                      </Label>
 
-                    <Label>
-                      상태
-                      <Select
-                        value={postEdit.status}
-                        onChange={(event) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            status: event.target.value as PostStatus,
-                          }))
-                        }
-                      >
-                        <option value="PUBLISHED">PUBLISHED</option>
-                        <option value="DRAFT">DRAFT</option>
-                        <option value="ARCHIVED">ARCHIVED</option>
-                      </Select>
-                    </Label>
+                      <Label>
+                        상태
+                        <PostSelect
+                          value={postEdit.status}
+                          onChange={(event) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              status: event.target.value as PostStatus,
+                            }))
+                          }
+                        >
+                          <option value="PUBLISHED">PUBLISHED</option>
+                          <option value="DRAFT">DRAFT</option>
+                          <option value="ARCHIVED">ARCHIVED</option>
+                        </PostSelect>
+                      </Label>
 
-                    <Label>
-                      썸네일 URL
-                      <TextInput
-                        value={postEdit.thumbnailUrl}
-                        onChange={(event) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            thumbnailUrl: event.target.value,
-                          }))
-                        }
-                      />
-                    </Label>
+                      <Label>
+                        썸네일 URL
+                        <TextInput
+                          value={postEdit.thumbnailUrl}
+                          onChange={(event) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              thumbnailUrl: event.target.value,
+                            }))
+                          }
+                        />
+                      </Label>
 
-                    <CheckLabel>
-                      <input
-                        type="checkbox"
-                        checked={postEdit.allowComment}
-                        onChange={(event) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            allowComment: event.target.checked,
-                          }))
-                        }
-                      />
-                      댓글 허용
-                    </CheckLabel>
+                      <CheckLabel>
+                        <input
+                          type="checkbox"
+                          checked={postEdit.allowComment}
+                          onChange={(event) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              allowComment: event.target.checked,
+                            }))
+                          }
+                        />
+                        댓글 허용
+                      </CheckLabel>
 
-                    <CheckLabel>
-                      <input
-                        type="checkbox"
-                        checked={postEdit.isPinned}
-                        onChange={(event) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            isPinned: event.target.checked,
-                          }))
-                        }
-                      />
-                      상단 고정
-                    </CheckLabel>
+                      <CheckLabel>
+                        <input
+                          type="checkbox"
+                          checked={postEdit.isPinned}
+                          onChange={(event) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              isPinned: event.target.checked,
+                            }))
+                          }
+                        />
+                        상단 고정
+                      </CheckLabel>
 
-                    <PanelEditorField>
-                      <EditorFieldTitle>본문</EditorFieldTitle>
-                      <ToastEditorField
-                        initialValue={postEdit.contentHtml}
-                        onChange={(contentHtml) =>
-                          setPostEdit((current) => ({
-                            ...current,
-                            contentHtml,
-                          }))
-                        }
-                      />
-                    </PanelEditorField>
+                      <PanelEditorField>
+                        <EditorFieldTitle>본문</EditorFieldTitle>
+                        <ToastEditorField
+                          initialValue={postEdit.contentHtml}
+                          onChange={(contentHtml) =>
+                            setPostEdit((current) => ({
+                              ...current,
+                              contentHtml,
+                            }))
+                          }
+                        />
+                      </PanelEditorField>
 
-                    <ButtonRow>
-                      <PrimaryButton disabled={updatePostMutation.isPending || !selectedPost}>
-                        저장
-                      </PrimaryButton>
-                      <SmallButton
-                        type="button"
-                        disabled={updatePostMutation.isPending}
-                        onClick={() => {
-                          setPostEdit(postView);
-                          setIsPostEditing(false);
-                        }}
-                      >
-                        취소
-                      </SmallButton>
-                    </ButtonRow>
-                  </FormGrid>
-                ) : (
-                  <ReadonlyDetail>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>제목</ReadonlyLabel>
-                      <ReadonlyValue>{postView.title || "-"}</ReadonlyValue>
-                    </ReadonlyItem>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>상태</ReadonlyLabel>
-                      <ReadonlyValue>{postView.status || "-"}</ReadonlyValue>
-                    </ReadonlyItem>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>댓글</ReadonlyLabel>
-                      <ReadonlyValue>{postView.allowComment ? "허용" : "허용 안 함"}</ReadonlyValue>
-                    </ReadonlyItem>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>고정</ReadonlyLabel>
-                      <ReadonlyValue>{postView.isPinned ? "고정" : "고정 안 함"}</ReadonlyValue>
-                    </ReadonlyItem>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>썸네일 URL</ReadonlyLabel>
-                      <ReadonlyValue>{postView.thumbnailUrl || "-"}</ReadonlyValue>
-                    </ReadonlyItem>
-                    <ReadonlyItem>
-                      <ReadonlyLabel>본문</ReadonlyLabel>
-                      <ReadonlyContent>
-                        {postView.contentHtml ? (
-                          <ToastViewerField value={postView.contentHtml} />
-                        ) : (
-                          <ReadonlyEmpty>본문이 없습니다.</ReadonlyEmpty>
-                        )}
-                      </ReadonlyContent>
-                    </ReadonlyItem>
+                      <ButtonRow>
+                        <PostActionButton
+                          type="submit"
+                          disabled={updatePostMutation.isPending || !selectedPost}
+                        >
+                          저장
+                        </PostActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={updatePostMutation.isPending}
+                          onClick={() => {
+                            setPostEdit(postView);
+                            setIsPostEditing(false);
+                          }}
+                        >
+                          취소
+                        </SmallButton>
+                      </ButtonRow>
+                    </FormGrid>
+                  ) : (
+                    <ReadonlyDetail>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>제목</ReadonlyLabel>
+                        <ReadonlyValue>{postView.title || "-"}</ReadonlyValue>
+                      </ReadonlyItem>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>상태</ReadonlyLabel>
+                        <ReadonlyValue>{postView.status || "-"}</ReadonlyValue>
+                      </ReadonlyItem>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>댓글</ReadonlyLabel>
+                        <ReadonlyValue>
+                          {postView.allowComment ? "허용" : "허용 안 함"}
+                        </ReadonlyValue>
+                      </ReadonlyItem>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>고정</ReadonlyLabel>
+                        <ReadonlyValue>{postView.isPinned ? "고정" : "고정 안 함"}</ReadonlyValue>
+                      </ReadonlyItem>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>썸네일 URL</ReadonlyLabel>
+                        <ReadonlyValue>{postView.thumbnailUrl || "-"}</ReadonlyValue>
+                      </ReadonlyItem>
+                      <ReadonlyItem>
+                        <ReadonlyLabel>본문</ReadonlyLabel>
+                        <ReadonlyContent>
+                          {postView.contentHtml ? (
+                            <ToastViewerField value={postView.contentHtml} />
+                          ) : (
+                            <ReadonlyEmpty>본문이 없습니다.</ReadonlyEmpty>
+                          )}
+                        </ReadonlyContent>
+                      </ReadonlyItem>
 
-                    <ButtonRow>
-                      <PrimaryButton
-                        type="button"
-                        disabled={!selectedPost}
-                        onClick={() => {
-                          setPostEdit(postView);
-                          setIsPostEditing(true);
-                        }}
-                      >
-                        수정
-                      </PrimaryButton>
-                      <SmallButton
-                        type="button"
-                        disabled={pinPostMutation.isPending}
-                        onClick={() =>
-                          pinPostMutation.mutate(!(postDetailQuery.data?.isPinned ?? false))
-                        }
-                      >
-                        {postDetailQuery.data?.isPinned ? "고정 해제" : "고정"}
-                      </SmallButton>
-                      <DangerButton
-                        type="button"
-                        disabled={deletePostMutation.isPending}
-                        onClick={() => deletePostMutation.mutate()}
-                      >
-                        삭제
-                      </DangerButton>
-                    </ButtonRow>
-                  </ReadonlyDetail>
-                )}
+                      <ButtonRow>
+                        <PostActionButton
+                          type="button"
+                          disabled={!selectedPost}
+                          onClick={() => {
+                            setPostEdit(postView);
+                            setIsPostEditing(true);
+                          }}
+                        >
+                          수정
+                        </PostActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={pinPostMutation.isPending}
+                          onClick={() =>
+                            pinPostMutation.mutate(!(postDetailQuery.data?.isPinned ?? false))
+                          }
+                        >
+                          {postDetailQuery.data?.isPinned ? "고정 해제" : "고정"}
+                        </SmallButton>
+                        <DangerButton
+                          type="button"
+                          disabled={deletePostMutation.isPending}
+                          onClick={() => setIsPostDeleteConfirmOpen(true)}
+                        >
+                          삭제
+                        </DangerButton>
+                      </ButtonRow>
+                    </ReadonlyDetail>
+                  )}
+                </PanelContent>
               </DataState>
             </SlidePanel>
           </>
         ) : null}
       </PostListSection>
+
+      {selectedPost && isPostDeleteConfirmOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsPostDeleteConfirmOpen(false)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="post-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="post-delete-confirm-title">게시글 삭제</ConfirmTitle>
+            <ConfirmMessage>삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
+              <DangerButton
+                type="button"
+                disabled={deletePostMutation.isPending}
+                onClick={() => deletePostMutation.mutate()}
+              >
+                확인
+              </DangerButton>
+              <SmallButton
+                type="button"
+                disabled={deletePostMutation.isPending}
+                onClick={() => setIsPostDeleteConfirmOpen(false)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
     </>
   );
 }
@@ -616,26 +810,224 @@ function mapPostDetailToEditState(post?: PostDetailResponseDto): PostEditState {
   };
 }
 
-const PostListSection = styled.section<{ $isPanelOpen: boolean }>`
+const PostListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
   position: relative;
-  min-width: 0;
-  min-height: 44rem;
+  display: grid;
+  align-content: start;
   overflow: hidden;
-  padding: 1.25rem 1rem;
-  background-color: ${colors.white};
-  border: 1px solid #e6e9e7;
-  border-radius: ${radii.radius12};
   box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
-
-  @media (min-width: 120rem) {
-    padding: 2rem 1.75rem;
-  }
 `;
 
 const PostListFrame = styled.div`
   position: relative;
-  min-height: 32rem;
+  min-height: 22.35rem;
   border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const PostControlRow = styled(ControlRow)`
+  align-items: center;
+
+  ${TextInput} {
+    flex: 1;
+    min-width: 12rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    flex-wrap: wrap;
+
+    ${TextInput} {
+      flex-basis: 100%;
+    }
+  }
+`;
+
+const FilterSelect = styled.select`
+  width: 9.5rem;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const PostSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const PostCreateModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 56rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(PostCreateModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const PostActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;
 
 const PanelBackdrop = styled.div`
@@ -709,9 +1101,9 @@ const PanelHeader = styled.div`
 `;
 
 const CloseIcon = styled.span`
-  width: 1rem;
-  height: 1rem;
   display: block;
+  width: 1.5rem;
+  height: 1.5rem;
   background-color: currentColor;
   mask: url("/chevron_right.svg") center / contain no-repeat;
   -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
@@ -721,19 +1113,23 @@ const ClosePanelButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid ${colors.border};
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
   border-radius: 0.375rem;
-  background-color: ${colors.white};
+  background-color: transparent;
   color: #1f2b28;
   cursor: pointer;
 
   &:hover {
-    border-color: #88cd5a;
     background-color: #f5fff0;
     color: #5eb63a;
   }
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
 `;
 
 const PanelEditorField = styled.div`

--- a/components/admin/posts/AdminPostsSection.tsx
+++ b/components/admin/posts/AdminPostsSection.tsx
@@ -417,9 +417,6 @@ export function AdminPostsSection({
                 </ClosePanelButton>
                 <SectionTitle>{isPostEditing ? "게시글 수정" : "게시글 상세"}</SectionTitle>
               </PanelHeader>
-              <SectionDescription>
-                선택한 게시글을 먼저 읽기 전용으로 확인하고, 수정 버튼을 누르면 편집합니다.
-              </SectionDescription>
 
               <DataState
                 isLoading={postDetailQuery.isLoading}

--- a/components/admin/posts/AdminPostsSection.tsx
+++ b/components/admin/posts/AdminPostsSection.tsx
@@ -1198,14 +1198,21 @@ const ReadonlyLabel = styled.span`
 `;
 
 const ReadonlyValue = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.375rem;
   min-height: 2.375rem;
+  box-sizing: border-box;
   border: 1px solid ${colors.border};
   border-radius: 0.375rem;
-  padding: 0.625rem ${spacing.space12};
+  padding: 0 ${spacing.space12};
   color: #1f2b28;
   font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight150};
-  overflow-wrap: anywhere;
+  line-height: ${typography.lineHeight130};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const ReadonlyContent = styled.div`

--- a/components/admin/posts/AdminPostsSection.tsx
+++ b/components/admin/posts/AdminPostsSection.tsx
@@ -847,6 +847,7 @@ const PostControlRow = styled(ControlRow)`
 
 const FilterSelect = styled.select`
   width: 9.5rem;
+  height: 2.375rem;
   min-height: 2.375rem;
   border: 1px solid ${colors.border};
   border-radius: 0.375rem;
@@ -875,6 +876,7 @@ const FilterSelect = styled.select`
 
 const PostSelect = styled.select`
   width: 100%;
+  height: 2.375rem;
   min-height: 2.375rem;
   border: 1px solid ${colors.border};
   border-radius: 0.375rem;

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -286,10 +286,7 @@ export function AdminPurchasesSection({
           </DataState>
         </SectionCard>
         <SectionCard>
-          <SectionTitle>구매 요청 상세/처리</SectionTitle>
-          <SectionDescription>
-            선택한 구매 요청의 품목을 확인하고 승인, 반려, 결재 확인, 삭제 처리를 수행합니다.
-          </SectionDescription>
+          <SectionTitle>구매 요청 상세</SectionTitle>
           <DataState
             isLoading={purchaseDetailQuery.isLoading}
             isError={purchaseDetailQuery.isError}

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -181,9 +181,9 @@ export function AdminPurchasesSection({
     isRejecting && reviewNote.trim().length > 0 && !rejectPurchaseMutation.isPending;
   const canSubmitPurchase = Boolean(
     purchaseCreate.title.trim().length > 0 &&
-      purchaseCreate.classroomId &&
-      purchaseCreate.items.length > 0 &&
-      purchaseCreate.items.every((item) => item.itemName.trim().length > 0),
+    purchaseCreate.classroomId &&
+    purchaseCreate.items.length > 0 &&
+    purchaseCreate.items.every((item) => item.itemName.trim().length > 0),
   );
   const confirmMessage = {
     approve: "승인하시겠습니까?",
@@ -335,6 +335,15 @@ export function AdminPurchasesSection({
     }
   }
 
+  function handlePurchaseSearchChange(value: string) {
+    setPurchaseSearch(value);
+    setPagination({ page: 1, search: `${purchaseStatus}:${value}` });
+
+    if (isDetailOpen) {
+      closePurchaseDetail();
+    }
+  }
+
   return (
     <>
       <PurchaseListSection $isPanelOpen={isDetailOpen} onClick={handlePurchaseListSectionClick}>
@@ -358,7 +367,7 @@ export function AdminPurchasesSection({
             }
             aria-label="결제 요청 상태 필터"
           >
-            <option value="">전체 상태</option>
+            <option value="">전체</option>
             <option value="PENDING">대기</option>
             <option value="APPROVED">승인</option>
             <option value="PURCHASED">구매 완료</option>
@@ -367,7 +376,7 @@ export function AdminPurchasesSection({
           </FilterSelect>
           <TextInput
             value={purchaseSearch}
-            onChange={(event) => setPurchaseSearch(event.target.value)}
+            onChange={(event) => handlePurchaseSearchChange(event.target.value)}
             placeholder="제목, 소속, 요청자, ID 검색"
           />
         </ControlRow>
@@ -484,16 +493,16 @@ export function AdminPurchasesSection({
                         <span>{purchaseDetailQuery.data?.title ?? "-"}</span>
                       </ListItem>
                       <ListItem>
-                        <span>상태</span>
-                        <span>{formatPurchaseStatus(purchaseDetailQuery.data?.status)}</span>
-                      </ListItem>
-                      <ListItem>
                         <span>요청자</span>
                         <span>{purchaseDetailQuery.data?.requestedByName ?? "-"}</span>
                       </ListItem>
                       <ListItem>
                         <span>소속</span>
                         <span>{purchaseDetailQuery.data?.classroomName ?? "-"}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>상태</span>
+                        <span>{formatPurchaseStatus(purchaseDetailQuery.data?.status)}</span>
                       </ListItem>
                     </List>
                   </DetailBlock>
@@ -1159,7 +1168,12 @@ const selectBase = `
 
 const FilterSelect = styled.select`
   ${selectBase}
-  flex: 0 0 10rem;
+  width: 9.5rem;
+  min-width: 9.5rem;
+  max-width: 9.5rem;
+  flex: 0 0 9.5rem;
+  height: 2.375rem;
+  min-height: 2.375rem;
 `;
 
 const PurchaseSelect = styled.select`

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useState, type Dispatch, type SetStateAction } from "react";
+import { useState } from "react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
 import styled from "styled-components";
 import type { ClassroomListItemDto } from "@/api/classroom/classroom.dto";
 import type {
+  PaymentType,
   PurchaseRequestListItemDto,
   PurchaseRequestResponseDto,
+  PurchaseRequestItemResponseDto,
+  PurchaseTransactionResponseDto,
   PurchaseRequestStatus,
 } from "@/api/request/request.dto";
-import type { PurchaseCreateState } from "@/components/admin/AdminDashboardTypes";
+import type { VendorResponseDto } from "@/api/vendor/vendor.dto";
+import type {
+  PurchaseCreateItemState,
+  PurchaseCreateState,
+} from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
   ControlRow,
@@ -18,20 +26,17 @@ import {
   Label,
   List,
   ListItem,
-  MetaGrid,
-  MetaItem,
-  PrimaryButton,
   SectionCard,
   SectionDescription,
+  SectionHeaderRow,
   SectionTitle,
-  Select,
   SmallButton,
   Table,
-  TextArea,
   TextInput,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
-import { colors, spacing } from "@/styles/tokens";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+const PURCHASES_PER_PAGE = 10;
 
 type QueryState<TData> = {
   data?: TData;
@@ -44,46 +49,129 @@ type VoidMutationAction = {
   mutate: () => void;
 };
 
+type PurchaseConfirmAction = "approve" | "reject" | "confirm" | "delete";
+
 type AdminPurchasesSectionProps = {
   classrooms: ClassroomListItemDto[];
   purchases: PurchaseRequestListItemDto[];
   selectedPurchaseId: number | null;
   purchaseStatus: PurchaseRequestStatus | "";
+  purchaseSearch: string;
+  isPurchaseCreateModalOpen: boolean;
   purchaseCreate: PurchaseCreateState;
   reviewNote: string;
   purchasesQuery: QueryState<unknown>;
   purchaseDetailQuery: QueryState<PurchaseRequestResponseDto>;
+  vendorsQuery: QueryState<VendorResponseDto[]>;
   createPurchaseMutation: VoidMutationAction;
   approvePurchaseMutation: VoidMutationAction;
   rejectPurchaseMutation: VoidMutationAction;
   confirmPurchaseMutation: VoidMutationAction;
   deletePurchaseMutation: VoidMutationAction;
   setPurchaseStatus: Dispatch<SetStateAction<PurchaseRequestStatus | "">>;
+  setPurchaseSearch: Dispatch<SetStateAction<string>>;
+  setIsPurchaseCreateModalOpen: Dispatch<SetStateAction<boolean>>;
   setPurchaseCreate: Dispatch<SetStateAction<PurchaseCreateState>>;
   setSelectedPurchaseId: Dispatch<SetStateAction<number | null>>;
   setReviewNote: Dispatch<SetStateAction<string>>;
+  emptyPurchaseCreate: PurchaseCreateState;
 };
+
+function formatPurchaseStatus(status?: PurchaseRequestStatus) {
+  const labels: Record<PurchaseRequestStatus, string> = {
+    PENDING: "대기",
+    APPROVED: "승인",
+    PURCHASED: "구매 완료",
+    CONFIRMED: "결제 확인",
+    REJECTED: "반려",
+  };
+
+  return status ? labels[status] : "-";
+}
+
+function formatPaymentType(paymentType?: PaymentType) {
+  return paymentType === "PREPAID" ? "선금 결제" : "실 결제";
+}
+
+function formatCurrency(value?: number) {
+  if (typeof value !== "number") {
+    return "-";
+  }
+
+  return `${value.toLocaleString("ko-KR")}원`;
+}
+
+function formatPurchaseListAmount(item: PurchaseRequestListItemDto) {
+  if (item.status !== "PURCHASED" && item.status !== "CONFIRMED") {
+    return "-";
+  }
+
+  return formatCurrency(item.totalPrice);
+}
+
+function createPurchaseItem(): PurchaseCreateItemState {
+  return {
+    id: `purchase-item-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    itemName: "",
+    itemQuantity: "1",
+    itemReason: "",
+    itemPaymentType: "ACTUAL",
+  };
+}
+
+function getReceiptsForItem(
+  item: PurchaseRequestItemResponseDto,
+  transactions?: PurchaseTransactionResponseDto[],
+) {
+  const itemName = item.name?.trim();
+
+  if (!itemName) {
+    return [];
+  }
+
+  return (transactions ?? []).filter((transaction) =>
+    transaction.itemNames?.some((name) => name.trim() === itemName),
+  );
+}
 
 export function AdminPurchasesSection({
   classrooms,
   purchases,
   selectedPurchaseId,
   purchaseStatus,
+  purchaseSearch,
+  isPurchaseCreateModalOpen,
   purchaseCreate,
   reviewNote,
   purchasesQuery,
   purchaseDetailQuery,
+  vendorsQuery,
   createPurchaseMutation,
   approvePurchaseMutation,
   rejectPurchaseMutation,
   confirmPurchaseMutation,
   deletePurchaseMutation,
   setPurchaseStatus,
+  setPurchaseSearch,
+  setIsPurchaseCreateModalOpen,
   setPurchaseCreate,
   setSelectedPurchaseId,
   setReviewNote,
+  emptyPurchaseCreate,
 }: AdminPurchasesSectionProps) {
   const [rejectTargetId, setRejectTargetId] = useState<number | null>(null);
+  const [confirmAction, setConfirmAction] = useState<PurchaseConfirmAction | null>(null);
+  const [isVendorBalanceModalOpen, setIsVendorBalanceModalOpen] = useState(false);
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const isDetailOpen = selectedPurchaseId !== null;
+  const paginationKey = `${purchaseStatus}:${purchaseSearch}`;
+  const totalPages = Math.max(1, Math.ceil(purchases.length / PURCHASES_PER_PAGE));
+  const requestedPage = pagination.search === paginationKey ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedPurchases = purchases.slice(
+    (safeCurrentPage - 1) * PURCHASES_PER_PAGE,
+    safeCurrentPage * PURCHASES_PER_PAGE,
+  );
   const selectedStatus = purchaseDetailQuery.data?.status;
   const canReviewPurchase = selectedStatus === "PENDING";
   const canConfirmPurchase = selectedStatus === "PURCHASED";
@@ -91,17 +179,58 @@ export function AdminPurchasesSection({
   const isRejecting = rejectTargetId === selectedPurchaseId && canReviewPurchase;
   const canSubmitRejection =
     isRejecting && reviewNote.trim().length > 0 && !rejectPurchaseMutation.isPending;
-  const canShowReceiptRows = selectedStatus === "PURCHASED" || selectedStatus === "CONFIRMED";
-  const receiptRows =
-    purchaseDetailQuery.data?.transactions?.map((transaction, index) => ({
-      id: transaction.id ?? index,
-      label: transaction.itemNames?.join(", ") || "영수증",
-      url: transaction.receiptFileUrl,
-    })) ?? [];
+  const canSubmitPurchase = Boolean(
+    purchaseCreate.title.trim().length > 0 &&
+      purchaseCreate.classroomId &&
+      purchaseCreate.items.length > 0 &&
+      purchaseCreate.items.every((item) => item.itemName.trim().length > 0),
+  );
+  const confirmMessage = {
+    approve: "승인하시겠습니까?",
+    reject: "반려하시겠습니까?",
+    confirm: "결제 확인하시겠습니까?",
+    delete: "삭제하시겠습니까?",
+  } satisfies Record<PurchaseConfirmAction, string>;
+
+  function closePurchaseDetail() {
+    setSelectedPurchaseId(null);
+    setReviewNote("");
+    setRejectTargetId(null);
+    setConfirmAction(null);
+  }
+
+  function openCreateModal() {
+    setSelectedPurchaseId(null);
+    setReviewNote("");
+    setRejectTargetId(null);
+    setConfirmAction(null);
+    setPurchaseCreate(emptyPurchaseCreate);
+    setIsPurchaseCreateModalOpen(true);
+  }
+
+  function closeCreateModal() {
+    if (createPurchaseMutation.isPending) {
+      return;
+    }
+
+    setIsPurchaseCreateModalOpen(false);
+    setPurchaseCreate(emptyPurchaseCreate);
+  }
+
+  function selectPurchase(item: PurchaseRequestListItemDto) {
+    if (!item.id) {
+      return;
+    }
+
+    setSelectedPurchaseId(item.id);
+    setReviewNote("");
+    setRejectTargetId(null);
+    setConfirmAction(null);
+  }
 
   function approvePurchase() {
     setReviewNote("");
-    approvePurchaseMutation.mutate();
+    setConfirmAction("approve");
   }
 
   function startRejecting() {
@@ -123,291 +252,1012 @@ export function AdminPurchasesSection({
       return;
     }
 
-    rejectPurchaseMutation.mutate();
-    setRejectTargetId(null);
+    setConfirmAction("reject");
+  }
+
+  function runConfirmedAction() {
+    if (!confirmAction) {
+      return;
+    }
+
+    if (confirmAction === "approve") {
+      approvePurchaseMutation.mutate();
+      setConfirmAction(null);
+      return;
+    }
+
+    if (confirmAction === "reject") {
+      rejectPurchaseMutation.mutate();
+      setConfirmAction(null);
+      setRejectTargetId(null);
+      return;
+    }
+
+    if (confirmAction === "confirm") {
+      confirmPurchaseMutation.mutate();
+      setConfirmAction(null);
+      return;
+    }
+
+    deletePurchaseMutation.mutate();
+    setConfirmAction(null);
+  }
+
+  function addPurchaseItem() {
+    setPurchaseCreate((current) => ({
+      ...current,
+      items: [...current.items, createPurchaseItem()],
+    }));
+  }
+
+  function updatePurchaseItem(
+    itemId: string,
+    field: keyof Omit<PurchaseCreateItemState, "id">,
+    value: string,
+  ) {
+    setPurchaseCreate((current) => ({
+      ...current,
+      items: current.items.map((item) =>
+        item.id === itemId
+          ? {
+              ...item,
+              [field]: value,
+            }
+          : item,
+      ),
+    }));
+  }
+
+  function removePurchaseItem(itemId: string) {
+    setPurchaseCreate((current) => {
+      if (current.items.length <= 1) {
+        return current;
+      }
+
+      return {
+        ...current,
+        items: current.items.filter((item) => item.id !== itemId),
+      };
+    });
+  }
+
+  function handlePurchaseListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedPurchaseRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedPurchaseRow) {
+      closePurchaseDetail();
+    }
   }
 
   return (
     <>
-      <SectionCard>
-        <SectionTitle>구매 요청 작성</SectionTitle>
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            createPurchaseMutation.mutate();
-          }}
-        >
-          <Label>
-            제목
-            <TextInput
-              value={purchaseCreate.title}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({ ...current, title: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            내용
-            <TextArea
-              value={purchaseCreate.content}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({ ...current, content: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            분반
-            <Select
-              value={purchaseCreate.classroomId}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({ ...current, classroomId: event.target.value }))
-              }
-              required
-            >
-              <option value="">분반 선택</option>
-              {classrooms.map((classroom) => (
-                <option key={classroom.id} value={classroom.id}>
-                  {classroom.name}
-                </option>
-              ))}
-            </Select>
-          </Label>
-          <Label>
-            품목명
-            <TextInput
-              value={purchaseCreate.itemName}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({ ...current, itemName: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            수량
-            <TextInput
-              type="number"
-              min="1"
-              step="1"
-              value={purchaseCreate.itemQuantity}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({
-                  ...current,
-                  itemQuantity: event.target.value,
-                }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            구매 사유
-            <TextInput
-              value={purchaseCreate.itemReason}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({ ...current, itemReason: event.target.value }))
-              }
-            />
-          </Label>
-          <Label>
-            결제 유형
-            <Select
-              value={purchaseCreate.itemPaymentType}
-              onChange={(event) =>
-                setPurchaseCreate((current) => ({
-                  ...current,
-                  itemPaymentType: event.target.value as PurchaseCreateState["itemPaymentType"],
-                }))
-              }
-            >
-              <option value="ACTUAL">실 결제</option>
-              <option value="PREPAID">선금 결제</option>
-            </Select>
-          </Label>
-          <PrimaryButton disabled={createPurchaseMutation.isPending || !purchaseCreate.classroomId}>
-            구매 요청 작성
-          </PrimaryButton>
-        </FormGrid>
-      </SectionCard>
-      <TwoColumnGrid>
-        <SectionCard>
-          <SectionTitle>구매 요청 목록</SectionTitle>
-          <ControlRow>
-            <Select
-              value={purchaseStatus}
-              onChange={(event) =>
-                setPurchaseStatus(event.target.value as PurchaseRequestStatus | "")
-              }
-            >
-              <option value="">전체</option>
-              <option value="PENDING">PENDING</option>
-              <option value="APPROVED">APPROVED</option>
-              <option value="PURCHASED">PURCHASED</option>
-              <option value="CONFIRMED">CONFIRMED</option>
-              <option value="REJECTED">REJECTED</option>
-            </Select>
-          </ControlRow>
+      <PurchaseListSection $isPanelOpen={isDetailOpen} onClick={handlePurchaseListSectionClick}>
+        <SectionHeaderRow>
+          <SectionTitle>결제 요청 목록</SectionTitle>
+          <HeaderButtonGroup>
+            <SmallButton type="button" onClick={() => setIsVendorBalanceModalOpen(true)}>
+              거래처별 잔액 확인
+            </SmallButton>
+            <SmallButton type="button" onClick={openCreateModal}>
+              요청서 작성
+            </SmallButton>
+          </HeaderButtonGroup>
+        </SectionHeaderRow>
+
+        <ControlRow>
+          <FilterSelect
+            value={purchaseStatus}
+            onChange={(event) =>
+              setPurchaseStatus(event.target.value as PurchaseRequestStatus | "")
+            }
+            aria-label="결제 요청 상태 필터"
+          >
+            <option value="">전체 상태</option>
+            <option value="PENDING">대기</option>
+            <option value="APPROVED">승인</option>
+            <option value="PURCHASED">구매 완료</option>
+            <option value="CONFIRMED">결제 확인</option>
+            <option value="REJECTED">반려</option>
+          </FilterSelect>
+          <TextInput
+            value={purchaseSearch}
+            onChange={(event) => setPurchaseSearch(event.target.value)}
+            placeholder="제목, 소속, 요청자, ID 검색"
+          />
+        </ControlRow>
+
+        <PurchaseListFrame>
           <DataState
             isLoading={purchasesQuery.isLoading}
             isError={purchasesQuery.isError}
             isEmpty={purchases.length === 0}
-            loadingLabel="구매 요청 목록 불러오는 중"
-            errorLabel="구매 요청 목록을 불러오지 못했습니다."
-            emptyLabel="구매 요청이 없습니다."
+            loadingLabel="결제 요청 목록 불러오는 중"
+            errorLabel="결제 요청 목록을 불러오지 못했습니다."
+            emptyLabel="결제 요청이 없습니다."
           >
             <Table>
               <thead>
                 <tr>
+                  <th>ID</th>
                   <th>제목</th>
-                  <th>분반</th>
+                  <th>소속</th>
                   <th>요청자</th>
                   <th>상태</th>
-                  <th>금액</th>
+                  <th>결제 금액</th>
                 </tr>
               </thead>
               <tbody>
-                {purchases.map((item) => (
-                  <tr key={item.id} onClick={() => item.id && setSelectedPurchaseId(item.id)}>
-                    <td>{item.title}</td>
-                    <td>{item.classroomName}</td>
-                    <td>{item.requestedByName}</td>
-                    <td>{item.status}</td>
-                    <td>
-                      {item.status === "PENDING" ||
-                      item.status === "REJECTED" ||
-                      item.status === "APPROVED"
-                        ? "-"
-                        : (item.totalPrice ?? 0)}
-                    </td>
+                {pagedPurchases.map((item) => (
+                  <tr key={item.id} onClick={() => selectPurchase(item)}>
+                    <td>{item.id ?? "-"}</td>
+                    <td>{item.title ?? "-"}</td>
+                    <td>{item.classroomName ?? "-"}</td>
+                    <td>{item.requestedByName ?? "-"}</td>
+                    <td>{formatPurchaseStatus(item.status)}</td>
+                    <td>{formatPurchaseListAmount(item)}</td>
                   </tr>
                 ))}
               </tbody>
             </Table>
           </DataState>
-        </SectionCard>
-        <SectionCard>
-          <SectionTitle>구매 요청 상세</SectionTitle>
-          <DataState
-            isLoading={purchaseDetailQuery.isLoading}
-            isError={purchaseDetailQuery.isError}
-            isEmpty={!selectedPurchaseId}
-            loadingLabel="구매 요청 상세 불러오는 중"
-            errorLabel="구매 요청 상세를 불러오지 못했습니다."
-            emptyLabel="구매 요청을 선택하세요."
+        </PurchaseListFrame>
+
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({
+                page: Math.max(1, safeCurrentPage - 1),
+                search: paginationKey,
+              })
+            }
           >
-            <MetaGrid>
-              <MetaItem>제목: {purchaseDetailQuery.data?.title}</MetaItem>
-              <MetaItem>상태: {purchaseDetailQuery.data?.status}</MetaItem>
-              <MetaItem>요청자: {purchaseDetailQuery.data?.requestedByName}</MetaItem>
-              <MetaItem>분반: {purchaseDetailQuery.data?.classroomName}</MetaItem>
-            </MetaGrid>
-            <List>
-              {purchaseDetailQuery.data?.items?.map((item) => (
-                <ListItem key={item.id}>
-                  <span>{item.name}</span>
-                  <span>
-                    {item.quantity ?? 0}개 /{" "}
-                    {item.paymentType === "PREPAID" ? "선금 결제" : "실 결제"}
-                  </span>
-                </ListItem>
-              ))}
-              {canShowReceiptRows && receiptRows.length
-                ? receiptRows.map((receipt) => (
-                    <ListItem key={`receipt-${receipt.id}`}>
-                      <span>영수증</span>
-                      <span>
-                        {receipt.url ? (
-                          <ReceiptLink href={receipt.url} target="_blank" rel="noreferrer">
-                            영수증 보기
-                          </ReceiptLink>
-                        ) : (
-                          "-"
-                        )}
-                      </span>
-                    </ListItem>
-                  ))
-                : null}
-              {canShowReceiptRows && receiptRows.length === 0 ? (
-                <ListItem>
-                  <span>영수증</span>
-                  <span>-</span>
-                </ListItem>
-              ) : null}
-            </List>
-            {purchaseDetailQuery.data?.status === "REJECTED" ? (
-              <SectionDescription>
-                반려 사유: {purchaseDetailQuery.data.note?.trim() || "-"}
-              </SectionDescription>
-            ) : null}
-            <FormGrid onSubmit={(event) => event.preventDefault()}>
-              {isRejecting ? (
-                <>
-                  <Label>
-                    반려 사유
-                    <TextInput
-                      value={reviewNote}
-                      onChange={(event) => setReviewNote(event.target.value)}
-                      autoFocus
-                    />
-                  </Label>
-                  <ButtonRow>
-                    <DangerButton
-                      type="button"
-                      disabled={!canSubmitRejection}
-                      onClick={submitRejection}
-                    >
-                      확인
-                    </DangerButton>
-                    <SmallButton
-                      type="button"
-                      disabled={rejectPurchaseMutation.isPending}
-                      onClick={cancelRejecting}
-                    >
-                      취소
-                    </SmallButton>
-                  </ButtonRow>
-                </>
-              ) : (
-                <ButtonRow>
-                  <ApproveButton
-                    type="button"
-                    disabled={!canReviewPurchase || approvePurchaseMutation.isPending}
-                    onClick={approvePurchase}
-                  >
-                    승인
-                  </ApproveButton>
-                  <DangerButton
-                    type="button"
-                    disabled={!canReviewPurchase || rejectPurchaseMutation.isPending}
-                    onClick={startRejecting}
-                  >
-                    반려
-                  </DangerButton>
-                  <SmallButton
-                    type="button"
-                    disabled={!canConfirmPurchase || confirmPurchaseMutation.isPending}
-                    onClick={() => confirmPurchaseMutation.mutate()}
-                  >
-                    결재 확인
-                  </SmallButton>
-                  <DangerButton
-                    type="button"
-                    disabled={!canDeletePurchase || deletePurchaseMutation.isPending}
-                    onClick={() => deletePurchaseMutation.mutate()}
-                  >
-                    삭제
-                  </DangerButton>
-                </ButtonRow>
-              )}
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: paginationKey })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: paginationKey,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
+        {isDetailOpen ? (
+          <>
+            <PanelBackdrop aria-hidden="true" />
+            <SlidePanel aria-label="결제 요청 상세" onClick={(event) => event.stopPropagation()}>
+              <PanelHeader>
+                <ClosePanelButton
+                  type="button"
+                  aria-label="결제 요청 상세 닫기"
+                  onClick={closePurchaseDetail}
+                >
+                  <CloseIcon aria-hidden="true" />
+                </ClosePanelButton>
+                <SectionTitle>결제 요청 상세</SectionTitle>
+              </PanelHeader>
+
+              <DataState
+                isLoading={purchaseDetailQuery.isLoading}
+                isError={purchaseDetailQuery.isError}
+                isEmpty={!selectedPurchaseId}
+                loadingLabel="결제 요청 상세 불러오는 중"
+                errorLabel="결제 요청 상세를 불러오지 못했습니다."
+                emptyLabel="결제 요청을 선택하세요."
+              >
+                <PanelContent>
+                  <DetailBlock>
+                    <DetailBlockTitle>요청 정보</DetailBlockTitle>
+                    <List>
+                      <ListItem>
+                        <span>제목</span>
+                        <span>{purchaseDetailQuery.data?.title ?? "-"}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>상태</span>
+                        <span>{formatPurchaseStatus(purchaseDetailQuery.data?.status)}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>요청자</span>
+                        <span>{purchaseDetailQuery.data?.requestedByName ?? "-"}</span>
+                      </ListItem>
+                      <ListItem>
+                        <span>소속</span>
+                        <span>{purchaseDetailQuery.data?.classroomName ?? "-"}</span>
+                      </ListItem>
+                    </List>
+                  </DetailBlock>
+
+                  <DetailBlock>
+                    <DetailBlockTitle>품목</DetailBlockTitle>
+                    <ItemDetailList>
+                      {purchaseDetailQuery.data?.items?.length ? (
+                        purchaseDetailQuery.data.items.map((item, index) => {
+                          const receipts = getReceiptsForItem(
+                            item,
+                            purchaseDetailQuery.data?.transactions,
+                          );
+
+                          return (
+                            <ItemDetailCard key={item.id ?? `item-${index}`}>
+                              <ItemDetailHeader>
+                                <strong>{item.name ?? `품목 ${index + 1}`}</strong>
+                                <span>
+                                  {item.quantity ?? 0}개 / {formatPaymentType(item.paymentType)}
+                                </span>
+                              </ItemDetailHeader>
+                              <ItemDetailRow>
+                                <span>결제 사유</span>
+                                <span>{item.reason?.trim() || "-"}</span>
+                              </ItemDetailRow>
+                              <ItemDetailRow>
+                                <span>구매처</span>
+                                <span>
+                                  {receipts.length
+                                    ? receipts
+                                        .map((receipt) => receipt.vendorName)
+                                        .filter(Boolean)
+                                        .join(", ") || "-"
+                                    : "-"}
+                                </span>
+                              </ItemDetailRow>
+                              <ItemDetailRow>
+                                <span>영수증</span>
+                                <span>
+                                  {receipts.length
+                                    ? receipts.map((receipt, receiptIndex) =>
+                                        receipt.receiptFileUrl ? (
+                                          <ReceiptLink
+                                            key={receipt.id ?? `receipt-${receiptIndex}`}
+                                            href={receipt.receiptFileUrl}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                          >
+                                            영수증 보기
+                                          </ReceiptLink>
+                                        ) : (
+                                          <span key={receipt.id ?? `receipt-${receiptIndex}`}>
+                                            -
+                                          </span>
+                                        ),
+                                      )
+                                    : "-"}
+                                </span>
+                              </ItemDetailRow>
+                            </ItemDetailCard>
+                          );
+                        })
+                      ) : (
+                        <ItemDetailCard>
+                          <ItemDetailHeader>
+                            <strong>품목</strong>
+                            <span>-</span>
+                          </ItemDetailHeader>
+                        </ItemDetailCard>
+                      )}
+                    </ItemDetailList>
+                  </DetailBlock>
+
+                  {purchaseDetailQuery.data?.status === "REJECTED" ? (
+                    <SectionDescription>
+                      반려 사유: {purchaseDetailQuery.data.note?.trim() || "-"}
+                    </SectionDescription>
+                  ) : null}
+
+                  <FormGrid onSubmit={(event) => event.preventDefault()}>
+                    {isRejecting ? (
+                      <>
+                        <Label>
+                          반려 사유
+                          <TextInput
+                            value={reviewNote}
+                            onChange={(event) => setReviewNote(event.target.value)}
+                            autoFocus
+                          />
+                        </Label>
+                        <ButtonRow>
+                          <DangerButton
+                            type="button"
+                            disabled={!canSubmitRejection}
+                            onClick={submitRejection}
+                          >
+                            확인
+                          </DangerButton>
+                          <SmallButton
+                            type="button"
+                            disabled={rejectPurchaseMutation.isPending}
+                            onClick={cancelRejecting}
+                          >
+                            취소
+                          </SmallButton>
+                        </ButtonRow>
+                      </>
+                    ) : (
+                      <ButtonRow>
+                        <PurchaseActionButton
+                          type="button"
+                          disabled={!canReviewPurchase || approvePurchaseMutation.isPending}
+                          onClick={approvePurchase}
+                        >
+                          승인
+                        </PurchaseActionButton>
+                        <DangerButton
+                          type="button"
+                          disabled={!canReviewPurchase || rejectPurchaseMutation.isPending}
+                          onClick={startRejecting}
+                        >
+                          반려
+                        </DangerButton>
+                        <SmallButton
+                          type="button"
+                          disabled={!canConfirmPurchase || confirmPurchaseMutation.isPending}
+                          onClick={() => setConfirmAction("confirm")}
+                        >
+                          결제 확인
+                        </SmallButton>
+                        <DangerButton
+                          type="button"
+                          disabled={!canDeletePurchase || deletePurchaseMutation.isPending}
+                          onClick={() => setConfirmAction("delete")}
+                        >
+                          삭제
+                        </DangerButton>
+                      </ButtonRow>
+                    )}
+                  </FormGrid>
+                </PanelContent>
+              </DataState>
+            </SlidePanel>
+          </>
+        ) : null}
+      </PurchaseListSection>
+
+      {isPurchaseCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="purchase-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="purchase-create-modal-title">요청서 작성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createPurchaseMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createPurchaseMutation.mutate();
+              }}
+            >
+              <Label>
+                제목
+                <TextInput
+                  value={purchaseCreate.title}
+                  onChange={(event) =>
+                    setPurchaseCreate((current) => ({ ...current, title: event.target.value }))
+                  }
+                  required
+                />
+              </Label>
+              <Label>
+                소속
+                <PurchaseSelect
+                  value={purchaseCreate.classroomId}
+                  onChange={(event) =>
+                    setPurchaseCreate((current) => ({
+                      ...current,
+                      classroomId: event.target.value,
+                    }))
+                  }
+                  required
+                >
+                  <option value="">소속 선택</option>
+                  {classrooms.map((classroom) => (
+                    <option key={classroom.id} value={classroom.id}>
+                      {classroom.name}
+                    </option>
+                  ))}
+                </PurchaseSelect>
+              </Label>
+              <CreateItemsStack>
+                {purchaseCreate.items.map((item, index) => (
+                  <CreateItemGroup key={item.id}>
+                    <CreateItemTitle>품목 {index + 1}</CreateItemTitle>
+                    <Label>
+                      품목명
+                      <TextInput
+                        value={item.itemName}
+                        onChange={(event) =>
+                          updatePurchaseItem(item.id, "itemName", event.target.value)
+                        }
+                        required
+                      />
+                    </Label>
+                    <Label>
+                      수량
+                      <TextInput
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={item.itemQuantity}
+                        onChange={(event) =>
+                          updatePurchaseItem(item.id, "itemQuantity", event.target.value)
+                        }
+                        required
+                      />
+                    </Label>
+                    <Label>
+                      구매 사유
+                      <TextInput
+                        value={item.itemReason}
+                        onChange={(event) =>
+                          updatePurchaseItem(item.id, "itemReason", event.target.value)
+                        }
+                      />
+                    </Label>
+                    <Label>
+                      결제 유형
+                      <PurchaseSelect
+                        value={item.itemPaymentType}
+                        onChange={(event) =>
+                          updatePurchaseItem(item.id, "itemPaymentType", event.target.value)
+                        }
+                      >
+                        <option value="ACTUAL">실 결제</option>
+                        <option value="PREPAID">선금 결제</option>
+                      </PurchaseSelect>
+                    </Label>
+                    {purchaseCreate.items.length > 1 ? (
+                      <ItemDeleteRow>
+                        <DangerButton type="button" onClick={() => removePurchaseItem(item.id)}>
+                          삭제
+                        </DangerButton>
+                      </ItemDeleteRow>
+                    ) : null}
+                  </CreateItemGroup>
+                ))}
+              </CreateItemsStack>
+              <ButtonRow>
+                <PurchaseActionButton
+                  type="submit"
+                  disabled={createPurchaseMutation.isPending || !canSubmitPurchase}
+                >
+                  작성
+                </PurchaseActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createPurchaseMutation.isPending}
+                  onClick={addPurchaseItem}
+                >
+                  품목 추가
+                </SmallButton>
+                <SmallButton
+                  type="button"
+                  disabled={createPurchaseMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
             </FormGrid>
-          </DataState>
-        </SectionCard>
-      </TwoColumnGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {confirmAction ? (
+        <ModalBackdrop onMouseDown={() => setConfirmAction(null)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="purchase-action-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="purchase-action-confirm-title">결제 요청 처리</ConfirmTitle>
+            <ConfirmMessage>{confirmMessage[confirmAction]}</ConfirmMessage>
+            <ButtonRow>
+              <PurchaseActionButton
+                type="button"
+                disabled={
+                  approvePurchaseMutation.isPending ||
+                  rejectPurchaseMutation.isPending ||
+                  confirmPurchaseMutation.isPending ||
+                  deletePurchaseMutation.isPending
+                }
+                onClick={runConfirmedAction}
+              >
+                확인
+              </PurchaseActionButton>
+              <SmallButton
+                type="button"
+                disabled={
+                  approvePurchaseMutation.isPending ||
+                  rejectPurchaseMutation.isPending ||
+                  confirmPurchaseMutation.isPending ||
+                  deletePurchaseMutation.isPending
+                }
+                onClick={() => setConfirmAction(null)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isVendorBalanceModalOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsVendorBalanceModalOpen(false)}>
+          <VendorBalanceDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="vendor-balance-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="vendor-balance-modal-title">현재 거래처별 잔액</SectionTitle>
+              <SmallButton type="button" onClick={() => setIsVendorBalanceModalOpen(false)}>
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <DataState
+              isLoading={vendorsQuery.isLoading}
+              isError={vendorsQuery.isError}
+              isEmpty={!vendorsQuery.data?.length}
+              loadingLabel="거래처 잔액 불러오는 중"
+              errorLabel="거래처 잔액을 불러오지 못했습니다."
+              emptyLabel="거래처 정보가 없습니다."
+              compact
+            >
+              <VendorBalanceTable>
+                <tbody>
+                  {vendorsQuery.data?.map((vendor) => (
+                    <tr key={vendor.id ?? vendor.name}>
+                      <th scope="row">{vendor.name ?? "-"}</th>
+                      <td>{formatCurrency(vendor.balance)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </VendorBalanceTable>
+            </DataState>
+          </VendorBalanceDialog>
+        </ModalBackdrop>
+      ) : null}
     </>
   );
 }
 
-const ApproveButton = styled.button`
+const PurchaseListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const HeaderButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space8};
+`;
+
+const PurchaseListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadePurchasePanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadePurchasePanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slidePurchasePanelIn 0.22s ease-out both;
+
+  @keyframes slidePurchasePanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ItemDetailList = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const ItemDetailCard = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+  padding: ${spacing.space8};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+`;
+
+const ItemDetailHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+
+  strong {
+    font-weight: 800;
+  }
+
+  span {
+    color: #64706c;
+    font-weight: 700;
+  }
+`;
+
+const ItemDetailRow = styled.div`
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: ${spacing.space8};
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+
+  > span:first-child {
+    color: #64706c;
+    font-weight: 800;
+  }
+
+  > span:last-child {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: ${spacing.space8};
+    text-align: right;
+    word-break: keep-all;
+  }
+`;
+
+const CreateItemsStack = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const CreateItemGroup = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+  padding: ${spacing.space12};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  background-color: #fbfcfb;
+`;
+
+const CreateItemTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ItemDeleteRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const selectBase = `
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const FilterSelect = styled.select`
+  ${selectBase}
+  flex: 0 0 10rem;
+`;
+
+const PurchaseSelect = styled.select`
+  ${selectBase}
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 32rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(ModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const VendorBalanceDialog = styled(ModalDialog)`
+  width: min(100%, 48rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const VendorBalanceTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #cfd6d2;
+  table-layout: fixed;
+
+  th,
+  td {
+    width: 50%;
+    padding: ${spacing.space12};
+    border: 1px solid #cfd6d2;
+    color: #000000;
+    font-size: ${typography.fontSize14};
+    line-height: ${typography.lineHeight130};
+  }
+
+  th {
+    background-color: #fbfcfb;
+    font-weight: 700;
+    text-align: left;
+  }
+
+  td {
+    font-weight: 700;
+    text-align: right;
+  }
+`;
+
+const PurchaseActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 2.375rem;
   border: 1px solid ${colors.point};
   border-radius: 0.375rem;
@@ -415,12 +1265,13 @@ const ApproveButton = styled.button`
   padding: 0 ${spacing.space16};
   color: ${colors.point};
   font-family: inherit;
+  font-size: ${typography.fontSize14};
   font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
   cursor: pointer;
   transition:
     background-color 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease,
     opacity 0.15s ease;
 
   &:not(:disabled):hover {
@@ -428,8 +1279,14 @@ const ApproveButton = styled.button`
   }
 
   &:disabled {
+    opacity: 0.5;
     cursor: not-allowed;
-    opacity: 0.55;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.375rem;
+    padding: 0 ${spacing.space16};
+    font-size: ${typography.fontSize14};
   }
 `;
 

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+import styled from "styled-components";
+import type { DepartmentListItemDto } from "@/api/department/department.dto";
 import type {
   PermissionDefinitionDto,
   PermissionResponseDto,
@@ -15,20 +18,60 @@ import {
   DataState,
   Divider,
   FormGrid,
-  InlineStatus,
   Label,
   List,
   ListItem,
-  PrimaryButton,
   SectionCard,
   SectionHeaderRow,
   SectionTitle,
-  Select,
   SmallButton,
   Table,
   TextInput,
-  TwoColumnGrid,
 } from "@/components/admin/AdminDashboardSectionParts";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatPhoneNumber } from "@/utils/phoneNumber";
+
+const USERS_PER_PAGE = 11;
+
+function getDepartmentLabel(item: UserListItemDto, departments: DepartmentListItemDto[]) {
+  if (item.department?.name) {
+    return item.department.name;
+  }
+
+  if (typeof item.departmentId === "number") {
+    return (
+      departments.find((department) => department.id === item.departmentId)?.name ??
+      `부서 ${item.departmentId}`
+    );
+  }
+
+  return "-";
+}
+
+function getPermissionActions(permissionOptions: PermissionDefinitionDto[], resourceType: string) {
+  return permissionOptions
+    .filter((option) => option.resourceCode === resourceType)
+    .map((option) => option.actionCode)
+    .filter(
+      (value, index, array): value is string => Boolean(value) && array.indexOf(value) === index,
+    );
+}
+
+function getPermissionDefinition(
+  permissionOptions: PermissionDefinitionDto[],
+  resourceType: string,
+  actionType: string,
+) {
+  return permissionOptions.find(
+    (option) => option.resourceCode === resourceType && option.actionCode === actionType,
+  );
+}
+
+function getDefaultPermissionScope(definition?: PermissionDefinitionDto) {
+  const canUseGlobal = definition?.globalAllowed ?? definition?.scope !== "TARGET_ONLY";
+
+  return canUseGlobal ? "GLOBAL" : "TARGET";
+}
 
 type QueryState<TData> = {
   data?: TData;
@@ -48,7 +91,11 @@ type ValueMutationAction<TVariables> = {
 
 type AdminUsersSectionProps = {
   filteredUsers: UserListItemDto[];
+  departments: DepartmentListItemDto[];
   selectedUserId: number | null;
+  isUserEditing: boolean;
+  isUserCreateModalOpen: boolean;
+  isUserDeleteConfirmOpen: boolean;
   userSearch: string;
   userForm: UserFormState;
   permissionForm: PermissionFormState;
@@ -56,7 +103,6 @@ type AdminUsersSectionProps = {
   availableActions: string[];
   canUseGlobalPermission: boolean;
   canUseTargetPermission: boolean;
-  generatedPermissionCode: string;
   usersQuery: QueryState<unknown>;
   userDetailQuery: QueryState<UserResponseDto>;
   userPermissionsQuery: QueryState<PermissionResponseDto[]>;
@@ -66,6 +112,9 @@ type AdminUsersSectionProps = {
   addPermissionMutation: VoidMutationAction;
   removePermissionMutation: ValueMutationAction<string>;
   setSelectedUserId: Dispatch<SetStateAction<number | null>>;
+  setIsUserEditing: Dispatch<SetStateAction<boolean>>;
+  setIsUserCreateModalOpen: Dispatch<SetStateAction<boolean>>;
+  setIsUserDeleteConfirmOpen: Dispatch<SetStateAction<boolean>>;
   setUserSearch: Dispatch<SetStateAction<string>>;
   setUserForm: Dispatch<SetStateAction<UserFormState>>;
   setPermissionForm: Dispatch<SetStateAction<PermissionFormState>>;
@@ -75,7 +124,11 @@ type AdminUsersSectionProps = {
 
 export function AdminUsersSection({
   filteredUsers,
+  departments,
   selectedUserId,
+  isUserEditing,
+  isUserCreateModalOpen,
+  isUserDeleteConfirmOpen,
   userSearch,
   userForm,
   permissionForm,
@@ -83,7 +136,6 @@ export function AdminUsersSection({
   availableActions,
   canUseGlobalPermission,
   canUseTargetPermission,
-  generatedPermissionCode,
   usersQuery,
   userDetailQuery,
   userPermissionsQuery,
@@ -93,27 +145,94 @@ export function AdminUsersSection({
   addPermissionMutation,
   removePermissionMutation,
   setSelectedUserId,
+  setIsUserEditing,
+  setIsUserCreateModalOpen,
+  setIsUserDeleteConfirmOpen,
   setUserSearch,
   setUserForm,
   setPermissionForm,
   selectUser,
   emptyUserForm,
 }: AdminUsersSectionProps) {
+  const isDetailOpen = selectedUserId !== null;
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const totalPages = Math.max(1, Math.ceil(filteredUsers.length / USERS_PER_PAGE));
+  const requestedPage = pagination.search === userSearch ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedUsers = filteredUsers.slice(
+    (safeCurrentPage - 1) * USERS_PER_PAGE,
+    safeCurrentPage * USERS_PER_PAGE,
+  );
+  const permissionResources = Array.from(
+    new Set(permissionOptions.map((option) => option.resourceCode).filter(Boolean)),
+  );
+
+  function closeUserDetail() {
+    setSelectedUserId(null);
+    setIsUserEditing(false);
+    setIsUserDeleteConfirmOpen(false);
+  }
+
+  function openCreateModal() {
+    setSelectedUserId(null);
+    setIsUserEditing(false);
+    setUserForm(emptyUserForm);
+    setIsUserCreateModalOpen(true);
+  }
+
+  function closeCreateModal() {
+    if (createUserMutation.isPending) {
+      return;
+    }
+
+    setIsUserCreateModalOpen(false);
+    setUserForm(emptyUserForm);
+  }
+
+  function cancelEditing() {
+    const detail = userDetailQuery.data;
+
+    setUserForm({
+      email: detail?.email ?? userForm.email,
+      nickname: detail?.nickname ?? userForm.nickname,
+      password: "",
+      name: detail?.name ?? userForm.name,
+      phoneNumber: detail?.phoneNumber ?? userForm.phoneNumber,
+      role: detail?.role ?? userForm.role,
+      departmentId:
+        detail?.departmentId !== null && detail?.departmentId !== undefined
+          ? String(detail.departmentId)
+          : typeof detail?.department?.id === "number"
+            ? String(detail.department.id)
+            : userForm.departmentId,
+    });
+    setIsUserEditing(false);
+  }
+
+  function handleUserListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedUserRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedUserRow) {
+      closeUserDetail();
+    }
+  }
+
   return (
-    <TwoColumnGrid>
-      <SectionCard>
+    <>
+      <UserListSection $isPanelOpen={isDetailOpen} onClick={handleUserListSectionClick}>
         <SectionHeaderRow>
           <SectionTitle>사용자 목록</SectionTitle>
-          <SmallButton
-            type="button"
-            onClick={() => {
-              setSelectedUserId(null);
-              setUserForm(emptyUserForm);
-            }}
-          >
+          <SmallButton type="button" onClick={openCreateModal}>
             신규 생성
           </SmallButton>
         </SectionHeaderRow>
+
         <ControlRow>
           <TextInput
             value={userSearch}
@@ -121,252 +240,775 @@ export function AdminUsersSection({
             placeholder="이름, 이메일, 역할 검색"
           />
         </ControlRow>
-        <DataState
-          isLoading={usersQuery.isLoading}
-          isError={usersQuery.isError}
-          isEmpty={filteredUsers.length === 0}
-          loadingLabel="사용자 목록 불러오는 중"
-          errorLabel="사용자 목록을 불러오지 못했습니다."
-          emptyLabel="사용자가 없습니다."
-        >
-          <Table>
-            <thead>
-              <tr>
-                <th>이름</th>
-                <th>이메일</th>
-                <th>역할</th>
-                <th>부서</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredUsers.map((item) => (
-                <tr key={item.id} onClick={() => selectUser(item)}>
-                  <td>{item.name ?? item.nickname ?? "-"}</td>
-                  <td>{item.email ?? "-"}</td>
-                  <td>{item.role ?? "-"}</td>
-                  <td>{item.departmentId ?? "-"}</td>
+
+        <UserListFrame>
+          <DataState
+            isLoading={usersQuery.isLoading}
+            isError={usersQuery.isError}
+            isEmpty={filteredUsers.length === 0}
+            loadingLabel="사용자 목록 불러오는 중"
+            errorLabel="사용자 목록을 불러오지 못했습니다."
+            emptyLabel="사용자가 없습니다."
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <th>이름</th>
+                  <th>이메일</th>
+                  <th>역할</th>
+                  <th>부서</th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-        </DataState>
-      </SectionCard>
-      <SectionCard>
-        <SectionTitle>{selectedUserId ? "사용자 상세" : "사용자 생성"}</SectionTitle>
-        {userDetailQuery.isLoading ? (
-          <InlineStatus>사용자 상세를 불러오는 중입니다.</InlineStatus>
-        ) : null}
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (selectedUserId) {
-              updateUserMutation.mutate();
-            } else {
-              createUserMutation.mutate();
+              </thead>
+              <tbody>
+                {pagedUsers.map((item) => (
+                  <tr key={item.id} onClick={() => selectUser(item)}>
+                    <td>{item.name ?? item.nickname ?? "-"}</td>
+                    <td>{item.email ?? "-"}</td>
+                    <td>{item.role ?? "-"}</td>
+                    <td>{getDepartmentLabel(item, departments)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </DataState>
+        </UserListFrame>
+        <Pagination aria-label="페이지 이동">
+          <PageArrowButton
+            type="button"
+            aria-label="이전 페이지"
+            disabled={safeCurrentPage === 1}
+            onClick={() =>
+              setPagination({ page: Math.max(1, safeCurrentPage - 1), search: userSearch })
             }
-          }}
-        >
-          <Label>
-            이메일
-            <TextInput
-              value={userForm.email}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, email: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            닉네임
-            <TextInput
-              value={userForm.nickname}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, nickname: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            비밀번호
-            <TextInput
-              type="password"
-              value={userForm.password}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, password: event.target.value }))
-              }
-              placeholder={selectedUserId ? "수정 시 변경하지 않음" : ""}
-              required={!selectedUserId}
-            />
-          </Label>
-          <Label>
-            이름
-            <TextInput
-              value={userForm.name}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, name: event.target.value }))
-              }
-              required
-            />
-          </Label>
-          <Label>
-            전화번호
-            <TextInput
-              value={userForm.phoneNumber}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, phoneNumber: event.target.value }))
-              }
-            />
-          </Label>
-          <Label>
-            역할
-            <Select
-              value={userForm.role}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, role: event.target.value }))
-              }
+          >
+            ◀
+          </PageArrowButton>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+
+            return (
+              <PageNumberButton
+                key={pageNumber}
+                type="button"
+                $isActive={pageNumber === safeCurrentPage}
+                aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+                onClick={() => setPagination({ page: pageNumber, search: userSearch })}
+              >
+                {pageNumber}
+              </PageNumberButton>
+            );
+          })}
+          <PageArrowButton
+            type="button"
+            aria-label="다음 페이지"
+            disabled={safeCurrentPage === totalPages}
+            onClick={() =>
+              setPagination({
+                page: Math.min(totalPages, safeCurrentPage + 1),
+                search: userSearch,
+              })
+            }
+          >
+            ▶
+          </PageArrowButton>
+        </Pagination>
+
+        {isDetailOpen ? (
+          <>
+            <PanelBackdrop aria-hidden="true" />
+            <SlidePanel aria-label="사용자 상세/수정" onClick={(event) => event.stopPropagation()}>
+              <PanelHeader>
+                <ClosePanelButton
+                  type="button"
+                  aria-label="사용자 상세 닫기"
+                  onClick={closeUserDetail}
+                >
+                  <CloseIcon aria-hidden="true" />
+                </ClosePanelButton>
+                <SectionTitle>{isUserEditing ? "사용자 수정" : "사용자 상세"}</SectionTitle>
+              </PanelHeader>
+
+              <DataState
+                isLoading={userDetailQuery.isLoading}
+                isError={userDetailQuery.isError}
+                isEmpty={!selectedUserId}
+                loadingLabel="사용자 상세 불러오는 중"
+                errorLabel="사용자 상세를 불러오지 못했습니다."
+                emptyLabel="사용자를 선택하세요."
+              >
+                {isUserEditing ? (
+                  <FormGrid
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      updateUserMutation.mutate();
+                    }}
+                  >
+                    <UserFields
+                      form={userForm}
+                      departments={departments}
+                      disabled={updateUserMutation.isPending}
+                      setUserForm={setUserForm}
+                    />
+
+                    <ButtonRow>
+                      <UserActionButton
+                        disabled={
+                          updateUserMutation.isPending ||
+                          !userForm.name.trim() ||
+                          !userForm.email.trim()
+                        }
+                      >
+                        저장
+                      </UserActionButton>
+                      <SmallButton
+                        type="button"
+                        disabled={updateUserMutation.isPending}
+                        onClick={cancelEditing}
+                      >
+                        취소
+                      </SmallButton>
+                    </ButtonRow>
+                  </FormGrid>
+                ) : (
+                  <DetailFormView>
+                    <UserFields
+                      form={userForm}
+                      departments={departments}
+                      disabled
+                      setUserForm={setUserForm}
+                    />
+
+                    <ButtonRow>
+                      <UserActionButton
+                        type="button"
+                        disabled={!selectedUserId}
+                        onClick={() => setIsUserEditing(true)}
+                      >
+                        수정
+                      </UserActionButton>
+                      <DangerButton
+                        type="button"
+                        disabled={deleteUserMutation.isPending}
+                        onClick={() => setIsUserDeleteConfirmOpen(true)}
+                      >
+                        삭제
+                      </DangerButton>
+                    </ButtonRow>
+                  </DetailFormView>
+                )}
+
+                <Divider />
+                <SectionTitle>직접 권한</SectionTitle>
+                <DataState
+                  isLoading={userPermissionsQuery.isLoading}
+                  isError={userPermissionsQuery.isError}
+                  isEmpty={!selectedUserId || (userPermissionsQuery.data?.length ?? 0) === 0}
+                  loadingLabel="권한 목록 불러오는 중"
+                  errorLabel="권한 목록을 불러오지 못했습니다."
+                  emptyLabel={
+                    selectedUserId ? "직접 부여된 권한이 없습니다." : "사용자를 선택하세요."
+                  }
+                >
+                  <List>
+                    {userPermissionsQuery.data?.map((permission) => {
+                      const code = permission.permissionCode ?? permission.code ?? "";
+                      return (
+                        <ListItem key={code || permission.id}>
+                          <span>{code || permission.label || "-"}</span>
+                          {code ? (
+                            <SmallButton
+                              type="button"
+                              disabled={removePermissionMutation.isPending}
+                              onClick={() => removePermissionMutation.mutate(code)}
+                            >
+                              제거
+                            </SmallButton>
+                          ) : null}
+                        </ListItem>
+                      );
+                    })}
+                  </List>
+                </DataState>
+
+                <FormGrid
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    addPermissionMutation.mutate();
+                  }}
+                >
+                  <Label>
+                    리소스
+                    <UserSelect
+                      value={permissionForm.resourceType}
+                      onChange={(event) => {
+                        const resourceType = event.target.value;
+                        const actions = getPermissionActions(permissionOptions, resourceType);
+                        const actionType = actions[0] ?? "";
+                        const definition = getPermissionDefinition(
+                          permissionOptions,
+                          resourceType,
+                          actionType,
+                        );
+                        const scope = getDefaultPermissionScope(definition);
+
+                        setPermissionForm((current) => ({
+                          ...current,
+                          resourceType,
+                          actionType,
+                          scope,
+                          target: scope === "GLOBAL" ? "" : current.target,
+                        }));
+                      }}
+                    >
+                      {permissionResources.map((resource) => (
+                        <option key={resource} value={resource}>
+                          {resource}
+                        </option>
+                      ))}
+                    </UserSelect>
+                  </Label>
+                  <Label>
+                    액션
+                    <UserSelect
+                      value={permissionForm.actionType}
+                      disabled={availableActions.length === 0}
+                      onChange={(event) => {
+                        const actionType = event.target.value;
+                        const definition = getPermissionDefinition(
+                          permissionOptions,
+                          permissionForm.resourceType,
+                          actionType,
+                        );
+                        const scope = getDefaultPermissionScope(definition);
+
+                        setPermissionForm((current) => ({
+                          ...current,
+                          actionType,
+                          scope,
+                          target: scope === "GLOBAL" ? "" : current.target,
+                        }));
+                      }}
+                    >
+                      {availableActions.map((action) => (
+                        <option key={action} value={action}>
+                          {action}
+                        </option>
+                      ))}
+                    </UserSelect>
+                  </Label>
+                  <Label>
+                    범위
+                    <UserSelect
+                      value={permissionForm.scope}
+                      onChange={(event) =>
+                        setPermissionForm((current) => ({
+                          ...current,
+                          scope: event.target.value as PermissionFormState["scope"],
+                          target: event.target.value === "GLOBAL" ? "" : current.target,
+                        }))
+                      }
+                    >
+                      <option value="GLOBAL" disabled={!canUseGlobalPermission}>
+                        전체 권한
+                      </option>
+                      <option value="TARGET" disabled={!canUseTargetPermission}>
+                        특정 대상 권한
+                      </option>
+                    </UserSelect>
+                  </Label>
+                  <Label>
+                    대상 ID
+                    <TextInput
+                      value={permissionForm.target}
+                      disabled={permissionForm.scope === "GLOBAL"}
+                      onChange={(event) =>
+                        setPermissionForm((current) => ({
+                          ...current,
+                          target: event.target.value,
+                        }))
+                      }
+                    />
+                  </Label>
+                  <UserActionButton
+                    disabled={
+                      !selectedUserId ||
+                      addPermissionMutation.isPending ||
+                      !permissionForm.resourceType ||
+                      !permissionForm.actionType ||
+                      (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
+                    }
+                  >
+                    권한 추가
+                  </UserActionButton>
+                </FormGrid>
+              </DataState>
+            </SlidePanel>
+          </>
+        ) : null}
+      </UserListSection>
+
+      {isUserCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="user-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <SectionTitle id="user-create-modal-title">사용자 생성</SectionTitle>
+              <SmallButton
+                type="button"
+                disabled={createUserMutation.isPending}
+                onClick={closeCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                createUserMutation.mutate();
+              }}
             >
-              <option value="ADMIN">ADMIN</option>
-              <option value="MANAGER">MANAGER</option>
-              <option value="VOLUNTEER">VOLUNTEER</option>
-              <option value="GUEST">GUEST</option>
-            </Select>
-          </Label>
-          <Label>
-            부서 ID
-            <TextInput
-              value={userForm.departmentId}
-              onChange={(event) =>
-                setUserForm((current) => ({ ...current, departmentId: event.target.value }))
-              }
-            />
-          </Label>
-          <ButtonRow>
-            <PrimaryButton disabled={createUserMutation.isPending || updateUserMutation.isPending}>
-              {selectedUserId ? "수정" : "생성"}
-            </PrimaryButton>
-            {selectedUserId ? (
+              <UserFields
+                form={userForm}
+                departments={departments}
+                disabled={createUserMutation.isPending}
+                setUserForm={setUserForm}
+                includePassword
+              />
+              <ButtonRow>
+                <UserActionButton
+                  disabled={
+                    createUserMutation.isPending ||
+                    !userForm.name.trim() ||
+                    !userForm.email.trim() ||
+                    !userForm.password
+                  }
+                >
+                  생성
+                </UserActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={createUserMutation.isPending}
+                  onClick={closeCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isUserDeleteConfirmOpen ? (
+        <ModalBackdrop onMouseDown={() => setIsUserDeleteConfirmOpen(false)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="user-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="user-delete-confirm-title">사용자 삭제</ConfirmTitle>
+            <ConfirmMessage>삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
               <DangerButton
                 type="button"
                 disabled={deleteUserMutation.isPending}
                 onClick={() => deleteUserMutation.mutate()}
               >
-                삭제
+                확인
               </DangerButton>
-            ) : null}
-          </ButtonRow>
-        </FormGrid>
-        <Divider />
-        <SectionTitle>직접 권한</SectionTitle>
-        <DataState
-          isLoading={userPermissionsQuery.isLoading}
-          isError={userPermissionsQuery.isError}
-          isEmpty={!selectedUserId || (userPermissionsQuery.data?.length ?? 0) === 0}
-          loadingLabel="권한 목록 불러오는 중"
-          errorLabel="권한 목록을 불러오지 못했습니다."
-          emptyLabel={selectedUserId ? "직접 부여된 권한이 없습니다." : "사용자를 선택하세요."}
-        >
-          <List>
-            {userPermissionsQuery.data?.map((permission) => {
-              const code = permission.permissionCode ?? permission.code ?? "";
-              return (
-                <ListItem key={code || permission.id}>
-                  <span>{code || permission.label || "-"}</span>
-                  {code ? (
-                    <SmallButton
-                      type="button"
-                      disabled={removePermissionMutation.isPending}
-                      onClick={() => removePermissionMutation.mutate(code)}
-                    >
-                      제거
-                    </SmallButton>
-                  ) : null}
-                </ListItem>
-              );
-            })}
-          </List>
-        </DataState>
-        <FormGrid
-          onSubmit={(event) => {
-            event.preventDefault();
-            addPermissionMutation.mutate();
-          }}
-        >
-          <Label>
-            리소스
-            <Select
-              value={permissionForm.resourceType}
-              onChange={(event) =>
-                setPermissionForm((current) => ({
-                  ...current,
-                  resourceType: event.target.value,
-                  actionType: "",
-                }))
-              }
-            >
-              {Array.from(
-                new Set(permissionOptions.map((option) => option.resourceCode).filter(Boolean)),
-              ).map((resource) => (
-                <option key={resource} value={resource}>
-                  {resource}
-                </option>
-              ))}
-            </Select>
-          </Label>
-          <Label>
-            액션
-            <Select
-              value={permissionForm.actionType}
-              onChange={(event) =>
-                setPermissionForm((current) => ({ ...current, actionType: event.target.value }))
-              }
-            >
-              {availableActions.map((action) => (
-                <option key={action} value={action}>
-                  {action}
-                </option>
-              ))}
-            </Select>
-          </Label>
-          <Label>
-            범위
-            <Select
-              value={permissionForm.scope}
-              onChange={(event) =>
-                setPermissionForm((current) => ({
-                  ...current,
-                  scope: event.target.value as PermissionFormState["scope"],
-                }))
-              }
-            >
-              <option value="GLOBAL" disabled={!canUseGlobalPermission}>
-                전체 권한
-              </option>
-              <option value="TARGET" disabled={!canUseTargetPermission}>
-                특정 대상 권한
-              </option>
-            </Select>
-          </Label>
-          <Label>
-            대상 ID
-            <TextInput
-              value={permissionForm.target}
-              disabled={permissionForm.scope === "GLOBAL"}
-              onChange={(event) =>
-                setPermissionForm((current) => ({ ...current, target: event.target.value }))
-              }
-            />
-          </Label>
-          <PrimaryButton
-            disabled={
-              !selectedUserId ||
-              addPermissionMutation.isPending ||
-              (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
-            }
-          >
-            권한 추가
-          </PrimaryButton>
-        </FormGrid>
-      </SectionCard>
-    </TwoColumnGrid>
+              <SmallButton
+                type="button"
+                disabled={deleteUserMutation.isPending}
+                onClick={() => setIsUserDeleteConfirmOpen(false)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </>
   );
 }
+
+type UserFieldsProps = {
+  form: UserFormState;
+  departments: DepartmentListItemDto[];
+  disabled: boolean;
+  includePassword?: boolean;
+  setUserForm: Dispatch<SetStateAction<UserFormState>>;
+};
+
+function UserFields({
+  form,
+  departments,
+  disabled,
+  includePassword = false,
+  setUserForm,
+}: UserFieldsProps) {
+  return (
+    <>
+      <Label>
+        이름
+        <TextInput
+          value={form.name}
+          disabled={disabled}
+          onChange={(event) => setUserForm((current) => ({ ...current, name: event.target.value }))}
+          required
+        />
+      </Label>
+      <Label>
+        이메일
+        <TextInput
+          type="email"
+          value={form.email}
+          disabled={disabled}
+          onChange={(event) =>
+            setUserForm((current) => ({ ...current, email: event.target.value }))
+          }
+          required
+        />
+      </Label>
+      {includePassword ? (
+        <Label>
+          비밀번호
+          <TextInput
+            type="password"
+            value={form.password}
+            disabled={disabled}
+            onChange={(event) =>
+              setUserForm((current) => ({ ...current, password: event.target.value }))
+            }
+            required
+          />
+        </Label>
+      ) : null}
+      <Label>
+        전화번호
+        <TextInput
+          value={form.phoneNumber}
+          disabled={disabled}
+          onChange={(event) =>
+            setUserForm((current) => ({
+              ...current,
+              phoneNumber: formatPhoneNumber(event.target.value),
+            }))
+          }
+        />
+      </Label>
+      <Label>
+        역할
+        <UserSelect
+          value={form.role}
+          disabled={disabled}
+          onChange={(event) => setUserForm((current) => ({ ...current, role: event.target.value }))}
+        >
+          <option value="ADMIN">ADMIN</option>
+          <option value="MANAGER">MANAGER</option>
+          <option value="VOLUNTEER">VOLUNTEER</option>
+          <option value="GUEST">GUEST</option>
+        </UserSelect>
+      </Label>
+      <Label>
+        부서
+        <UserSelect
+          value={form.departmentId}
+          disabled={disabled}
+          onChange={(event) =>
+            setUserForm((current) => ({ ...current, departmentId: event.target.value }))
+          }
+        >
+          <option value="">부서 없음</option>
+          {departments
+            .filter((department) => typeof department.id === "number")
+            .map((department) => (
+              <option key={department.id} value={String(department.id)}>
+                {department.name ?? `부서 ${department.id}`}
+              </option>
+            ))}
+        </UserSelect>
+      </Label>
+    </>
+  );
+}
+
+const UserListSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const UserListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+
+  @media (min-width: 120rem) {
+    min-height: 22.5rem;
+  }
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeUserPanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeUserPanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideUserPanelIn 0.22s ease-out both;
+
+  @keyframes slideUserPanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space4};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const DetailFormView = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const UserSelect = styled.select`
+  width: 100%;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+
+  &:disabled {
+    opacity: 1;
+    color: #64706c;
+    background-color: ${colors.white};
+  }
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 32rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
+const ConfirmDialog = styled(ModalDialog)`
+  width: min(100%, 24rem);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;
+
+const UserActionButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.point};
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  padding: 0 ${spacing.space16};
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2.375rem;
+    padding: 0 ${spacing.space16};
+    font-size: ${typography.fontSize14};
+  }
+`;

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -734,7 +734,15 @@ function UserFields({
         <UserSelect
           value={form.role}
           disabled={disabled}
-          onChange={(event) => setUserForm((current) => ({ ...current, role: event.target.value }))}
+          onChange={(event) => {
+            const role = event.target.value;
+
+            setUserForm((current) => ({
+              ...current,
+              role,
+              departmentId: role === "GUEST" ? "" : current.departmentId,
+            }));
+          }}
         >
           <option value="ADMIN">ADMIN</option>
           <option value="MANAGER">MANAGER</option>
@@ -748,7 +756,11 @@ function UserFields({
           value={form.departmentId}
           disabled={disabled}
           onChange={(event) =>
-            setUserForm((current) => ({ ...current, departmentId: event.target.value }))
+            setUserForm((current) => ({
+              ...current,
+              departmentId: event.target.value,
+              role: event.target.value && current.role === "GUEST" ? "VOLUNTEER" : current.role,
+            }))
           }
         >
           <option value="">부서 없음</option>

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -16,7 +16,6 @@ import {
   ControlRow,
   DangerButton,
   DataState,
-  Divider,
   FormGrid,
   Label,
   List,
@@ -71,6 +70,13 @@ function getDefaultPermissionScope(definition?: PermissionDefinitionDto) {
   const canUseGlobal = definition?.globalAllowed ?? definition?.scope !== "TARGET_ONLY";
 
   return canUseGlobal ? "GLOBAL" : "TARGET";
+}
+
+function getPermissionDescription(permission: PermissionResponseDto) {
+  const code = permission.permissionCode ?? permission.code ?? "";
+  const description = permission.description ?? permission.label ?? permission.name ?? "";
+
+  return description && description !== code ? description : "";
 }
 
 type QueryState<TData> = {
@@ -134,8 +140,6 @@ export function AdminUsersSection({
   permissionForm,
   permissionOptions,
   availableActions,
-  canUseGlobalPermission,
-  canUseTargetPermission,
   usersQuery,
   userDetailQuery,
   userPermissionsQuery,
@@ -336,211 +340,235 @@ export function AdminUsersSection({
                 errorLabel="사용자 상세를 불러오지 못했습니다."
                 emptyLabel="사용자를 선택하세요."
               >
-                {isUserEditing ? (
-                  <FormGrid
-                    onSubmit={(event) => {
-                      event.preventDefault();
-                      updateUserMutation.mutate();
-                    }}
-                  >
-                    <UserFields
-                      form={userForm}
-                      departments={departments}
-                      disabled={updateUserMutation.isPending}
-                      setUserForm={setUserForm}
-                    />
-
-                    <ButtonRow>
-                      <UserActionButton
-                        disabled={
-                          updateUserMutation.isPending ||
-                          !userForm.name.trim() ||
-                          !userForm.email.trim()
-                        }
-                      >
-                        저장
-                      </UserActionButton>
-                      <SmallButton
-                        type="button"
+                <PanelContent>
+                  {isUserEditing ? (
+                    <DetailFormView>
+                      <UserFields
+                        form={userForm}
+                        departments={departments}
                         disabled={updateUserMutation.isPending}
-                        onClick={cancelEditing}
+                        setUserForm={setUserForm}
+                      />
+                    </DetailFormView>
+                  ) : (
+                    <DetailFormView>
+                      <UserFields
+                        form={userForm}
+                        departments={departments}
+                        disabled
+                        setUserForm={setUserForm}
+                      />
+                    </DetailFormView>
+                  )}
+
+                  <PermissionBlock>
+                    <PermissionTitle>직접 권한</PermissionTitle>
+                    {userPermissionsQuery.isLoading || userPermissionsQuery.isError ? (
+                      <DataState
+                        compact
+                        isLoading={userPermissionsQuery.isLoading}
+                        isError={userPermissionsQuery.isError}
+                        isEmpty={false}
+                        loadingLabel="권한 목록 불러오는 중"
+                        errorLabel="권한 목록을 불러오지 못했습니다."
+                        emptyLabel=""
                       >
-                        취소
-                      </SmallButton>
-                    </ButtonRow>
-                  </FormGrid>
-                ) : (
-                  <DetailFormView>
-                    <UserFields
-                      form={userForm}
-                      departments={departments}
-                      disabled
-                      setUserForm={setUserForm}
-                    />
+                        <span />
+                      </DataState>
+                    ) : (
+                      <List>
+                        {userPermissionsQuery.data?.length ? (
+                          userPermissionsQuery.data.map((permission) => {
+                            const code = permission.permissionCode ?? permission.code ?? "";
+                            return (
+                              <ListItem key={code || permission.id}>
+                                <PermissionItemContent>
+                                  <PermissionCode>{code || permission.label || "-"}</PermissionCode>
+                                  {getPermissionDescription(permission) ? (
+                                    <PermissionDescription>
+                                      {getPermissionDescription(permission)}
+                                    </PermissionDescription>
+                                  ) : null}
+                                </PermissionItemContent>
+                                {code ? (
+                                  <SmallButton
+                                    type="button"
+                                    disabled={removePermissionMutation.isPending}
+                                    onClick={() => removePermissionMutation.mutate(code)}
+                                  >
+                                    제거
+                                  </SmallButton>
+                                ) : null}
+                              </ListItem>
+                            );
+                          })
+                        ) : (
+                          <EmptyPermissionItem>직접 부여된 권한이 없습니다.</EmptyPermissionItem>
+                        )}
+                      </List>
+                    )}
 
-                    <ButtonRow>
-                      <UserActionButton
-                        type="button"
-                        disabled={!selectedUserId}
-                        onClick={() => setIsUserEditing(true)}
+                    {isUserEditing ? (
+                      <PermissionAddForm
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          addPermissionMutation.mutate();
+                        }}
                       >
-                        수정
-                      </UserActionButton>
-                      <DangerButton
-                        type="button"
-                        disabled={deleteUserMutation.isPending}
-                        onClick={() => setIsUserDeleteConfirmOpen(true)}
-                      >
-                        삭제
-                      </DangerButton>
-                    </ButtonRow>
-                  </DetailFormView>
-                )}
+                        <PermissionAddHeader>
+                          <PermissionAddTitle>권한 추가</PermissionAddTitle>
+                        </PermissionAddHeader>
+                        <Label>
+                          리소스
+                          <UserSelect
+                            value={permissionForm.resourceType}
+                            onChange={(event) => {
+                              const resourceType = event.target.value;
+                              const actions = getPermissionActions(permissionOptions, resourceType);
+                              const actionType = actions[0] ?? "";
+                              const definition = getPermissionDefinition(
+                                permissionOptions,
+                                resourceType,
+                                actionType,
+                              );
+                              const scope = getDefaultPermissionScope(definition);
 
-                <Divider />
-                <SectionTitle>직접 권한</SectionTitle>
-                <DataState
-                  isLoading={userPermissionsQuery.isLoading}
-                  isError={userPermissionsQuery.isError}
-                  isEmpty={!selectedUserId || (userPermissionsQuery.data?.length ?? 0) === 0}
-                  loadingLabel="권한 목록 불러오는 중"
-                  errorLabel="권한 목록을 불러오지 못했습니다."
-                  emptyLabel={
-                    selectedUserId ? "직접 부여된 권한이 없습니다." : "사용자를 선택하세요."
-                  }
-                >
-                  <List>
-                    {userPermissionsQuery.data?.map((permission) => {
-                      const code = permission.permissionCode ?? permission.code ?? "";
-                      return (
-                        <ListItem key={code || permission.id}>
-                          <span>{code || permission.label || "-"}</span>
-                          {code ? (
-                            <SmallButton
-                              type="button"
-                              disabled={removePermissionMutation.isPending}
-                              onClick={() => removePermissionMutation.mutate(code)}
-                            >
-                              제거
-                            </SmallButton>
-                          ) : null}
-                        </ListItem>
-                      );
-                    })}
-                  </List>
-                </DataState>
+                              setPermissionForm((current) => ({
+                                ...current,
+                                resourceType,
+                                actionType,
+                                scope,
+                                target: scope === "GLOBAL" ? "" : current.target,
+                              }));
+                            }}
+                          >
+                            {permissionResources.map((resource) => (
+                              <option key={resource} value={resource}>
+                                {resource}
+                              </option>
+                            ))}
+                          </UserSelect>
+                        </Label>
+                        <Label>
+                          액션
+                          <UserSelect
+                            value={permissionForm.actionType}
+                            disabled={availableActions.length === 0}
+                            onChange={(event) => {
+                              const actionType = event.target.value;
+                              const definition = getPermissionDefinition(
+                                permissionOptions,
+                                permissionForm.resourceType,
+                                actionType,
+                              );
+                              const scope = getDefaultPermissionScope(definition);
 
-                <FormGrid
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    addPermissionMutation.mutate();
-                  }}
-                >
-                  <Label>
-                    리소스
-                    <UserSelect
-                      value={permissionForm.resourceType}
-                      onChange={(event) => {
-                        const resourceType = event.target.value;
-                        const actions = getPermissionActions(permissionOptions, resourceType);
-                        const actionType = actions[0] ?? "";
-                        const definition = getPermissionDefinition(
-                          permissionOptions,
-                          resourceType,
-                          actionType,
-                        );
-                        const scope = getDefaultPermissionScope(definition);
+                              setPermissionForm((current) => ({
+                                ...current,
+                                actionType,
+                                scope,
+                                target: scope === "GLOBAL" ? "" : current.target,
+                              }));
+                            }}
+                          >
+                            {availableActions.map((action) => (
+                              <option key={action} value={action}>
+                                {action}
+                              </option>
+                            ))}
+                          </UserSelect>
+                        </Label>
+                        <Label>
+                          범위
+                          <UserSelect
+                            value={permissionForm.scope}
+                            onChange={(event) =>
+                              setPermissionForm((current) => ({
+                                ...current,
+                                scope: event.target.value as PermissionFormState["scope"],
+                                target: event.target.value === "GLOBAL" ? "" : current.target,
+                              }))
+                            }
+                          >
+                            <option value="GLOBAL">전체 권한</option>
+                            <option value="TARGET">특정 대상 권한</option>
+                          </UserSelect>
+                        </Label>
+                        <Label>
+                          대상 ID
+                          <TextInput
+                            value={permissionForm.target}
+                            disabled={permissionForm.scope === "GLOBAL"}
+                            onChange={(event) =>
+                              setPermissionForm((current) => ({
+                                ...current,
+                                target: event.target.value,
+                              }))
+                            }
+                          />
+                        </Label>
+                        <UserActionButton
+                          type="submit"
+                          disabled={
+                            !selectedUserId ||
+                            addPermissionMutation.isPending ||
+                            !permissionForm.resourceType ||
+                            !permissionForm.actionType ||
+                            (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
+                          }
+                        >
+                          권한 추가
+                        </UserActionButton>
+                      </PermissionAddForm>
+                    ) : null}
+                  </PermissionBlock>
 
-                        setPermissionForm((current) => ({
-                          ...current,
-                          resourceType,
-                          actionType,
-                          scope,
-                          target: scope === "GLOBAL" ? "" : current.target,
-                        }));
-                      }}
-                    >
-                      {permissionResources.map((resource) => (
-                        <option key={resource} value={resource}>
-                          {resource}
-                        </option>
-                      ))}
-                    </UserSelect>
-                  </Label>
-                  <Label>
-                    액션
-                    <UserSelect
-                      value={permissionForm.actionType}
-                      disabled={availableActions.length === 0}
-                      onChange={(event) => {
-                        const actionType = event.target.value;
-                        const definition = getPermissionDefinition(
-                          permissionOptions,
-                          permissionForm.resourceType,
-                          actionType,
-                        );
-                        const scope = getDefaultPermissionScope(definition);
-
-                        setPermissionForm((current) => ({
-                          ...current,
-                          actionType,
-                          scope,
-                          target: scope === "GLOBAL" ? "" : current.target,
-                        }));
-                      }}
-                    >
-                      {availableActions.map((action) => (
-                        <option key={action} value={action}>
-                          {action}
-                        </option>
-                      ))}
-                    </UserSelect>
-                  </Label>
-                  <Label>
-                    범위
-                    <UserSelect
-                      value={permissionForm.scope}
-                      onChange={(event) =>
-                        setPermissionForm((current) => ({
-                          ...current,
-                          scope: event.target.value as PermissionFormState["scope"],
-                          target: event.target.value === "GLOBAL" ? "" : current.target,
-                        }))
-                      }
-                    >
-                      <option value="GLOBAL" disabled={!canUseGlobalPermission}>
-                        전체 권한
-                      </option>
-                      <option value="TARGET" disabled={!canUseTargetPermission}>
-                        특정 대상 권한
-                      </option>
-                    </UserSelect>
-                  </Label>
-                  <Label>
-                    대상 ID
-                    <TextInput
-                      value={permissionForm.target}
-                      disabled={permissionForm.scope === "GLOBAL"}
-                      onChange={(event) =>
-                        setPermissionForm((current) => ({
-                          ...current,
-                          target: event.target.value,
-                        }))
-                      }
-                    />
-                  </Label>
-                  <UserActionButton
-                    disabled={
-                      !selectedUserId ||
-                      addPermissionMutation.isPending ||
-                      !permissionForm.resourceType ||
-                      !permissionForm.actionType ||
-                      (permissionForm.scope === "TARGET" && !permissionForm.target.trim())
-                    }
-                  >
-                    권한 추가
-                  </UserActionButton>
-                </FormGrid>
+                  <ButtonRow>
+                    {isUserEditing ? (
+                      <>
+                        <UserActionButton
+                          type="button"
+                          onClick={() => updateUserMutation.mutate()}
+                          disabled={
+                            updateUserMutation.isPending ||
+                            !userForm.name.trim() ||
+                            !userForm.email.trim()
+                          }
+                        >
+                          저장
+                        </UserActionButton>
+                        <SmallButton
+                          type="button"
+                          disabled={updateUserMutation.isPending}
+                          onClick={cancelEditing}
+                        >
+                          취소
+                        </SmallButton>
+                      </>
+                    ) : (
+                      <>
+                        <UserActionButton
+                          type="button"
+                          disabled={!selectedUserId}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            setIsUserEditing(true);
+                          }}
+                        >
+                          수정
+                        </UserActionButton>
+                        <DangerButton
+                          type="button"
+                          disabled={deleteUserMutation.isPending}
+                          onClick={() => setIsUserDeleteConfirmOpen(true)}
+                        >
+                          삭제
+                        </DangerButton>
+                      </>
+                    )}
+                  </ButtonRow>
+                </PanelContent>
               </DataState>
             </SlidePanel>
           </>
@@ -580,6 +608,7 @@ export function AdminUsersSection({
               />
               <ButtonRow>
                 <UserActionButton
+                  type="submit"
                   disabled={
                     createUserMutation.isPending ||
                     !userForm.name.trim() ||
@@ -897,6 +926,78 @@ const DetailFormView = styled.div`
   gap: ${spacing.space12};
 `;
 
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const PermissionBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const PermissionTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const PermissionAddForm = styled(FormGrid)`
+  margin-top: ${spacing.space12};
+`;
+
+const PermissionAddHeader = styled.div`
+  padding-top: ${spacing.space12};
+  border-top: 1px solid #e6e9e7;
+`;
+
+const PermissionAddTitle = styled.h4`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize16};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const PermissionItemContent = styled.span`
+  display: grid;
+  gap: ${spacing.space4};
+  min-width: 0;
+`;
+
+const PermissionCode = styled.span`
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  word-break: break-word;
+`;
+
+const PermissionDescription = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  word-break: keep-all;
+`;
+
+const EmptyPermissionItem = styled.li`
+  display: flex;
+  align-items: center;
+  min-height: 2.375rem;
+  padding: ${spacing.space8};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+`;
+
 const UserSelect = styled.select`
   width: 100%;
   min-height: 2.375rem;
@@ -977,7 +1078,11 @@ const ConfirmMessage = styled.p`
   line-height: ${typography.lineHeight130};
 `;
 
-const UserActionButton = styled.button`
+const UserActionButton = styled.button.attrs<{ type?: "button" | "submit" | "reset" }>(
+  ({ type }) => ({
+    type: type ?? "button",
+  }),
+)`
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -21,7 +21,6 @@ import {
   ListItem,
   PrimaryButton,
   SectionCard,
-  SectionDescription,
   SectionHeaderRow,
   SectionTitle,
   Select,
@@ -153,7 +152,7 @@ export function AdminUsersSection({
         </DataState>
       </SectionCard>
       <SectionCard>
-        <SectionTitle>{selectedUserId ? "사용자 상세/수정" : "사용자 생성"}</SectionTitle>
+        <SectionTitle>{selectedUserId ? "사용자 상세" : "사용자 생성"}</SectionTitle>
         {userDetailQuery.isLoading ? (
           <InlineStatus>사용자 상세를 불러오는 중입니다.</InlineStatus>
         ) : null}

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
 import { IconDownload, IconFilePlus } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -262,15 +262,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     );
 
     return currentAffiliation?.value ?? "";
-  }, [affiliationOptions, request?.classroomId, request?.classroomName]);
-
-  useEffect(() => {
-    if (!isEditing || editAffiliationValue || !requestAffiliationValue) {
-      return;
-    }
-
-    setEditAffiliationValue(requestAffiliationValue);
-  }, [editAffiliationValue, isEditing, requestAffiliationValue]);
+  }, [affiliationOptions, request]);
 
   const reportMutation = useMutation({
     mutationFn: async () => {

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -73,7 +73,11 @@ export const queryKeys = {
       ["admin", "classrooms", "detail", classroomId] as const,
     subjects: (classroomId?: number) => ["admin", "subjects", { classroomId }] as const,
     activeVolunteerTeachers: () => ["admin", "users", "active-volunteer-teachers"] as const,
-    purchaseRequests: (status?: string) => ["admin", "purchase-requests", { status }] as const,
+    purchaseRequests: (params?: string | { status?: string; keyword?: string }) => {
+      const normalizedParams = typeof params === "string" ? { status: params } : (params ?? {});
+
+      return ["admin", "purchase-requests", normalizedParams] as const;
+    },
     purchaseRequestDetail: (requestId: number) =>
       ["admin", "purchase-requests", "detail", requestId] as const,
   },


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 관리자 페이지 주요 관리 섹션 UI 통일
   \- 사용자/부서/분반/채널/게시글/결강 요청/수업 교환 요청/결제 요청 관리 섹션을 목록 중심 구조로 정리
   \- 목록 클릭 시 우측 슬라이드 패널에서 상세 정보를 확인하도록 UI 패턴 통일
   \- 페이지네이션, 검색창, 드롭박스, 입력 폼 높이, 버튼 톤 정렬

2. 관리자 페이지 사용성 개선
   \- 새로고침 후 마지막으로 보고 있던 관리자 메뉴를 유지하도록 처리
   \- 다른 섹션으로 이동 시 기존에 열려 있던 슬라이드 패널/편집 상태가 초기화되도록 개선

[대시보드]

<img width="1900" height="862" alt="스크린샷 2026-06-15 144658" src="https://github.com/user-attachments/assets/f4fbd3a2-2e36-49c8-994d-2c64127b7682" />

[사용자 관리]

<img width="1918" height="862" alt="스크린샷 2026-06-15 144734" src="https://github.com/user-attachments/assets/04114595-43f2-42fe-b693-56786e4e135b" />

<img width="1918" height="863" alt="스크린샷 2026-06-15 144753" src="https://github.com/user-attachments/assets/197f8a7d-1540-4796-a365-2ce50b28030b" /> <br>

\* 이하 부서/분반/채널/게시글/결강 요청/수업 교환 요청/결제 요청 관리 섹션은 모두 사용자 관리 섹션과 동일한 구조의 UI로 구성

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #133

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
