### PR TITLE
[REFACTOR] 수업 관리 섹션 개선

### DIFF
--- a/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
+++ b/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
@@ -1,0 +1,285 @@
+[     130ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[     260ms] [LOG] [Fast Refresh] done in 240ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[     398ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[     431ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  164084ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  164181ms] [LOG] [Fast Refresh] done in 207ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  176077ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  176146ms] [LOG] [Fast Refresh] done in 170ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  180798ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  180827ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  268498ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  268550ms] [LOG] [Fast Refresh] done in 133ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  272781ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  272839ms] [LOG] [Fast Refresh] done in 138ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  332114ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  332157ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  342975ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  343008ms] [LOG] [Fast Refresh] done in 124ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  368539ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  368571ms] [LOG] [Fast Refresh] done in 105ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  389434ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  389461ms] [LOG] [Fast Refresh] done in 93ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  680157ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  680242ms] [LOG] [Fast Refresh] done in 167ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  694017ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  694089ms] [LOG] [Fast Refresh] done in 155ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  708689ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  708753ms] [LOG] [Fast Refresh] done in 144ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  728193ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  728260ms] [LOG] [Fast Refresh] done in 149ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  769942ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  770389ms] [LOG] [Fast Refresh] done in 555ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  770540ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  771331ms] [LOG] [Fast Refresh] done in 895ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  771658ms] ReferenceError: HeaderCopy is not defined
+    at WeeklySchedulePageClient (http://localhost:3000/_next/static/chunks/_0kqd8jo._.js?id=%255Bproject%255D%252Fcomponents%252Fstaff%252Fclass-management%252Fweekly-schedule%252FWeeklySchedulePageClient.tsx+%255Bapp-client%255D+%2528ecmascript%2529:424:230)
+    at Object.react_stack_bottom_frame (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:15037:24)
+    at renderWithHooks (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:4620:24)
+    at updateFunctionComponent (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6081:21)
+    at beginWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6691:24)
+    at runWithFiberInDEV (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:965:74)
+    at performUnitOfWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9555:97)
+    at workLoopSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9449:40)
+    at renderRootSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9433:13)
+    at performWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9061:186)
+    at performSyncWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10263:9)
+    at flushSyncWorkAcrossRoots_impl (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10179:316)
+    at processRootScheduleInMicrotask (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10200:106)
+    at http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10274:158
+[  771661ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:3000/staff/class-management/weekly-schedule:0
+[  771841ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  771887ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  772191ms] ReferenceError: HeaderCopy is not defined
+    at WeeklySchedulePageClient (http://localhost:3000/_next/static/chunks/_0kqd8jo._.js:1397:230)
+    at Object.react_stack_bottom_frame (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:15037:24)
+    at renderWithHooks (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:4620:24)
+    at updateFunctionComponent (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6081:21)
+    at beginWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6665:639)
+    at runWithFiberInDEV (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:965:74)
+    at performUnitOfWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9555:97)
+    at workLoopSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9449:40)
+    at renderRootSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9433:13)
+    at performWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9098:47)
+    at performWorkOnRootViaSchedulerTask (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10255:9)
+    at MessagePort.performWorkUntilDeadline (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_0rpq4pf._.js:2647:64)
+[  798217ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  798257ms] [LOG] [Fast Refresh] done in 149ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  819777ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  819883ms] [WARNING] [Fast Refresh] performing full reload because your application had an unrecoverable error @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  820048ms] [LOG] [Fast Refresh] done in 364ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  820172ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  821139ms] [LOG] [Fast Refresh] done in 1073ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  821388ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:3000/staff/class-management/weekly-schedule:0
+[  821544ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  821602ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  821900ms] ReferenceError: HeaderCopy is not defined
+    at WeeklySchedulePageClient (http://localhost:3000/_next/static/chunks/_0.d9u3s._.js:1428:230)
+    at Object.react_stack_bottom_frame (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:15037:24)
+    at renderWithHooks (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:4620:24)
+    at updateFunctionComponent (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6081:21)
+    at beginWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:6665:639)
+    at runWithFiberInDEV (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:965:74)
+    at performUnitOfWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9555:97)
+    at workLoopSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9449:40)
+    at renderRootSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9433:13)
+    at performWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:9098:47)
+    at performWorkOnRootViaSchedulerTask (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_058-ah~._.js:10255:9)
+    at MessagePort.performWorkUntilDeadline (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_0rpq4pf._.js:2647:64)
+[  859733ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  859754ms] [LOG] [Fast Refresh] done in 128ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  916934ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  917074ms] [WARNING] [Fast Refresh] performing full reload because your application had an unrecoverable error @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  917193ms] [LOG] [Fast Refresh] done in 364ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  917316ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  917727ms] [LOG] [Fast Refresh] done in 521ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  918052ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  918094ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  931018ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  931068ms] [LOG] [Fast Refresh] done in 128ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  931210ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  931582ms] [LOG] [Fast Refresh] done in 485ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  955554ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  955589ms] [LOG] [Fast Refresh] done in 126ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  983279ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[  983339ms] [LOG] [Fast Refresh] done in 148ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1008989ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1008994ms] [LOG] [Fast Refresh] done in 115ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1042663ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1042666ms] [LOG] [Fast Refresh] done in 108ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1056691ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1056746ms] [LOG] [Fast Refresh] done in 138ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1070481ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1070483ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1071985ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1072044ms] [LOG] [Fast Refresh] done in 169ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1076508ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1076591ms] [LOG] [Fast Refresh] done in 189ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1088030ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1088039ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1119189ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1119190ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1120120ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1120308ms] [LOG] [Fast Refresh] done in 289ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1122320ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1122340ms] [LOG] [Fast Refresh] done in 124ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1122520ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1122522ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1125678ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1125680ms] [LOG] [Fast Refresh] done in 107ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1661349ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1661375ms] [LOG] [Fast Refresh] done in 122ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1666013ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1666038ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1710104ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1710173ms] [LOG] [Fast Refresh] done in 149ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1821086ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1821161ms] [LOG] [Fast Refresh] done in 165ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1834888ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1834909ms] [LOG] [Fast Refresh] done in 107ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1838692ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1838729ms] [LOG] [Fast Refresh] done in 121ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1844417ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1844456ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1870272ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1870309ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1877376ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1877407ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1887651ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1887686ms] [LOG] [Fast Refresh] done in 120ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1892333ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1892380ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1948166ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 1948495ms] [LOG] [Fast Refresh] done in 440ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2013363ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2013434ms] [LOG] [Fast Refresh] done in 159ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2017496ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2017572ms] [LOG] [Fast Refresh] done in 151ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2057942ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2057962ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2118551ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2118602ms] [LOG] [Fast Refresh] done in 134ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2122731ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2122797ms] [LOG] [Fast Refresh] done in 148ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2194090ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2194129ms] [LOG] [Fast Refresh] done in 123ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2197904ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2197939ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2201391ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2201414ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2210956ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2210989ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2215655ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2215691ms] [LOG] [Fast Refresh] done in 114ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2219916ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2219972ms] [LOG] [Fast Refresh] done in 143ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2236044ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2236078ms] [LOG] [Fast Refresh] done in 126ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2239127ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2239163ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2329312ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2329357ms] [LOG] [Fast Refresh] done in 154ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2341880ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2342241ms] [LOG] [Fast Refresh] done in 468ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2537228ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2537254ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2549047ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2549067ms] [LOG] [Fast Refresh] done in 102ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2589054ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2589115ms] [LOG] [Fast Refresh] done in 163ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2600198ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2600215ms] [LOG] [Fast Refresh] done in 120ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2600830ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2600869ms] [LOG] [Fast Refresh] done in 150ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2762167ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2762225ms] [LOG] [Fast Refresh] done in 131ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2773747ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2773800ms] [LOG] [Fast Refresh] done in 132ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2787756ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2787760ms] [LOG] [Fast Refresh] done in 110ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2828445ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2828446ms] [LOG] [Fast Refresh] done in 108ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2832278ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2832278ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2856476ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2856515ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2860615ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2860638ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2882867ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2882912ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2956513ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2956536ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2972482ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 2972527ms] [LOG] [Fast Refresh] done in 118ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3042578ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3042617ms] [LOG] [Fast Refresh] done in 131ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3061447ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3061487ms] [LOG] [Fast Refresh] done in 122ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3075274ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3075303ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3106278ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3106307ms] [LOG] [Fast Refresh] done in 114ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3107943ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3107963ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3118808ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3118833ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3146333ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3146354ms] [LOG] [Fast Refresh] done in 96ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3150129ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3150154ms] [LOG] [Fast Refresh] done in 97ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3153649ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3153680ms] [LOG] [Fast Refresh] done in 110ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3156914ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3156950ms] [LOG] [Fast Refresh] done in 130ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3157932ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3157970ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3168411ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3168442ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3174227ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3174257ms] [LOG] [Fast Refresh] done in 95ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3198962ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3198987ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3204678ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3204705ms] [LOG] [Fast Refresh] done in 107ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3212382ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3212421ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3241433ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3241816ms] [LOG] [Fast Refresh] done in 491ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3254546ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3254599ms] [LOG] [Fast Refresh] done in 136ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3288057ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3288084ms] [LOG] [Fast Refresh] done in 97ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3292005ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3292032ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3300807ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3300839ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3310014ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3310064ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3384443ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3384471ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3392288ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3392351ms] [LOG] [Fast Refresh] done in 149ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3410083ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3410151ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3425834ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3425857ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3431507ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3431533ms] [LOG] [Fast Refresh] done in 107ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3443843ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3443866ms] [LOG] [Fast Refresh] done in 97ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3447693ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3447722ms] [LOG] [Fast Refresh] done in 114ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3453759ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3453790ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3459000ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3459040ms] [LOG] [Fast Refresh] done in 126ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3464601ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3464651ms] [LOG] [Fast Refresh] done in 129ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3472623ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3472655ms] [LOG] [Fast Refresh] done in 108ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3481409ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3481440ms] [LOG] [Fast Refresh] done in 93ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3541576ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3541647ms] [LOG] [Fast Refresh] done in 167ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3718067ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3718289ms] [LOG] [Fast Refresh] done in 330ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431

--- a/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
+++ b/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
@@ -670,3 +670,75 @@
 [18825673ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [18857343ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [18857467ms] [LOG] [Fast Refresh] done in 229ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20098837ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20099086ms] [LOG] [Fast Refresh] done in 351ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20113315ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20113449ms] [LOG] [Fast Refresh] done in 240ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20114992ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20115110ms] [LOG] [Fast Refresh] done in 221ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20116610ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20116682ms] [LOG] [Fast Refresh] done in 175ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20129440ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20129545ms] [LOG] [Fast Refresh] done in 213ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20130559ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20130630ms] [LOG] [Fast Refresh] done in 176ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20291620ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20291829ms] [LOG] [Fast Refresh] done in 304ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20304583ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20304638ms] [LOG] [Fast Refresh] done in 142ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20317745ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20317900ms] [LOG] [Fast Refresh] done in 228ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20339708ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20339743ms] [LOG] [Fast Refresh] done in 141ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20342687ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20342689ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20385243ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20385244ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20385893ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20385902ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20388105ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20388107ms] [LOG] [Fast Refresh] done in 108ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20645066ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20645176ms] [LOG] [Fast Refresh] done in 214ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20646178ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20646293ms] [LOG] [Fast Refresh] done in 218ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20648623ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20648733ms] [LOG] [Fast Refresh] done in 213ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20650673ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20650750ms] [LOG] [Fast Refresh] done in 185ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20651246ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20651350ms] [LOG] [Fast Refresh] done in 208ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20653000ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20653092ms] [LOG] [Fast Refresh] done in 193ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20654360ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20654489ms] [LOG] [Fast Refresh] done in 231ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20668238ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20668341ms] [LOG] [Fast Refresh] done in 212ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20740096ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20740331ms] [LOG] [Fast Refresh] done in 319ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20757153ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20757241ms] [LOG] [Fast Refresh] done in 200ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20770043ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20770199ms] [LOG] [Fast Refresh] done in 261ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20792843ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20792944ms] [LOG] [Fast Refresh] done in 209ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20795544ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20795620ms] [LOG] [Fast Refresh] done in 178ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20796780ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20797128ms] [LOG] [Fast Refresh] done in 453ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20798040ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20798063ms] [LOG] [Fast Refresh] done in 128ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20798532ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20798575ms] [LOG] [Fast Refresh] done in 144ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20798967ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20799266ms] [LOG] [Fast Refresh] done in 400ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20799516ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20799728ms] [LOG] [Fast Refresh] done in 317ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20803554ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20803808ms] [LOG] [Fast Refresh] done in 358ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20804470ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20804544ms] [LOG] [Fast Refresh] done in 181ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20807532ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20807607ms] [LOG] [Fast Refresh] done in 182ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20842787ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[20842789ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431

--- a/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
+++ b/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
@@ -283,3 +283,372 @@
 [ 3541647ms] [LOG] [Fast Refresh] done in 167ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [ 3718067ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [ 3718289ms] [LOG] [Fast Refresh] done in 330ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3806679ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3806726ms] [LOG] [Fast Refresh] done in 157ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3809244ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 3809264ms] [LOG] [Fast Refresh] done in 122ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4155063ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4155096ms] [LOG] [Fast Refresh] done in 133ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4768297ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4768381ms] [LOG] [Fast Refresh] done in 194ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4788327ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4788344ms] [LOG] [Fast Refresh] done in 127ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4817073ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4817215ms] [LOG] [Fast Refresh] done in 231ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4842661ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4842925ms] [LOG] [Fast Refresh] done in 371ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4843028ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4843358ms] [LOG] [Fast Refresh] done in 431ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4844134ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4844171ms] [LOG] [Fast Refresh] done in 141ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4861554ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4861588ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4861719ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4862075ms] [LOG] [Fast Refresh] done in 465ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4913605ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4913841ms] [LOG] [Fast Refresh] done in 339ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4913970ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4914199ms] [LOG] [Fast Refresh] done in 337ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4933150ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4933166ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4933298ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4933504ms] [LOG] [Fast Refresh] done in 313ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4946445ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4946477ms] [LOG] [Fast Refresh] done in 134ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4946623ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4946893ms] [LOG] [Fast Refresh] done in 380ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4985265ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 4985307ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5008559ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5008562ms] [LOG] [Fast Refresh] done in 115ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5018684ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5018691ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5036268ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5036322ms] [LOG] [Fast Refresh] done in 160ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5049211ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5049213ms] [LOG] [Fast Refresh] done in 102ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5200601ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5200820ms] [LOG] [Fast Refresh] done in 328ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5528405ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5528436ms] [LOG] [Fast Refresh] done in 105ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5541577ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5541614ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5552355ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5552403ms] [LOG] [Fast Refresh] done in 119ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5565683ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5565704ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5585955ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5586282ms] [LOG] [Fast Refresh] done in 428ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5586396ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5586643ms] [LOG] [Fast Refresh] done in 356ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5586765ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5586777ms] [LOG] [Fast Refresh] done in 115ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5589765ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5589798ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5602909ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5602945ms] [LOG] [Fast Refresh] done in 122ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5618912ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5618944ms] [LOG] [Fast Refresh] done in 102ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5622328ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5622433ms] [LOG] [Fast Refresh] done in 208ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5622555ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5622661ms] [LOG] [Fast Refresh] done in 211ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5641332ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5641381ms] [LOG] [Fast Refresh] done in 131ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5652294ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5652298ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5659518ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5659592ms] [LOG] [Fast Refresh] done in 143ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5679411ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5679442ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5691848ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5691883ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5695356ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5695450ms] [LOG] [Fast Refresh] done in 207ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5703087ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5703120ms] [LOG] [Fast Refresh] done in 119ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5714558ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5714571ms] [LOG] [Fast Refresh] done in 128ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5716886ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5717594ms] [LOG] [Fast Refresh] done in 669ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5721802ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5721869ms] [LOG] [Fast Refresh] done in 169ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5728553ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5728569ms] [LOG] [Fast Refresh] done in 130ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5728819ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5728871ms] [LOG] [Fast Refresh] done in 161ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5733070ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5733099ms] [LOG] [Fast Refresh] done in 137ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5741566ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5742810ms] [LOG] [Fast Refresh] done in 1344ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5742935ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5743140ms] [LOG] [Fast Refresh] done in 316ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5743284ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5743679ms] [LOG] [Fast Refresh] done in 511ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5743849ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5743881ms] [LOG] [Fast Refresh] done in 132ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5756813ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5757175ms] [LOG] [Fast Refresh] done in 461ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5757315ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5757465ms] [LOG] [Fast Refresh] done in 265ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5775373ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5775374ms] [LOG] [Fast Refresh] done in 112ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5836654ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5836690ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5847651ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5847670ms] [LOG] [Fast Refresh] done in 120ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5859828ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5859850ms] [LOG] [Fast Refresh] done in 97ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5862965ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5863239ms] [LOG] [Fast Refresh] done in 374ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5935007ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5935028ms] [LOG] [Fast Refresh] done in 134ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5937271ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5937314ms] [LOG] [Fast Refresh] done in 150ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5957372ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5957423ms] [LOG] [Fast Refresh] done in 151ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5957917ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5958206ms] [LOG] [Fast Refresh] done in 392ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5961315ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5961357ms] [LOG] [Fast Refresh] done in 115ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5972950ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 5972977ms] [LOG] [Fast Refresh] done in 130ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6041956ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6041993ms] [LOG] [Fast Refresh] done in 152ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6060803ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6060822ms] [LOG] [Fast Refresh] done in 208ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6226604ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6226607ms] [LOG] [Fast Refresh] done in 115ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6275501ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6275518ms] [LOG] [Fast Refresh] done in 121ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6477765ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6477786ms] [LOG] [Fast Refresh] done in 124ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6495369ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6495484ms] [LOG] [Fast Refresh] done in 188ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6574042ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6574111ms] [LOG] [Fast Refresh] done in 177ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6576008ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6576059ms] [LOG] [Fast Refresh] done in 162ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6579881ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6579903ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6668371ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6669931ms] [LOG] [Fast Refresh] done in 1676ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6670066ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6670325ms] [LOG] [Fast Refresh] done in 366ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6670452ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6670484ms] [LOG] [Fast Refresh] done in 132ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6671015ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6671092ms] [LOG] [Fast Refresh] done in 178ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6671581ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6671605ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672363ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672484ms] [LOG] [Fast Refresh] done in 222ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672614ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672619ms] [LOG] [Fast Refresh] done in 119ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672776ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672810ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672914ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6672925ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6673741ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6673819ms] [LOG] [Fast Refresh] done in 183ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674148ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674153ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674294ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674301ms] [LOG] [Fast Refresh] done in 107ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674615ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674631ms] [LOG] [Fast Refresh] done in 116ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674747ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6674800ms] [LOG] [Fast Refresh] done in 159ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6675193ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6675194ms] [LOG] [Fast Refresh] done in 105ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6675578ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6675579ms] [LOG] [Fast Refresh] done in 103ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6675996ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676009ms] [LOG] [Fast Refresh] done in 117ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676115ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676124ms] [LOG] [Fast Refresh] done in 111ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676248ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676289ms] [LOG] [Fast Refresh] done in 151ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676524ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676573ms] [LOG] [Fast Refresh] done in 159ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676686ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676715ms] [LOG] [Fast Refresh] done in 133ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676830ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6676875ms] [LOG] [Fast Refresh] done in 147ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677054ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677057ms] [LOG] [Fast Refresh] done in 106ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677296ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677304ms] [LOG] [Fast Refresh] done in 122ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677648ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677689ms] [LOG] [Fast Refresh] done in 142ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677801ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677882ms] [LOG] [Fast Refresh] done in 182ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6677994ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6678058ms] [LOG] [Fast Refresh] done in 175ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6678202ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6678208ms] [LOG] [Fast Refresh] done in 131ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6678374ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6678413ms] [LOG] [Fast Refresh] done in 140ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6681103ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6681215ms] [LOG] [Fast Refresh] done in 213ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6809635ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6809676ms] [LOG] [Fast Refresh] done in 143ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6812686ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6812718ms] [LOG] [Fast Refresh] done in 135ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6824179ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6825755ms] [LOG] [Fast Refresh] done in 1684ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6865750ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6865808ms] [LOG] [Fast Refresh] done in 168ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6913846ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6914022ms] [LOG] [Fast Refresh] done in 280ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6989866ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6989894ms] [LOG] [Fast Refresh] done in 99ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6989999ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6990033ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6990138ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6990219ms] [LOG] [Fast Refresh] done in 152ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6990325ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 6990354ms] [LOG] [Fast Refresh] done in 105ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7023520ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7023554ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7054704ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7054765ms] [LOG] [Fast Refresh] done in 162ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7060949ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7061110ms] [LOG] [Fast Refresh] done in 231ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7061731ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7061793ms] [LOG] [Fast Refresh] done in 172ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7062144ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7062196ms] [LOG] [Fast Refresh] done in 164ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7063304ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7063347ms] [LOG] [Fast Refresh] done in 146ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7063741ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7063799ms] [LOG] [Fast Refresh] done in 163ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7066042ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7066141ms] [LOG] [Fast Refresh] done in 200ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7068676ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7068737ms] [LOG] [Fast Refresh] done in 169ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7072399ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7072477ms] [LOG] [Fast Refresh] done in 151ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7073860ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7073868ms] [LOG] [Fast Refresh] done in 109ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7091592ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7091593ms] [LOG] [Fast Refresh] done in 101ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7094869ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7094871ms] [LOG] [Fast Refresh] done in 114ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7095776ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7095792ms] [LOG] [Fast Refresh] done in 130ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7098234ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7098273ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7136339ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7136340ms] [LOG] [Fast Refresh] done in 110ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7137006ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7137019ms] [LOG] [Fast Refresh] done in 123ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7221529ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7221632ms] [LOG] [Fast Refresh] done in 211ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7265565ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7265590ms] [LOG] [Fast Refresh] done in 134ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7419380ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7419416ms] [LOG] [Fast Refresh] done in 137ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7426729ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7426743ms] [LOG] [Fast Refresh] done in 119ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7570769ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7570780ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7571338ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7571386ms] [LOG] [Fast Refresh] done in 152ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[ 7847854ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[15974115ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[15974564ms] [LOG] [Fast Refresh] done in 552ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16028875ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16029011ms] [LOG] [Fast Refresh] done in 242ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16091939ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16091941ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16234055ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16234088ms] [LOG] [Fast Refresh] done in 143ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16234193ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16234277ms] [LOG] [Fast Refresh] done in 187ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16313329ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16313757ms] [LOG] [Fast Refresh] done in 536ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16318828ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16319051ms] [LOG] [Fast Refresh] done in 326ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16457436ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[16457524ms] [LOG] [Fast Refresh] done in 195ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17109343ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17109518ms] [LOG] [Fast Refresh] done in 269ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17119488ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17119601ms] [LOG] [Fast Refresh] done in 199ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17140031ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17140041ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17144052ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17144075ms] [LOG] [Fast Refresh] done in 129ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17147340ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17147367ms] [LOG] [Fast Refresh] done in 129ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17150599ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17150646ms] [LOG] [Fast Refresh] done in 151ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17151135ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17151154ms] [LOG] [Fast Refresh] done in 132ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17151338ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17151461ms] [LOG] [Fast Refresh] done in 224ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17190921ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17190943ms] [LOG] [Fast Refresh] done in 124ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17191523ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17191526ms] [LOG] [Fast Refresh] done in 119ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17355813ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17355937ms] [LOG] [Fast Refresh] done in 237ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17364240ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17364277ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17364393ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17364432ms] [LOG] [Fast Refresh] done in 144ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17385794ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17385864ms] [LOG] [Fast Refresh] done in 176ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17392126ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17392385ms] [LOG] [Fast Refresh] done in 366ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17690277ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17690488ms] [LOG] [Fast Refresh] done in 310ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17712230ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17712318ms] [LOG] [Fast Refresh] done in 171ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17715715ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17715803ms] [LOG] [Fast Refresh] done in 203ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17720396ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17720476ms] [LOG] [Fast Refresh] done in 195ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17725754ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17725855ms] [LOG] [Fast Refresh] done in 171ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17726971ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17727140ms] [LOG] [Fast Refresh] done in 272ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17751050ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17751085ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17754307ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17754346ms] [LOG] [Fast Refresh] done in 146ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17754558ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17754571ms] [LOG] [Fast Refresh] done in 118ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17797457ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17797486ms] [LOG] [Fast Refresh] done in 139ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17798097ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17798143ms] [LOG] [Fast Refresh] done in 148ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17800401ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17800402ms] [LOG] [Fast Refresh] done in 102ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17917035ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17917115ms] [LOG] [Fast Refresh] done in 170ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17938562ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17938622ms] [LOG] [Fast Refresh] done in 161ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17940636ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17940704ms] [LOG] [Fast Refresh] done in 170ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17941081ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17941543ms] [LOG] [Fast Refresh] done in 563ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17984456ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[17984458ms] [LOG] [Fast Refresh] done in 113ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18000625ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18000759ms] [LOG] [Fast Refresh] done in 233ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18064573ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18064575ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18065324ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18065339ms] [LOG] [Fast Refresh] done in 125ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18184532ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18184665ms] [LOG] [Fast Refresh] done in 238ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18187484ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18187621ms] [LOG] [Fast Refresh] done in 240ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18187732ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18187755ms] [LOG] [Fast Refresh] done in 131ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18210260ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18210266ms] [LOG] [Fast Refresh] done in 120ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18210376ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18210411ms] [LOG] [Fast Refresh] done in 142ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431

--- a/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
+++ b/.playwright-mcp/console-2026-06-16T10-46-44-371Z.log
@@ -652,3 +652,21 @@
 [18210266ms] [LOG] [Fast Refresh] done in 120ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [18210376ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
 [18210411ms] [LOG] [Fast Refresh] done in 142ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18657431ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18658512ms] [LOG] [Fast Refresh] done in 1180ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18658921ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18659047ms] [LOG] [Fast Refresh] done in 228ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18659174ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18659268ms] [LOG] [Fast Refresh] done in 205ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18661966ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18662119ms] [LOG] [Fast Refresh] done in 256ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18681534ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18681589ms] [LOG] [Fast Refresh] done in 156ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18765191ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18765266ms] [LOG] [Fast Refresh] done in 152ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18783859ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18783864ms] [LOG] [Fast Refresh] done in 110ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18825671ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18825673ms] [LOG] [Fast Refresh] done in 104ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18857343ms] [LOG] [Fast Refresh] rebuilding @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431
+[18857467ms] [LOG] [Fast Refresh] done in 229ms @ http://localhost:3000/_next/static/chunks/node_modules_next_dist_115brz8._.js:2431

--- a/.playwright-mcp/page-2026-06-16T10-46-44-919Z.yml
+++ b/.playwright-mcp/page-2026-06-16T10-46-44-919Z.yml
@@ -1,0 +1,99 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e3]:
+    - generic [ref=e4]:
+      - link "금정야학 로고" [ref=e5] [cursor=pointer]:
+        - /url: /
+        - img "금정야학 로고" [ref=e6]
+      - navigation [ref=e7]:
+        - list [ref=e8]:
+          - listitem [ref=e9]:
+            - link "기관 정보" [ref=e10] [cursor=pointer]:
+              - /url: /info/history
+          - listitem [ref=e11]:
+            - link "교원" [ref=e12] [cursor=pointer]:
+              - /url: /staff/class-management
+          - listitem [ref=e13]:
+            - link "신규 등록" [ref=e14] [cursor=pointer]:
+              - /url: /register
+  - generic [ref=e18]:
+    - complementary [ref=e19]:
+      - heading "교원" [level=1] [ref=e20]
+      - generic [ref=e21]:
+        - generic [ref=e22]:
+          - button "수업 관리" [expanded] [ref=e23] [cursor=pointer]:
+            - generic [ref=e24]: 수업 관리
+            - generic [ref=e25]: ▾
+          - list [ref=e26]:
+            - listitem [ref=e27]:
+              - link "시간표" [ref=e28] [cursor=pointer]:
+                - /url: /staff/class-management/weekly-schedule
+            - listitem [ref=e29]:
+              - link "수업 일지" [ref=e30] [cursor=pointer]:
+                - /url: /staff/class-management
+            - listitem [ref=e31]:
+              - link "수업 교환 신청" [ref=e32] [cursor=pointer]:
+                - /url: /staff/class-management/exchange-request
+            - listitem [ref=e33]:
+              - link "수업 결강 신청" [ref=e34] [cursor=pointer]:
+                - /url: /staff/class-management/absence-request
+        - generic [ref=e35]:
+          - button "재무 관리" [ref=e36] [cursor=pointer]:
+            - generic [ref=e37]: 재무 관리
+            - generic [ref=e38]: ▾
+          - list:
+            - listitem [ref=e39]:
+              - link "결제 신청" [ref=e40] [cursor=pointer]:
+                - /url: /staff/finance-management
+        - generic [ref=e41]:
+          - button "자료실" [ref=e42] [cursor=pointer]:
+            - generic [ref=e43]: 자료실
+            - generic [ref=e44]: ▾
+          - list:
+            - listitem [ref=e45]:
+              - link "교칙" [ref=e46] [cursor=pointer]:
+                - /url: /staff/archive/school-rules
+            - listitem [ref=e47]:
+              - link "연락망" [ref=e48] [cursor=pointer]:
+                - /url: /staff/archive/phone-book
+            - listitem [ref=e49]:
+              - link "교학 회의록" [ref=e50] [cursor=pointer]:
+                - /url: /staff/archive/meeting-records
+            - listitem [ref=e51]:
+              - link "인수인계서" [ref=e52] [cursor=pointer]:
+                - /url: /staff/archive/handover-documents
+            - listitem [ref=e53]:
+              - link "시험 문제 자료" [ref=e54] [cursor=pointer]:
+                - /url: /staff/archive/exam-materials
+            - listitem [ref=e55]:
+              - link "서류 양식" [ref=e56] [cursor=pointer]:
+                - /url: /staff/archive/document-forms
+        - generic [ref=e57]:
+          - button "게시판" [ref=e58] [cursor=pointer]:
+            - generic [ref=e59]: 게시판
+            - generic [ref=e60]: ▾
+          - list:
+            - listitem [ref=e61]:
+              - link "게시판" [ref=e62] [cursor=pointer]:
+                - /url: /staff/board
+        - generic [ref=e63]:
+          - button "학사일정" [ref=e64] [cursor=pointer]:
+            - generic [ref=e65]: 학사일정
+            - generic [ref=e66]: ▾
+          - list:
+            - listitem [ref=e67]:
+              - link "월별 일정" [ref=e68] [cursor=pointer]:
+                - /url: /staff/calendar
+    - main [ref=e69]:
+      - generic [ref=e70]:
+        - generic [ref=e71]:
+          - generic [ref=e72]:
+            - heading "시간표" [level=1] [ref=e73]
+            - paragraph [ref=e74]: 2026-06-15 ~ 2026-06-21
+          - generic "주간 시간표 이동" [ref=e75]:
+            - button "이전 주" [ref=e76] [cursor=pointer]: ◀
+            - button "이번 주로 이동" [ref=e77] [cursor=pointer]: 06월 3주차
+            - button "다음 주" [ref=e78] [cursor=pointer]: ▶
+        - paragraph [ref=e79]: 주중 또는 주말 분반이 없습니다.
+  - region "Notifications Alt+T"
+  - button "Open Next.js Dev Tools" [ref=e85] [cursor=pointer]:
+    - img [ref=e86]

--- a/api/lesson/lesson.dto.ts
+++ b/api/lesson/lesson.dto.ts
@@ -33,10 +33,18 @@ export interface LessonSummaryResponseDto {
   period?: number;
   startTime?: string;
   endTime?: string;
+  status?: LessonStatus | "CANCELLED";
   teacherName?: string;
   subjectName?: string;
   classroomId?: number;
   classroomName?: string;
+  exchangeDate?: string;
+  exchangeWithDate?: string;
+  exchangedDate?: string;
+  exchangedFromDate?: string;
+  exchangedToDate?: string;
+  originalLessonDate?: string;
+  targetLessonDate?: string;
 }
 
 export type LessonListItemDto = LessonSummaryResponseDto;

--- a/app/staff/class-management/class-journal/new/page.tsx
+++ b/app/staff/class-management/class-journal/new/page.tsx
@@ -1,0 +1,5 @@
+import ClassJournalCreatePage from "@/components/staff/class-management/class-journal/ClassJournalCreatePage";
+
+export default function Page() {
+  return <ClassJournalCreatePage />;
+}

--- a/app/staff/class-management/class-journal/page.tsx
+++ b/app/staff/class-management/class-journal/page.tsx
@@ -1,5 +1,10 @@
-import ClassJournalCreatePage from "@/components/staff/class-management/class-journal/ClassJournalCreatePage";
+import { Suspense } from "react";
+import ClassJournalListPageClient from "@/components/staff/class-management/class-journal/ClassJournalListPageClient";
 
 export default function Page() {
-  return <ClassJournalCreatePage />;
+  return (
+    <Suspense fallback={null}>
+      <ClassJournalListPageClient />
+    </Suspense>
+  );
 }

--- a/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
+++ b/app/staff/class-management/exchange-request/ExchangeListPageClient.tsx
@@ -107,6 +107,7 @@ export default function ExchangeListPageClient() {
       mineOnly={mineOnly}
       emptyMessage={emptyMessage}
       headerTone="journal"
+      lineTone="muted"
       writeTone="archive"
       writeIcon={<IconEdit aria-hidden="true" size={16} stroke={2} />}
       searchSlot={

--- a/app/staff/class-management/page.tsx
+++ b/app/staff/class-management/page.tsx
@@ -1,10 +1,5 @@
-import { Suspense } from "react";
-import ClassJournalListPageClient from "@/components/staff/class-management/class-journal/ClassJournalListPageClient";
+import { redirect } from "next/navigation";
 
 export default function StaffClassPage() {
-  return (
-    <Suspense fallback={null}>
-      <ClassJournalListPageClient />
-    </Suspense>
-  );
+  redirect("/staff/class-management/weekly-schedule");
 }

--- a/app/staff/class-management/weekly-schedule/page.tsx
+++ b/app/staff/class-management/weekly-schedule/page.tsx
@@ -1,0 +1,5 @@
+import WeeklySchedulePageClient from "@/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient";
+
+export default function StaffWeeklySchedulePage() {
+  return <WeeklySchedulePageClient />;
+}

--- a/app/staff/page.tsx
+++ b/app/staff/page.tsx
@@ -1,5 +1,5 @@
-import PageTemplate from "@/components/common/PageTemplate";
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  return <PageTemplate title="교원" description="교원 페이지입니다." />;
+  redirect("/staff/class-management/weekly-schedule");
 }

--- a/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
+++ b/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
@@ -106,6 +106,7 @@ export default function AbsenceListPageClient() {
       showMineOnlyToggle={false}
       emptyMessage={emptyMessage}
       headerTone="journal"
+      lineTone="muted"
       writeTone="archive"
       writeIcon={<IconEdit aria-hidden="true" size={16} stroke={2} />}
       searchSlot={

--- a/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
+++ b/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import type { FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import styled, { css } from "styled-components";
 import { createAbsenceRequest } from "@/api/request/request.api";
 import { getCurrentUser } from "@/api/user/user.api";
 import { queryKeys } from "@/lib/queryKeys";
+import { parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 export default function AbsenceRequestForm() {
+  const [lessonDateText, setLessonDateText] = useState("");
+  const lessonDateInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const currentUserQuery = useQuery({
     queryKey: queryKeys.user.me(),
@@ -41,6 +45,26 @@ export default function AbsenceRequestForm() {
     },
   });
 
+  const handleOpenDatePicker = (ref: React.RefObject<HTMLInputElement | null>) => {
+    const dateInput = ref.current;
+    if (!dateInput) return;
+
+    if (typeof dateInput.showPicker === "function") {
+      dateInput.showPicker();
+      return;
+    }
+
+    dateInput.click();
+  };
+
+  const handleDateChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (!value) return;
+
+    const [year, month, day] = value.split("-");
+    setLessonDateText(`${year.slice(-2)}.${month}.${day}`);
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -48,7 +72,7 @@ export default function AbsenceRequestForm() {
 
     const formData = new FormData(event.currentTarget);
     const title = String(formData.get("title") ?? "").trim();
-    const lessonDate = String(formData.get("lessonDate") ?? "").trim();
+    const lessonDate = parseKoreanShortDateToIsoDate(lessonDateText.trim());
     const reason = String(formData.get("reason") ?? "").trim();
 
     if (!title || !lessonDate || !reason) {
@@ -78,35 +102,60 @@ export default function AbsenceRequestForm() {
         <Section>
           <SectionTitle>신청자 정보</SectionTitle>
 
-          <InfoRow>
-            <FieldLabel htmlFor="className">반 이름</FieldLabel>
-            {hasMultipleClassNames ? (
-              <InlineSelect id="className" name="className" defaultValue="">
-                <option value="" disabled>
-                  반 이름을 선택해 주세요
-                </option>
-                {assignmentClassNames.map((name) => (
-                  <option key={name} value={name}>
-                    {name}
+          <InfoStack>
+            <InfoPairRow>
+              <FieldLabel htmlFor="className">반 이름</FieldLabel>
+              {hasMultipleClassNames ? (
+                <InlineSelect id="className" name="className" defaultValue="">
+                  <option value="" disabled>
+                    반 이름을 선택해 주세요
                   </option>
-                ))}
-              </InlineSelect>
-            ) : (
-              <InlineInput
-                id="className"
-                name="className"
-                placeholder="개나리반"
-                value={className}
-                readOnly
-              />
-            )}
+                  {assignmentClassNames.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </InlineSelect>
+              ) : (
+                <InlineInput
+                  id="className"
+                  name="className"
+                  placeholder="반 이름"
+                  value={className}
+                  readOnly
+                />
+              )}
 
-            <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
-            <InlineInput id="lessonDate" name="lessonDate" type="date" />
+              <FieldLabel htmlFor="writer">작성자</FieldLabel>
+              <InlineInput id="writer" name="writer" placeholder="홍길동" value={writerName} readOnly />
 
-            <FieldLabel htmlFor="writer">작성자</FieldLabel>
-            <InlineInput id="writer" name="writer" placeholder="홍길동" value={writerName} readOnly />
-          </InfoRow>
+              <FieldLabel htmlFor="lessonDate">수업 일자</FieldLabel>
+              <DateRow>
+                <DateInput
+                  id="lessonDate"
+                  name="lessonDate"
+                  placeholder="00.00.00"
+                  value={lessonDateText}
+                  readOnly
+                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
+                />
+                <HiddenNativeDateInput
+                  ref={lessonDateInputRef}
+                  type="date"
+                  onChange={handleDateChange}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                />
+                <CalendarButton
+                  type="button"
+                  aria-label="수업 일자 달력 열기"
+                  onClick={() => handleOpenDatePicker(lessonDateInputRef)}
+                >
+                  <IconCalendarMonth size={16} stroke={2} color={colors.white} />
+                </CalendarButton>
+              </DateRow>
+            </InfoPairRow>
+          </InfoStack>
         </Section>
 
         <Section>
@@ -122,8 +171,8 @@ const inputStyle = css`
   min-width: 0;
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
-  border: 0;
-  background: ${colors.background};
+  border: 1px solid #c0c0c0;
+  background: transparent;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 400;
@@ -131,7 +180,7 @@ const inputStyle = css`
   outline: none;
 
   &::placeholder {
-    color: #b1b1b1;
+    color: #c0c0c0;
   }
 
   @media (min-width: 120rem) {
@@ -161,10 +210,10 @@ const HeaderRow = styled.div`
   align-items: flex-start;
   justify-content: space-between;
   gap: ${spacing.space24};
-  margin-bottom: 2.125rem;
+  margin-bottom: 2.625rem;
 
   @media (min-width: 120rem) {
-    margin-bottom: 3.1875rem;
+    margin-bottom: 3.9375rem;
   }
 
   @media (max-width: ${layout.breakpointMobile}) {
@@ -174,9 +223,8 @@ const HeaderRow = styled.div`
 
 const Title = styled.h1`
   margin: 0;
-  color: #000000;
-  font-size: ${typography.fontSize20};
-  font-weight: 600;
+  font-size: ${typography.fontSize24};
+  font-weight: 500;
   line-height: ${typography.lineHeight130};
 
   @media (min-width: 120rem) {
@@ -232,7 +280,7 @@ const Form = styled.form`
 const Section = styled.section`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.space12};
+  gap: ${spacing.space16};
 
   @media (min-width: 120rem) {
     gap: 1.875rem;
@@ -241,7 +289,6 @@ const Section = styled.section`
 
 const labelStyle = css`
   margin: 0;
-  color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 600;
   line-height: ${typography.lineHeight130};
@@ -282,11 +329,26 @@ const InlineSelect = styled.select`
 const TitleInput = styled.input`
   ${inputStyle}
   width: 100%;
+  font-weight: 600;
 `;
 
-const InfoRow = styled.div`
+const InfoStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+`;
+
+const InfoPairRow = styled.div`
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns:
+    auto minmax(0, 1fr)
+    auto minmax(0, 1fr)
+    auto auto;
+
   align-items: center;
   gap: ${spacing.space12};
 
@@ -300,9 +362,8 @@ const InfoRow = styled.div`
 `;
 
 const FieldLabel = styled.label`
-  color: #000000;
   font-size: ${typography.fontSize14};
-  font-weight: 600;
+  font-weight: 500;
   line-height: ${typography.lineHeight130};
   white-space: nowrap;
 
@@ -314,9 +375,9 @@ const FieldLabel = styled.label`
 const TextArea = styled.textarea`
   width: 100%;
   min-height: 6.875rem;
-  padding: 0.75rem ${spacing.space12};
-  border: 0;
-  background: ${colors.background};
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid #c0c0c0;
+  background: transparent;
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 500;
@@ -325,12 +386,71 @@ const TextArea = styled.textarea`
   outline: none;
 
   &::placeholder {
-    color: #b1b1b1;
+    color: #c0c0c0;
   }
 
   @media (min-width: 120rem) {
     min-height: 9.6875rem;
-    padding: 1.1875rem ${spacing.space20};
+    padding: ${spacing.space20};
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const DateRow = styled.div`
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  min-width: 7.75rem;
+  justify-content: space-between;
+  width: 7.75rem;
+  min-height: 2.6875rem;
+  padding: 0.4375rem ${spacing.space12};
+  border: 1px solid #c0c0c0;
+  outline: none;
+
+  @media (min-width: 120rem) {
+    width: 11.625rem;
+    min-height: 4rem;
+    padding: 0.625rem ${spacing.space20};
+  }
+`;
+
+const DateInput = styled.input`
+  width: 4.375rem;
+  background: transparent;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    width: 6.25rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const HiddenNativeDateInput = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+`;
+
+const CalendarButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 50%;
+  background: ${colors.point};
+  color: ${colors.white};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
   }
 `;

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import type {
   DailyScheduleLessonResponseDto,
@@ -14,10 +15,12 @@ import {
   getDailyScheduleDetailIfExists,
   updateStudentAttendances,
 } from "@/api/dailySchedule/dailySchedule.api";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import { getMyLessons } from "@/api/lesson/lesson.api";
 import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
-import type { UserTeacherAssignmentResponseDto } from "@/api/user/user.dto";
-import { getCurrentUser } from "@/api/user/user.api";
+import { getMyAssignedSubjects } from "@/api/subject/subject.api";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { buildClassAttendanceSheetPayload } from "@/lib/googleSheet/classAttendance/classAttendanceSheetPayload";
 import { sendClassAttendanceToGoogleSheet } from "@/lib/googleSheet/classAttendance/sendClassAttendanceToGoogleSheet";
 import {
@@ -29,41 +32,17 @@ import { queryKeys } from "@/lib/queryKeys";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 import { getKstTodayIsoDate, parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import {
+  buildTodayLessonOptions,
+  buildTodayLessonOptionsFromSubjects,
+  formatLessonRange,
+} from "./classJournalCreateState";
 
 const lessonPeriods = [1, 2, 3] as const;
 const attendanceColumns = Array.from({ length: 10 }, (_, index) => index);
 
-/** TODO: users/me에서 classroomId를 안정적으로 내려주기 전까지 조회 기본값으로 사용 */
-const CLASS_JOURNAL_DEFAULT_CLASSROOM_ID = 1;
-
 function buildAttendanceNameKey(rowIndex: number, column: number) {
   return `${rowIndex}-${column}`;
-}
-
-interface ResolvedTeacherAssignment {
-  subjectName: string;
-  classroomId: number;
-  classroomName: string;
-}
-
-function resolveTeacherAssignmentClassroomId(assignment: UserTeacherAssignmentResponseDto) {
-  const rawClassroomId = assignment.classroomId ?? assignment.classNameId;
-  const parsedClassroomId = Number.parseInt(String(rawClassroomId ?? ""), 10);
-
-  if (!Number.isFinite(parsedClassroomId) || parsedClassroomId <= 0) return null;
-  return parsedClassroomId;
-}
-
-function normalizeTeacherAssignments(teacherAssignments: UserTeacherAssignmentResponseDto[]) {
-  return teacherAssignments.flatMap((assignment, index) => {
-    const classroomId = resolveTeacherAssignmentClassroomId(assignment);
-    if (!classroomId) return [];
-
-    const classroomName = assignment.classroomName?.trim() ?? "";
-    const subjectName = assignment.subjectName?.trim() || classroomName || `수업 ${index + 1}`;
-
-    return [{ subjectName, classroomId, classroomName }];
-  });
 }
 
 function resolveClassroomName(
@@ -78,22 +57,6 @@ function resolveClassroomName(
     .find((classroom) => classroom.id === classroomId)?.name;
 
   return fromStudents?.trim() ? fromStudents : "";
-}
-
-function trimTrailingClockSeconds(time?: string) {
-  if (!time) return "";
-  return time.endsWith(":00") ? time.slice(0, -3) : time;
-}
-
-function formatLessonsActivityTime(lessons?: DailyScheduleLessonResponseDto[]) {
-  if (!lessons?.length) return "";
-
-  const sorted = [...lessons].sort((a, b) => (a.period ?? 0) - (b.period ?? 0));
-  const start = trimTrailingClockSeconds(sorted[0]?.startTime);
-  const end = trimTrailingClockSeconds(sorted[sorted.length - 1]?.endTime);
-
-  if (start && end) return `${start} - ${end}`;
-  return start || end || "";
 }
 
 function buildStudentAttendances(
@@ -118,7 +81,10 @@ function buildStudentAttendances(
 }
 
 function buildLessonJournals(
-  lessons: DailyScheduleLessonResponseDto[] | undefined,
+  lessons: Array<
+    Pick<DailyScheduleLessonResponseDto, "lessonId" | "period"> |
+    Pick<LessonSummaryResponseDto, "lessonId" | "period">
+  > | undefined,
   formData: FormData,
 ): LessonJournalRequestDto[] {
   const orderedLessons = [...(lessons ?? [])]
@@ -145,58 +111,47 @@ export default function ClassJournalCreatePage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const todayIsoDate = useMemo(() => getKstTodayIsoDate(), []);
-  const [lessonDateText, setLessonDateText] = useState("");
-  const [classroomNameText, setClassroomNameText] = useState("");
-  const [activityTimeText, setActivityTimeText] = useState("");
   const [attendanceNameOverrides, setAttendanceNameOverrides] = useState<Record<string, string>>({});
   const [additionalAttendanceRows, setAdditionalAttendanceRows] = useState(0);
+  const { status: authStatus, user: currentUser } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
+  const currentUserId = currentUser?.id ?? null;
 
-  const currentUserQuery = useQuery({
-    queryKey: queryKeys.user.me(),
-    queryFn: getCurrentUser,
+  const myTodayLessonsQuery = useQuery({
+    queryKey: ["lessons", "me", currentUserId, "today", todayIsoDate] as const,
+    queryFn: () => getMyLessons({ from: todayIsoDate, to: todayIsoDate }),
+    enabled: isAuthenticated,
     retry: false,
     refetchOnMount: "always",
   });
 
-  const currentUser = currentUserQuery.isFetchedAfterMount ? currentUserQuery.data : undefined;
-  const teacherAssignments = currentUser?.teacherAssignments ?? [];
-  const resolvedTeacherAssignments = useMemo(
-    () => normalizeTeacherAssignments(teacherAssignments),
-    [teacherAssignments],
+  const myAssignedSubjectsQuery = useQuery({
+    queryKey: ["subjects", "me", currentUserId, "today", todayIsoDate] as const,
+    queryFn: getMyAssignedSubjects,
+    enabled: isAuthenticated,
+    retry: false,
+    refetchOnMount: "always",
+  });
+
+  const lessonBackedOptions = useMemo(
+    () => buildTodayLessonOptions(myTodayLessonsQuery.data ?? []),
+    [myTodayLessonsQuery.data],
   );
-  const hasMultipleTeacherAssignments = resolvedTeacherAssignments.length > 1;
-  const [selectedAssignmentClassroomId, setSelectedAssignmentClassroomId] = useState<number | null>(
-    null,
+  const subjectBackedOptions = useMemo(
+    () => buildTodayLessonOptionsFromSubjects(myAssignedSubjectsQuery.data ?? [], todayIsoDate),
+    [myAssignedSubjectsQuery.data, todayIsoDate],
   );
+  const todayLessonOptions = lessonBackedOptions.length > 0 ? lessonBackedOptions : subjectBackedOptions;
+  const hasTodayLessons = todayLessonOptions.length > 0;
+  const showNoClassNotice =
+    myTodayLessonsQuery.isFetched && myAssignedSubjectsQuery.isFetched && !hasTodayLessons;
 
-  useEffect(() => {
-    if (!hasMultipleTeacherAssignments) {
-      if (selectedAssignmentClassroomId !== null) setSelectedAssignmentClassroomId(null);
-      return;
-    }
+  const selectedTodayLesson = useMemo(() => {
+    if (!todayLessonOptions.length) return null;
+    return todayLessonOptions[0];
+  }, [todayLessonOptions]);
 
-    const hasSelectedAssignment = resolvedTeacherAssignments.some(
-      (assignment) => assignment.classroomId === selectedAssignmentClassroomId,
-    );
-
-    if (!hasSelectedAssignment) {
-      setSelectedAssignmentClassroomId(resolvedTeacherAssignments[0]?.classroomId ?? null);
-    }
-  }, [hasMultipleTeacherAssignments, resolvedTeacherAssignments, selectedAssignmentClassroomId]);
-
-  const selectedTeacherAssignment = useMemo(() => {
-    if (hasMultipleTeacherAssignments) {
-      return (
-        resolvedTeacherAssignments.find(
-          (assignment) => assignment.classroomId === selectedAssignmentClassroomId,
-        ) ?? resolvedTeacherAssignments[0]
-      );
-    }
-
-    return resolvedTeacherAssignments[0];
-  }, [hasMultipleTeacherAssignments, resolvedTeacherAssignments, selectedAssignmentClassroomId]);
-
-  const enrollmentClassroomId = selectedTeacherAssignment?.classroomId ?? CLASS_JOURNAL_DEFAULT_CLASSROOM_ID;
+  const enrollmentClassroomId = selectedTodayLesson?.classroomId ?? 0;
 
   const studentsQuery = useQuery({
     queryKey: queryKeys.students.list({
@@ -208,7 +163,7 @@ export default function ClassJournalCreatePage() {
         classroomId: enrollmentClassroomId as number,
         status: "ENROLLED",
       }),
-    enabled: typeof enrollmentClassroomId === "number" && enrollmentClassroomId > 0,
+    enabled: enrollmentClassroomId > 0,
     retry: false,
   });
 
@@ -226,21 +181,17 @@ export default function ClassJournalCreatePage() {
         classroomId: enrollmentClassroomId,
         lessonDate: todayIsoDate,
       }),
-    enabled:
-      enrollmentClassroomId > 0 &&
-      (!hasMultipleTeacherAssignments || selectedAssignmentClassroomId !== null),
+    enabled: enrollmentClassroomId > 0,
     retry: false,
   });
 
   const submitMutation = useMutation({
     mutationFn: async ({
       journalBody,
-      dailyScheduleId,
       attendances,
       googleSheet,
     }: {
       journalBody: Parameters<typeof createJournal>[0];
-      dailyScheduleId: number;
       attendances: UpdateDailyStudentAttendanceItemRequestDto[];
       googleSheet: {
         journal: ReturnType<typeof buildClassJournalSheetPayloadFromFormData>;
@@ -248,9 +199,10 @@ export default function ClassJournalCreatePage() {
       };
     }) => {
       const journal = await createJournal(journalBody);
+      const dailyScheduleId = journal.dailyScheduleId;
 
       const schedule =
-        attendances.length > 0
+        typeof dailyScheduleId === "number" && attendances.length > 0
           ? await updateStudentAttendances({ dailyScheduleId }, { attendances })
           : journal;
 
@@ -272,15 +224,15 @@ export default function ClassJournalCreatePage() {
       await queryClient.invalidateQueries({ queryKey: ["daily-schedules", "list"] });
       queryClient.setQueryData(["daily-schedules", "detail", data.dailyScheduleId], data);
 
-      window.alert("수업 일지가 등록되었습니다.");
+      toast.success("수업 일지가 등록되었습니다.");
       if (data.dailyScheduleId) {
         router.push(`/staff/class-management/${data.dailyScheduleId}`);
         return;
       }
-      router.push("/staff/class-management");
+      router.push("/staff/class-management/class-journal");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "수업 일지 등록에 실패했습니다.");
+      toast.error(error instanceof Error ? error.message : "수업 일지 등록에 실패했습니다.");
     },
   });
 
@@ -291,14 +243,22 @@ export default function ClassJournalCreatePage() {
   const phoneNumber = currentUser?.phoneNumber ?? "";
 
   const resolvedLessonDate = useMemo(() => {
-    if (!scheduleDetail?.lessonDate) return "";
-    return formatUtcToKstShortDate(`${scheduleDetail.lessonDate}T00:00:00`);
-  }, [scheduleDetail?.lessonDate]);
+    if (scheduleDetail?.lessonDate) {
+      return formatUtcToKstShortDate(`${scheduleDetail.lessonDate}T00:00:00`);
+    }
+    if (selectedTodayLesson?.lessonDate) {
+      return formatUtcToKstShortDate(`${selectedTodayLesson.lessonDate}T00:00:00`);
+    }
+    return "";
+  }, [scheduleDetail?.lessonDate, selectedTodayLesson?.lessonDate]);
 
   const resolvedActivityTime = useMemo(
-    () => formatLessonsActivityTime(scheduleDetail?.lessons),
-    [scheduleDetail?.lessons],
+    () => formatLessonRange(scheduleDetail?.lessons ?? []) || selectedTodayLesson?.activityTime || "",
+    [scheduleDetail?.lessons, selectedTodayLesson?.activityTime],
   );
+  const journalSourceLessons = (
+    scheduleDetail?.lessons?.length ? scheduleDetail.lessons : myTodayLessonsQuery.data ?? []
+  ).filter((lesson) => typeof lesson.lessonId === "number");
 
   const resolvedClassroomName = useMemo(
     () =>
@@ -309,11 +269,12 @@ export default function ClassJournalCreatePage() {
       ),
     [enrollmentClassroomId, enrolledStudents, scheduleDetail?.classroomName],
   );
-  const assignedClassroomName = selectedTeacherAssignment?.classroomName?.trim() ?? "";
+  const selectedClassroomName = selectedTodayLesson?.classroomName?.trim() ?? "";
+  const hasResolvedSchedule = Boolean(selectedTodayLesson);
 
-  const lessonDateValue = lessonDateText || resolvedLessonDate;
-  const classroomNameValue = classroomNameText || assignedClassroomName || resolvedClassroomName;
-  const activityTimeValue = activityTimeText || resolvedActivityTime;
+  const lessonDateValue = resolvedLessonDate || (hasResolvedSchedule ? todayIsoDate.slice(2).replace(/-/g, ".") : "-");
+  const classroomNameValue = selectedClassroomName || resolvedClassroomName || "-";
+  const activityTimeValue = resolvedActivityTime || "-";
 
   const apiAttendanceNames = useMemo(() => {
     const names: Record<string, string> = {};
@@ -343,32 +304,34 @@ export default function ClassJournalCreatePage() {
     event.preventDefault();
 
     if (isSubmitting) return;
+    if (!hasTodayLessons) {
+      toast.info("오늘은 수업이 없습니다.");
+      return;
+    }
 
     const form = event.currentTarget;
     const formData = new FormData(form);
     const lessonDate = parseKoreanShortDateToIsoDate(lessonDateValue.trim());
     const parsedClassroomId = enrollmentClassroomId;
     const personalInfoConsent = formData.get("privacyConsent") === "on";
-    const lessonJournals = buildLessonJournals(scheduleDetail?.lessons, formData);
+    const lessonJournals = buildLessonJournals(journalSourceLessons, formData);
 
     if (!lessonDate) {
-      window.alert("활동 일자를 00.00.00 형식으로 입력해 주세요.");
+      toast.error("활동 일자를 00.00.00 형식으로 입력해 주세요.");
       return;
     }
 
     if (!Number.isInteger(parsedClassroomId) || parsedClassroomId <= 0) {
-      window.alert("담당 수업 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
+      toast.error("담당 수업 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
       return;
     }
 
     if (!personalInfoConsent) {
-      window.alert("개인정보 제공 동의가 필요합니다.");
+      toast.error("개인정보 제공 동의가 필요합니다.");
       return;
     }
-
-    const dailyScheduleId = scheduleDetail?.dailyScheduleId;
-    if (!dailyScheduleId) {
-      window.alert("일정 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
+    if (lessonJournals.length === 0) {
+      toast.error("수업 내용을 한 교시 이상 입력해 주세요.");
       return;
     }
 
@@ -376,7 +339,6 @@ export default function ClassJournalCreatePage() {
       birthPrefix.trim();
 
     submitMutation.mutate({
-      dailyScheduleId,
       attendances: buildStudentAttendances(formData, enrolledStudents),
       journalBody: {
         lessonDate,
@@ -411,13 +373,20 @@ export default function ClassJournalCreatePage() {
             />
             <span>정보 제공 동의</span>
           </ConsentLabel>
-          <SubmitButton type="submit" form="class-journal-form" disabled={isSubmitting}>
+          <SubmitButton
+            type="submit"
+            form="class-journal-form"
+            disabled={isSubmitting || !hasTodayLessons}
+          >
             {isSubmitting ? "제출 중..." : "수업 일지 제출하기"}
           </SubmitButton>
         </HeaderActions>
       </HeaderRow>
 
       <Form id="class-journal-form" onSubmit={handleSubmit}>
+        {showNoClassNotice ? (
+          <NoClassNotice role="status">오늘은 수업이 없습니다.</NoClassNotice>
+        ) : null}
         <InfoGrid>
           <InfoField>
             <FieldLabel htmlFor="writer">작성자</FieldLabel>
@@ -456,76 +425,41 @@ export default function ClassJournalCreatePage() {
           </InfoField>
 
           <InfoField>
-            <FieldLabel htmlFor="subjectName">과목</FieldLabel>
-            {hasMultipleTeacherAssignments ? (
-              <SubjectSelect
-                id="subjectName"
-                name="subjectName"
-                value={String(selectedAssignmentClassroomId ?? "")}
-                onChange={(event) => {
-                  const nextClassroomId = Number.parseInt(event.target.value, 10);
-                  setSelectedAssignmentClassroomId(
-                    Number.isFinite(nextClassroomId) && nextClassroomId > 0
-                      ? nextClassroomId
-                      : null,
-                  );
-                }}
-              >
-                {resolvedTeacherAssignments.map((assignment) => (
-                  <option
-                    key={`${assignment.classroomId}-${assignment.subjectName}`}
-                    value={assignment.classroomId}
-                  >
-                    {assignment.subjectName}
-                  </option>
-                ))}
-              </SubjectSelect>
-            ) : (
-              <ReadOnlyFieldInput
-                id="subjectName"
-                name="subjectName"
-                type="text"
-                value={resolvedTeacherAssignments[0]?.subjectName ?? ""}
-                placeholder="과목"
-                disabled
-                readOnly
-              />
-            )}
-          </InfoField>
-
-          <InfoField>
             <FieldLabel htmlFor="classroomName">담당 반</FieldLabel>
-            <EditableFieldInput
+            <ReadOnlyFieldInput
               id="classroomName"
               name="classroomName"
               type="text"
-              placeholder="장미반"
+              placeholder="-"
               value={classroomNameValue}
-              onChange={(event) => setClassroomNameText(event.target.value)}
+              disabled
+              readOnly
             />
           </InfoField>
 
           <InfoField>
             <FieldLabel htmlFor="lessonDate">활동 일자</FieldLabel>
-            <EditableFieldInput
+            <ReadOnlyFieldInput
               id="lessonDate"
               name="lessonDate"
               type="text"
-              placeholder="00.00.00"
+              placeholder="-"
               value={lessonDateValue}
-              onChange={(event) => setLessonDateText(event.target.value)}
+              disabled
+              readOnly
             />
           </InfoField>
 
           <InfoField>
             <FieldLabel htmlFor="activityTime">활동 시간</FieldLabel>
-            <EditableFieldInput
+            <ReadOnlyFieldInput
               id="activityTime"
               name="activityTime"
               type="text"
-              placeholder="14:00 - 15:00"
+              placeholder="-"
               value={activityTimeValue}
-              onChange={(event) => setActivityTimeText(event.target.value)}
+              disabled
+              readOnly
             />
           </InfoField>
         </InfoGrid>
@@ -539,6 +473,7 @@ export default function ClassJournalCreatePage() {
                 id={`lesson-${period}`}
                 name={`lesson${period}`}
                 placeholder={`${period}교시 수업 내용을 작성해주세요`}
+                disabled={!hasTodayLessons}
               />
             </LessonField>
           ))}
@@ -562,6 +497,7 @@ export default function ClassJournalCreatePage() {
                         name={`studentName${rowIndex * 10 + column + 1}`}
                         aria-label={`${rowIndex * 10 + column + 1}번 학생 이름`}
                         value={getAttendanceName(nameKey)}
+                        disabled={!hasTodayLessons}
                         onChange={(event) =>
                           setAttendanceNameOverrides((current) => ({
                             ...current,
@@ -580,6 +516,7 @@ export default function ClassJournalCreatePage() {
                           type="checkbox"
                           name={`attendanceStatus${statusIndex}`}
                           aria-label={`${statusIndex}번 출석`}
+                          disabled={!hasTodayLessons}
                         />
                       </AttendanceCheckboxCell>
                     );
@@ -589,6 +526,7 @@ export default function ClassJournalCreatePage() {
             </AttendanceBlocks>
             <AddAttendanceButton
               type="button"
+              disabled={!hasTodayLessons}
               onClick={() => setAdditionalAttendanceRows((count) => count + 1)}
             >
               출석부 추가하기
@@ -752,6 +690,22 @@ const Form = styled.form`
   }
 `;
 
+const NoClassNotice = styled.p`
+  margin: 0;
+  padding: ${spacing.space16} ${spacing.space20};
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius12};
+  background-color: #fdeceb;
+  color: #b24d46;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
 const InfoGrid = styled.section`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -833,17 +787,6 @@ const FieldInput = styled.input`
 const ReadOnlyFieldInput = styled(FieldInput)`
   color: #6d6d6d;
   cursor: not-allowed;
-`;
-
-const EditableFieldInput = styled(FieldInput)`
-  color: #000000;
-`;
-
-const SubjectSelect = styled.select`
-  ${fieldBaseStyle}
-  color: #000000;
-  appearance: none;
-  cursor: pointer;
 `;
 
 const LessonSection = styled.section`
@@ -980,8 +923,13 @@ const AddAttendanceButton = styled.button`
   line-height: ${typography.lineHeight130};
   cursor: pointer;
 
-  &:hover {
+  &:not(:disabled):hover {
     filter: brightness(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
   }
 
   @media (min-width: 120rem) {

--- a/components/staff/class-management/class-journal/ClassJournalDetailPageClient.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalDetailPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -79,7 +79,7 @@ export default function ClassJournalDetailPageClient({
 }: ClassJournalDetailPageClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { status: authStatus } = useAuthSession();
+  const { status: authStatus, user } = useAuthSession();
   const isAuthenticated = authStatus === "authenticated";
   const [isEditing, setIsEditing] = useState(false);
   const [editableNotes, setEditableNotes] = useState(["", "", ""]);
@@ -99,7 +99,7 @@ export default function ClassJournalDetailPageClient({
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["daily-schedules", "list"] });
       window.alert("수업 일지가 삭제되었습니다.");
-      router.push("/staff/class-management");
+      router.push("/staff/class-management/class-journal");
     },
     onError: (error) => {
       window.alert(error instanceof Error ? error.message : "수업 일지 삭제에 실패했습니다.");
@@ -138,15 +138,15 @@ export default function ClassJournalDetailPageClient({
     ? mapClassJournalDetailView(scheduleQuery.data)
     : emptyJournal;
 
-  useEffect(() => {
-    if (!scheduleQuery.data) return;
-    setEditableNotes(mapClassJournalDetailView(scheduleQuery.data).lessons);
-    setEditableAttendance(
-      mapStudentAttendancesToPresentFlags(scheduleQuery.data.studentAttendances),
-    );
-  }, [scheduleQuery.data]);
-
   const isSubmitting = updateJournalMutation.isPending || deleteJournalMutation.isPending;
+  const canManageJournal =
+    isAuthenticated &&
+    Boolean(
+      user?.role === "ADMIN" ||
+        (typeof user?.id === "number" &&
+          typeof scheduleQuery.data?.teacherId === "number" &&
+          user.id === scheduleQuery.data.teacherId),
+    );
 
   const handleDeleteClick = () => {
     if (deleteJournalMutation.isPending) return;
@@ -170,23 +170,27 @@ export default function ClassJournalDetailPageClient({
   return (
     <PageSection>
       <ButtonRow>
-        <ActionButton
-          type="button"
-          $variant="danger"
-          disabled={isSubmitting}
-          onClick={handleDeleteClick}
-        >
-          {deleteJournalMutation.isPending ? "삭제 중..." : "삭제"}
-        </ActionButton>
-        <ActionButton
-          type="button"
-          $variant="edit"
-          disabled={isSubmitting || !scheduleQuery.data}
-          onClick={handleEditClick}
-        >
-          {updateJournalMutation.isPending ? "저장 중..." : isEditing ? "저장" : "수정"}
-        </ActionButton>
-        <LinkButton href="/staff/class-management">목록</LinkButton>
+        {canManageJournal ? (
+          <>
+            <ActionButton
+              type="button"
+              $variant="danger"
+              disabled={isSubmitting}
+              onClick={handleDeleteClick}
+            >
+              {deleteJournalMutation.isPending ? "삭제 중..." : "삭제"}
+            </ActionButton>
+            <ActionButton
+              type="button"
+              $variant="edit"
+              disabled={isSubmitting || !scheduleQuery.data}
+              onClick={handleEditClick}
+            >
+              {updateJournalMutation.isPending ? "저장 중..." : isEditing ? "저장" : "수정"}
+            </ActionButton>
+          </>
+        ) : null}
+        <LinkButton href="/staff/class-management/class-journal">목록</LinkButton>
       </ButtonRow>
 
       <ContentColumn>

--- a/components/staff/class-management/class-journal/ClassJournalListPageClient.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalListPageClient.tsx
@@ -49,7 +49,7 @@ export default function ClassJournalListPageClient() {
         <Title>수업 일지</Title>
         <ActionGroup>
           <ActionButton type="button">수업 일지 출력</ActionButton>
-          <ActionLink href="/staff/class-management/class-journal">
+          <ActionLink href="/staff/class-management/class-journal/new">
             <span>새 수업 일지 작성하기</span>
             <IconEdit aria-hidden="true" size={16} stroke={2} />
           </ActionLink>

--- a/components/staff/class-management/class-journal/classJournalCreateState.test.ts
+++ b/components/staff/class-management/class-journal/classJournalCreateState.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import {
+  buildTodayLessonOptions,
+  buildTodayLessonOptionsFromSubjects,
+  formatLessonRange,
+} from "./classJournalCreateState";
+
+describe("classJournalCreateState", () => {
+  it("builds grouped today lesson options by classroom", () => {
+    const lessons: LessonSummaryResponseDto[] = [
+      {
+        lessonId: 1,
+        date: "2026-06-16",
+        period: 2,
+        startTime: "20:00:00",
+        endTime: "21:00:00",
+        subjectName: "생활 문해",
+        classroomId: 3,
+        classroomName: "장미반",
+      },
+      {
+        lessonId: 2,
+        date: "2026-06-16",
+        period: 1,
+        startTime: "19:00:00",
+        endTime: "20:00:00",
+        subjectName: "한글 기초",
+        classroomId: 3,
+        classroomName: "장미반",
+      },
+    ];
+
+    expect(buildTodayLessonOptions(lessons)).toEqual([
+      {
+        classroomId: 3,
+        classroomName: "장미반",
+        subjectName: "생활 문해",
+        activityTime: "19:00 - 21:00",
+        lessonDate: "2026-06-16",
+        source: "lesson",
+      },
+    ]);
+  });
+
+  it("skips cancelled lessons when building today lesson options", () => {
+    const lessons: LessonSummaryResponseDto[] = [
+      {
+        lessonId: 1,
+        date: "2026-06-16",
+        period: 1,
+        startTime: "19:00:00",
+        endTime: "20:00:00",
+        subjectName: "한글 기초",
+        classroomId: 3,
+        classroomName: "장미반",
+        status: "CANCELED",
+      },
+    ];
+
+    expect(buildTodayLessonOptions(lessons)).toEqual([]);
+  });
+
+  it("formats lesson range from first start to last end", () => {
+    expect(
+      formatLessonRange([
+        { period: 3, startTime: "21:00:00", endTime: "22:00:00" },
+        { period: 1, startTime: "19:00:00", endTime: "20:00:00" },
+      ]),
+    ).toBe("19:00 - 22:00");
+  });
+
+  it("builds fallback today lesson options from assigned subjects", () => {
+    const subjects: SubjectDetailResponseDto[] = [
+      {
+        classroomId: 5,
+        classroomName: "벚꽃반",
+        name: "한글 읽기",
+        dayOfWeek: "MONDAY",
+        period: 1,
+        startAt: "2026-06-01",
+        endAt: "2026-06-30",
+        startTime: "19:00:00",
+        endTime: "20:00:00",
+        isActive: true,
+      },
+      {
+        classroomId: 5,
+        classroomName: "벚꽃반",
+        name: "생활 문해",
+        dayOfWeek: "MONDAY",
+        period: 2,
+        startAt: "2026-06-01",
+        endAt: "2026-06-30",
+        startTime: "20:00:00",
+        endTime: "21:00:00",
+        isActive: true,
+      },
+    ];
+
+    expect(buildTodayLessonOptionsFromSubjects(subjects, "2026-06-22")).toEqual([
+      {
+        classroomId: 5,
+        classroomName: "벚꽃반",
+        subjectName: "한글 읽기",
+        activityTime: "19:00 - 21:00",
+        lessonDate: "2026-06-22",
+        source: "subject",
+      },
+    ]);
+  });
+
+  it("treats subjects without isActive as active by default", () => {
+    const subjects: SubjectDetailResponseDto[] = [
+      {
+        classroomId: 7,
+        classroomName: "목련반",
+        name: "기초 수학",
+        dayOfWeek: "MONDAY",
+        period: 1,
+        startAt: "2026-06-01",
+        endAt: "2026-06-30",
+        startTime: "18:00:00",
+        endTime: "19:00:00",
+      },
+    ];
+
+    expect(buildTodayLessonOptionsFromSubjects(subjects, "2026-06-22")).toEqual([
+      {
+        classroomId: 7,
+        classroomName: "목련반",
+        subjectName: "기초 수학",
+        activityTime: "18:00 - 19:00",
+        lessonDate: "2026-06-22",
+        source: "subject",
+      },
+    ]);
+  });
+});

--- a/components/staff/class-management/class-journal/classJournalCreateState.ts
+++ b/components/staff/class-management/class-journal/classJournalCreateState.ts
@@ -1,0 +1,118 @@
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import type { SubjectDayOfWeek, SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+
+export type TodayLessonOption = {
+  classroomId: number;
+  classroomName: string;
+  subjectName: string;
+  activityTime: string;
+  lessonDate: string;
+  source: "lesson" | "subject";
+};
+
+function trimTrailingClockSeconds(time?: string) {
+  if (!time) return "";
+  return time.endsWith(":00") ? time.slice(0, -3) : time;
+}
+
+export function formatLessonRange(lessons: LessonSummaryResponseDto[]) {
+  if (!lessons.length) return "";
+
+  const sorted = [...lessons].sort((a, b) => (a.period ?? 0) - (b.period ?? 0));
+  const start = trimTrailingClockSeconds(sorted[0]?.startTime);
+  const end = trimTrailingClockSeconds(sorted[sorted.length - 1]?.endTime);
+
+  if (start && end) return `${start} - ${end}`;
+  return start || end || "";
+}
+
+export function buildTodayLessonOptions(lessons: LessonSummaryResponseDto[]) {
+  const grouped = new Map<string, LessonSummaryResponseDto[]>();
+
+  for (const lesson of lessons) {
+    if (typeof lesson.classroomId !== "number" || !lesson.date) continue;
+    if (lesson.status === "CANCELED" || lesson.status === "CANCELLED") continue;
+
+    const key = `${lesson.classroomId}:${lesson.date}`;
+    const current = grouped.get(key) ?? [];
+    current.push(lesson);
+    grouped.set(key, current);
+  }
+
+  return [...grouped.values()]
+    .flatMap((group) => {
+      const first = group[0];
+      const classroomId = first?.classroomId;
+      const lessonDate = first?.date;
+
+      if (typeof classroomId !== "number" || !lessonDate) return [];
+
+      return [{
+        classroomId,
+        classroomName: first.classroomName?.trim() || "",
+        subjectName: first.subjectName?.trim() || "",
+        activityTime: formatLessonRange(group),
+        lessonDate,
+        source: "lesson",
+      } satisfies TodayLessonOption];
+    })
+    .sort((a, b) => {
+      if (a.lessonDate !== b.lessonDate) return a.lessonDate.localeCompare(b.lessonDate);
+      return a.classroomId - b.classroomId;
+    });
+}
+
+function mapIsoDayToSubjectDay(isoDate: string): SubjectDayOfWeek {
+  const day = new Date(`${isoDate}T00:00:00`).getDay();
+  if (day === 0) return "SUNDAY";
+  if (day === 1) return "MONDAY";
+  if (day === 2) return "TUESDAY";
+  if (day === 3) return "WEDNESDAY";
+  if (day === 4) return "THURSDAY";
+  if (day === 5) return "FRIDAY";
+  return "SATURDAY";
+}
+
+export function buildTodayLessonOptionsFromSubjects(
+  subjects: SubjectDetailResponseDto[],
+  isoDate: string,
+) {
+  const todayDayOfWeek = mapIsoDayToSubjectDay(isoDate);
+  const grouped = new Map<number, SubjectDetailResponseDto[]>();
+
+  for (const subject of subjects
+    .filter((subject) => {
+      if (subject.isActive === false) return false;
+      if (typeof subject.classroomId !== "number") return false;
+      if (subject.dayOfWeek !== todayDayOfWeek) return false;
+      if (subject.startAt && subject.startAt > isoDate) return false;
+      if (subject.endAt && subject.endAt < isoDate) return false;
+      return true;
+    })
+  ) {
+    const classroomId = subject.classroomId as number;
+    const current = grouped.get(classroomId) ?? [];
+    current.push(subject);
+    grouped.set(classroomId, current);
+  }
+
+  return [...grouped.entries()]
+    .map(([classroomId, group]) => {
+      const first = group[0];
+      return {
+        classroomId,
+        classroomName: first?.classroomName?.trim() || "",
+        subjectName: first?.name?.trim() || "",
+        activityTime: formatLessonRange(
+          group.map((subject) => ({
+            period: subject.period,
+            startTime: subject.startTime,
+            endTime: subject.endTime,
+          })),
+        ),
+        lessonDate: isoDate,
+        source: "subject",
+      } satisfies TodayLessonOption;
+    })
+    .sort((a, b) => a.classroomId - b.classroomId);
+}

--- a/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
+++ b/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
@@ -1,0 +1,986 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import styled from "styled-components";
+import { IconCalendarMonth } from "@tabler/icons-react";
+import { getClassrooms } from "@/api/classroom/classroom.api";
+import type { ClassroomListItemDto, ClassroomType } from "@/api/classroom/classroom.dto";
+import { getDailySchedules } from "@/api/dailySchedule/dailySchedule.api";
+import { getLessons } from "@/api/lesson/lesson.api";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import { getSubjects } from "@/api/subject/subject.api";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import {
+  filterActiveSubjects,
+  formatSubjectTeacherName,
+} from "@/components/admin/subjects/shared/subjectDisplay";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import {
+  DISPLAY_PERIODS,
+  WEEKDAY_COLUMNS,
+  WEEKEND_COLUMNS,
+  buildScheduleOverrides,
+  getDateForColumn,
+  getPeriodSubject,
+  getSubjectsForCell,
+  getWeekRange,
+  type WeeklyScheduleOverride,
+} from "./weeklyScheduleState";
+
+const DEFAULT_PERIOD_COLORS: Record<(typeof DISPLAY_PERIODS)[number], string> = {
+  1: colors.noticeSoft,
+  2: "#e7e9ff",
+  3: "#e6f6ea",
+};
+
+const PERIOD_COLOR_TEXT: Record<(typeof DISPLAY_PERIODS)[number], string> = {
+  1: "#9d2e28",
+  2: "#3c48c7",
+  3: "#26964a",
+};
+
+type PeriodNumber = (typeof DISPLAY_PERIODS)[number];
+
+type ScheduleCellSelection = {
+  classroomName: string;
+  classroomType?: ClassroomType;
+  date: string;
+  dayLabel: string;
+  teacherName: string;
+  periods: Array<{
+    period: number;
+    subjectName: string;
+    status?: WeeklyScheduleOverride["status"];
+    exchangeDescription?: string;
+    startTime?: string;
+    endTime?: string;
+  }>;
+};
+
+type ScheduleTableProps = {
+  title: string;
+  classrooms: ClassroomListItemDto[];
+  subjects: SubjectDetailResponseDto[];
+  columns: typeof WEEKDAY_COLUMNS | typeof WEEKEND_COLUMNS;
+  weekStartDate: string;
+  lessons: Awaited<ReturnType<typeof getLessons>>;
+  dailySchedules: Awaited<ReturnType<typeof getDailySchedules>>["content"];
+  onSelectCell: (selection: ScheduleCellSelection) => void;
+};
+
+function getClassroomId(classroom: ClassroomListItemDto) {
+  return typeof classroom.id === "number" ? classroom.id : null;
+}
+
+function isClassroomType(classroom: ClassroomListItemDto, type: "WEEKDAY" | "WEEKEND") {
+  return classroom.type === type;
+}
+
+function sortClassrooms(classrooms: ClassroomListItemDto[]) {
+  return [...classrooms].sort((a, b) => {
+    const aId = getClassroomId(a) ?? Number.MAX_SAFE_INTEGER;
+    const bId = getClassroomId(b) ?? Number.MAX_SAFE_INTEGER;
+    return aId - bId;
+  });
+}
+
+function formatClassroomTypeLabel(type?: ClassroomType) {
+  if (type === "WEEKDAY") return "주중";
+  if (type === "WEEKEND") return "주말";
+  return "기타";
+}
+
+function getTeacherName(subjects: SubjectDetailResponseDto[], override?: WeeklyScheduleOverride) {
+  if (override?.teacherName?.trim()) return formatSubjectTeacherName(override.teacherName);
+
+  const teacherName = subjects.find((subject) => subject.teacherName?.trim())?.teacherName;
+  return teacherName ? formatSubjectTeacherName(teacherName) : "담당 교사 미배정";
+}
+
+function hasAssignedTeacher(
+  subjects: SubjectDetailResponseDto[],
+  override?: WeeklyScheduleOverride,
+) {
+  return (
+    Boolean(override?.teacherName?.trim()) ||
+    subjects.some((subject) => subject.teacherName?.trim())
+  );
+}
+
+function formatSubjectName(subject?: SubjectDetailResponseDto, override?: WeeklyScheduleOverride) {
+  if (override?.subjectName?.trim()) return override.subjectName;
+  return subject?.name?.trim() || "미등록";
+}
+
+function formatExchangeDescription(override: WeeklyScheduleOverride) {
+  if (override.status !== "EXCHANGED") return "";
+  if (!override.relatedDate) return "교환된 수업";
+  return `${override.relatedDate} 수업과 교환`;
+}
+
+function formatWeekNavigatorLabel(weekStartDate: string) {
+  const start = dayjs(weekStartDate);
+  const month = start.format("MM");
+  const weekOfMonth = Math.ceil(start.date() / 7);
+  return `${month}월 ${weekOfMonth}주차`;
+}
+
+function formatHeaderDate(weekStartDate: string, isoWeekday: number) {
+  return dayjs(getDateForColumn(weekStartDate, isoWeekday)).format("MM/DD");
+}
+
+function formatLessonTime(
+  subject: SubjectDetailResponseDto | undefined,
+  lesson: LessonSummaryResponseDto | undefined,
+) {
+  const startTime = lesson?.startTime ?? subject?.startTime;
+  const endTime = lesson?.endTime ?? subject?.endTime;
+  if (!startTime || !endTime) return "";
+  return `${startTime.slice(0, 5)} - ${endTime.slice(0, 5)}`;
+}
+
+function getLessonForCell(
+  lessons: LessonSummaryResponseDto[],
+  classroomId: number | null,
+  date: string,
+  period: number,
+) {
+  if (classroomId == null) return undefined;
+  return lessons.find(
+    (lesson) =>
+      lesson.classroomId === classroomId && lesson.date === date && lesson.period === period,
+  );
+}
+
+function ScheduleTable({
+  title,
+  classrooms,
+  subjects,
+  columns,
+  weekStartDate,
+  lessons,
+  dailySchedules,
+  onSelectCell,
+}: ScheduleTableProps) {
+  return (
+    <TableBlock>
+      <ScheduleTitle>{title}</ScheduleTitle>
+      <TableScroll>
+        <ScheduleGrid $columns={columns.length + 1}>
+          <HeaderCell aria-label="분반" />
+          {columns.map((column) => (
+            <HeaderCell key={column.value}>
+              <HeaderDay>{column.label}</HeaderDay>
+              <HeaderDate>{formatHeaderDate(weekStartDate, column.isoWeekday)}</HeaderDate>
+            </HeaderCell>
+          ))}
+
+          {classrooms.map((classroom) => {
+            const classroomId = getClassroomId(classroom);
+
+            return (
+              <RowFragment key={classroomId ?? classroom.name}>
+                <ClassroomCell>
+                  <ClassroomName>{classroom.name ?? "이름 없음"}</ClassroomName>
+                  <ClassroomType>{formatClassroomTypeLabel(classroom.type)}</ClassroomType>
+                </ClassroomCell>
+                {columns.map((column) => {
+                  const date = getDateForColumn(weekStartDate, column.isoWeekday);
+                  const cellSubjects = getSubjectsForCell(subjects, classroomId, column.value);
+                  const overrides = buildScheduleOverrides(
+                    cellSubjects,
+                    lessons,
+                    dailySchedules,
+                    classroomId,
+                    date,
+                  );
+                  const firstOverride = [...overrides.values()][0];
+                  const hasRegisteredSubject = cellSubjects.length > 0;
+                  const hasTeacher = hasAssignedTeacher(cellSubjects, firstOverride);
+                  const teacherName = getTeacherName(cellSubjects, firstOverride);
+                  const periodDetails = DISPLAY_PERIODS.map((period) => {
+                    const subject = getPeriodSubject(cellSubjects, period);
+                    const override = overrides.get(period);
+                    const lesson = getLessonForCell(lessons, classroomId, date, period);
+
+                    return {
+                      period,
+                      subjectName: formatSubjectName(subject, override),
+                      status: override?.status,
+                      exchangeDescription:
+                        override?.status === "EXCHANGED"
+                          ? formatExchangeDescription(override)
+                          : undefined,
+                      startTime: formatLessonTime(subject, lesson) || undefined,
+                      endTime: undefined,
+                    };
+                  });
+
+                  return (
+                    <ScheduleCellButton
+                      key={`${classroomId}-${column.value}`}
+                      type="button"
+                      $hasStatus={Boolean(firstOverride)}
+                      onClick={() =>
+                        onSelectCell({
+                          classroomName: classroom.name ?? "이름 없음",
+                          classroomType: classroom.type,
+                          date,
+                          dayLabel: column.label,
+                          teacherName,
+                          periods: periodDetails,
+                        })
+                      }
+                    >
+                      {firstOverride ? (
+                        <StatusPill $status={firstOverride.status}>
+                          {firstOverride.status === "EXCHANGED" ? "교환" : "결강"}
+                        </StatusPill>
+                      ) : null}
+                      {hasRegisteredSubject ? (
+                        <TeacherName $assigned={hasTeacher}>
+                          {getTeacherName(cellSubjects, firstOverride)}
+                        </TeacherName>
+                      ) : (
+                        <EmptyText>담당 교사 미배정</EmptyText>
+                      )}
+                      <PeriodList>
+                        {DISPLAY_PERIODS.map((period) => {
+                          const subject = getPeriodSubject(cellSubjects, period);
+                          const override = overrides.get(period);
+
+                          return (
+                            <PeriodItem key={period}>
+                              <PeriodBadge>{period}교시</PeriodBadge>
+                              <SubjectBlock
+                                $period={period}
+                                $status={override?.status}
+                                $empty={!subject && !override}
+                              >
+                                <SubjectNameText>
+                                  {formatSubjectName(subject, override)}
+                                </SubjectNameText>
+                                {override?.status === "EXCHANGED" ? (
+                                  <ExchangeText>{formatExchangeDescription(override)}</ExchangeText>
+                                ) : null}
+                              </SubjectBlock>
+                            </PeriodItem>
+                          );
+                        })}
+                      </PeriodList>
+                    </ScheduleCellButton>
+                  );
+                })}
+              </RowFragment>
+            );
+          })}
+        </ScheduleGrid>
+      </TableScroll>
+    </TableBlock>
+  );
+}
+
+export default function WeeklySchedulePageClient() {
+  const { status: authStatus } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
+  const [anchorDate, setAnchorDate] = useState(() => new Date());
+  const [selectedCell, setSelectedCell] = useState<ScheduleCellSelection | null>(null);
+  const weekRange = useMemo(() => getWeekRange(anchorDate), [anchorDate]);
+  const datePickerRef = useRef<HTMLInputElement | null>(null);
+
+  const classroomsQuery = useQuery({
+    queryKey: queryKeys.classrooms.list(),
+    queryFn: () => getClassrooms({ page: 0, size: 100 }),
+    enabled: isAuthenticated,
+  });
+
+  const subjectsQuery = useQuery({
+    queryKey: queryKeys.admin.subjects(),
+    queryFn: () => getSubjects(),
+    enabled: isAuthenticated,
+  });
+
+  const lessonsQuery = useQuery({
+    queryKey: queryKeys.lessons.weekly(weekRange.from, weekRange.to),
+    queryFn: () => getLessons({ from: weekRange.from, to: weekRange.to }),
+    enabled: isAuthenticated,
+  });
+
+  const dailySchedulesQuery = useQuery({
+    queryKey: ["daily-schedules", "weekly-schedule", weekRange.from, weekRange.to] as const,
+    queryFn: () => getDailySchedules({ page: 0, size: 100 }),
+    enabled: isAuthenticated,
+  });
+
+  const classrooms = useMemo(
+    () => sortClassrooms(classroomsQuery.data?.content ?? []),
+    [classroomsQuery.data?.content],
+  );
+  const subjects = useMemo(() => {
+    const items = Array.isArray(subjectsQuery.data) ? subjectsQuery.data : [];
+    return filterActiveSubjects(items);
+  }, [subjectsQuery.data]);
+  const dailySchedules = useMemo(
+    () =>
+      (dailySchedulesQuery.data?.content ?? []).filter(
+        (schedule) => schedule.lessonDate >= weekRange.from && schedule.lessonDate <= weekRange.to,
+      ),
+    [dailySchedulesQuery.data?.content, weekRange.from, weekRange.to],
+  );
+
+  const weekdayClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKDAY"));
+  const weekendClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKEND"));
+  const hasClassrooms = weekdayClassrooms.length > 0 || weekendClassrooms.length > 0;
+  const isBaseLoading = classroomsQuery.isLoading || subjectsQuery.isLoading;
+  const isBaseError = classroomsQuery.isError || subjectsQuery.isError;
+  const hasScheduleOverlayError = lessonsQuery.isError || dailySchedulesQuery.isError;
+
+  const openDatePicker = () => {
+    const input = datePickerRef.current;
+    if (!input) return;
+    if ("showPicker" in input && typeof input.showPicker === "function") {
+      input.showPicker();
+      return;
+    }
+    input.click();
+  };
+
+  return (
+    <PageSection>
+      <HeaderRow>
+        <HeaderCopy>
+          <Title>시간표</Title>
+          <Description>
+            {weekRange.from} ~ {weekRange.to}
+          </Description>
+        </HeaderCopy>
+        <WeekNavigator aria-label="주간 시간표 이동">
+          <WeekArrowButton
+            type="button"
+            onClick={() => setAnchorDate(dayjs(anchorDate).subtract(1, "week").toDate())}
+            aria-label="이전 주"
+          >
+            ◀
+          </WeekArrowButton>
+          <WeekNavigatorLabel
+            type="button"
+            onClick={() => setAnchorDate(new Date())}
+            aria-label="이번 주로 이동"
+          >
+            {formatWeekNavigatorLabel(weekRange.from)}
+          </WeekNavigatorLabel>
+          <WeekArrowButton
+            type="button"
+            onClick={() => setAnchorDate(dayjs(anchorDate).add(1, "week").toDate())}
+            aria-label="다음 주"
+          >
+            ▶
+          </WeekArrowButton>
+          <CalendarButton type="button" aria-label="날짜 선택" onClick={openDatePicker}>
+            <IconCalendarMonth className="calendar-icon" stroke={1.8} />
+          </CalendarButton>
+          <HiddenDateInput
+            ref={datePickerRef}
+            type="date"
+            value={dayjs(anchorDate).format("YYYY-MM-DD")}
+            onChange={(event) => {
+              if (!event.target.value) return;
+              setAnchorDate(dayjs(event.target.value).toDate());
+            }}
+          />
+        </WeekNavigator>
+      </HeaderRow>
+
+      {isBaseLoading ? <StateText>시간표를 불러오는 중입니다.</StateText> : null}
+      {isBaseError ? <StateText role="alert">시간표를 불러오지 못했습니다.</StateText> : null}
+      {!isBaseLoading && !isBaseError && hasScheduleOverlayError ? (
+        <InlineNotice role="status">
+          교환/결강 반영 정보를 불러오지 못해 기본 시간표만 표시합니다.
+        </InlineNotice>
+      ) : null}
+      {!isBaseLoading && !isBaseError && !hasClassrooms ? (
+        <StateText>주중 또는 주말 분반이 없습니다.</StateText>
+      ) : null}
+      {!isBaseLoading && !isBaseError && hasClassrooms ? (
+        <ScheduleShell>
+          <ScheduleStack>
+            <ScheduleContentTrack>
+              <ScheduleTable
+                title="주중 시간표"
+                classrooms={weekdayClassrooms}
+                subjects={subjects}
+                columns={WEEKDAY_COLUMNS}
+                weekStartDate={weekRange.from}
+                lessons={lessonsQuery.isError ? [] : (lessonsQuery.data ?? [])}
+                dailySchedules={dailySchedulesQuery.isError ? [] : dailySchedules}
+                onSelectCell={setSelectedCell}
+              />
+              <ScheduleTable
+                title="주말 시간표"
+                classrooms={weekendClassrooms}
+                subjects={subjects}
+                columns={WEEKEND_COLUMNS}
+                weekStartDate={weekRange.from}
+                lessons={lessonsQuery.isError ? [] : (lessonsQuery.data ?? [])}
+                dailySchedules={dailySchedulesQuery.isError ? [] : dailySchedules}
+                onSelectCell={setSelectedCell}
+              />
+            </ScheduleContentTrack>
+          </ScheduleStack>
+        </ScheduleShell>
+      ) : null}
+
+      {selectedCell ? (
+        <ModalBackdrop onMouseDown={() => setSelectedCell(null)}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="weekly-schedule-detail-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <div>
+                <ModalTitle id="weekly-schedule-detail-title">
+                  {selectedCell.classroomName} {selectedCell.dayLabel}요일 수업
+                </ModalTitle>
+                <ModalDescription>
+                  {selectedCell.date} · {selectedCell.teacherName}
+                </ModalDescription>
+              </div>
+              <CloseButton type="button" onClick={() => setSelectedCell(null)}>
+                닫기
+              </CloseButton>
+            </ModalHeader>
+            <ModalPeriodList>
+              {selectedCell.periods.map((period) => (
+                <ModalPeriodCard key={period.period}>
+                  <ModalPeriodHeading>{period.period}교시</ModalPeriodHeading>
+                  <ModalPeriodSubject>{period.subjectName}</ModalPeriodSubject>
+                  {period.startTime ? <ModalPeriodTime>{period.startTime}</ModalPeriodTime> : null}
+                  {period.status === "EXCHANGED" ? (
+                    <ModalStatusText $status="EXCHANGED">
+                      교환 · {period.exchangeDescription ?? "교환된 수업"}
+                    </ModalStatusText>
+                  ) : null}
+                  {period.status === "CANCELLED" ? (
+                    <ModalStatusText $status="CANCELLED">결강</ModalStatusText>
+                  ) : null}
+                </ModalPeriodCard>
+              ))}
+            </ModalPeriodList>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+    </PageSection>
+  );
+}
+
+const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 3.125rem 3rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 4rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: ${spacing.space24};
+  margin-bottom: ${spacing.space16};
+  border-bottom: 1px solid ${colors.border};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+`;
+
+const HeaderCopy = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: 2.5rem;
+  }
+`;
+
+const Description = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ScheduleShell = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const WeekNavigator = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+`;
+
+const WeekArrowButton = styled.button`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #b8b8b8;
+  font-family: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: 900;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    color: #7f7f7f;
+    outline: none;
+  }
+`;
+
+const WeekNavigatorLabel = styled.button`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #303030;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    color: #111111;
+    outline: none;
+  }
+`;
+
+const CalendarButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.625rem;
+  height: 1.625rem;
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+  color: #7f7f7f;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    border-color: #bdbdbd;
+    color: #404040;
+    outline: none;
+  }
+
+  .calendar-icon {
+    width: 20px;
+    height: 20px;
+    margin-bottom: 0.9px;
+  }
+
+  @media (min-width: 120rem) {
+    .calendar-icon {
+      width: 22px;
+      height: 22px;
+      margin-bottom: 3px;
+    }
+  }
+`;
+
+const HiddenDateInput = styled.input`
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+`;
+
+const StateText = styled.p`
+  margin: 0;
+  padding: ${spacing.space24};
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius12};
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+`;
+
+const ScheduleStack = styled.div`
+  overflow-x: auto;
+  overflow-y: hidden;
+`;
+
+const ScheduleContentTrack = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: ${spacing.space20};
+  width: max-content;
+`;
+
+const TableBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+  flex: 0 0 auto;
+`;
+
+const ScheduleTitle = styled.h2`
+  margin: 0;
+  color: #1f2b28;
+  font-size: ${typography.fontSize16};
+  font-weight: 900;
+  line-height: 1.25rem;
+`;
+
+const TableScroll = styled.div`
+  overflow-x: visible;
+`;
+
+const ScheduleGrid = styled.div<{ $columns: number }>`
+  display: grid;
+  grid-template-columns: 8.5rem repeat(${({ $columns }) => $columns - 1}, 10.5rem);
+  width: max-content;
+  border-right: 1px solid ${colors.borderStrong};
+  border-bottom: 1px solid ${colors.borderStrong};
+  border-radius: 0.25rem;
+  overflow: hidden;
+
+  @media (min-width: 120rem) {
+    grid-template-columns: 10rem repeat(${({ $columns }) => $columns - 1}, 12.5rem);
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 8rem repeat(${({ $columns }) => $columns - 1}, 9.75rem);
+  }
+`;
+
+const RowFragment = styled.div`
+  display: contents;
+`;
+
+const BaseCell = styled.div`
+  min-width: 0;
+  border-top: 1px solid ${colors.borderStrong};
+  border-left: 1px solid ${colors.borderStrong};
+`;
+
+const HeaderCell = styled(BaseCell)`
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 0.125rem;
+  min-height: 3.25rem;
+  padding: ${spacing.space8} ${spacing.space12};
+  background-color: ${colors.pointSoft};
+  color: #111;
+  line-height: ${typography.lineHeight130};
+`;
+
+const HeaderDay = styled.span`
+  font-size: ${typography.fontSize14};
+  font-weight: 900;
+`;
+
+const HeaderDate = styled.span`
+  color: #64706c;
+  font-size: 0.6875rem;
+  font-weight: 700;
+`;
+
+const ClassroomCell = styled(BaseCell)`
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: ${spacing.space4};
+  min-height: 7rem;
+  padding: ${spacing.space12};
+  background-color: ${colors.pointSoft};
+  text-align: center;
+`;
+
+const ClassroomName = styled.span`
+  color: #111;
+  font-size: ${typography.fontSize14};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+  word-break: keep-all;
+`;
+
+const ClassroomType = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ScheduleCellButton = styled.button<{ $hasStatus: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space4};
+  min-height: 7rem;
+  padding: ${({ $hasStatus }) =>
+    $hasStatus
+      ? `1.5rem ${spacing.space12} ${spacing.space8}`
+      : `${spacing.space8} ${spacing.space12}`};
+  border: 0;
+  border-top: 1px solid ${colors.borderStrong};
+  border-left: 1px solid ${colors.borderStrong};
+  background-color: ${colors.white};
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #fbfcfb;
+  }
+
+  &:focus-visible {
+    box-shadow: inset 0 0 0 1px ${colors.point};
+    outline: none;
+  }
+`;
+
+const StatusPill = styled.span<{ $status: "EXCHANGED" | "CANCELLED" }>`
+  position: absolute;
+  top: ${spacing.space8};
+  left: ${spacing.space8};
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.125rem;
+  border-radius: ${radii.radius999};
+  background-color: ${({ $status }) => ($status === "EXCHANGED" ? "#eee7ff" : "#fde4e2")};
+  padding: 0 ${spacing.space8};
+  color: ${({ $status }) => ($status === "EXCHANGED" ? "#6846c9" : colors.notice)};
+  font-size: 0.6875rem;
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+`;
+
+const TeacherName = styled.p<{ $assigned: boolean }>`
+  margin: 0;
+  color: ${({ $assigned }) => ($assigned ? "#111" : colors.muted)};
+  font-size: ${typography.fontSize14};
+  font-weight: ${({ $assigned }) => ($assigned ? 900 : 700)};
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+  word-break: keep-all;
+`;
+
+const EmptyText = styled.p`
+  margin: 0;
+  color: ${colors.muted};
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+`;
+
+const PeriodList = styled.div`
+  display: grid;
+  gap: 0.1875rem;
+`;
+
+const PeriodItem = styled.div`
+  display: grid;
+  grid-template-columns: 3.25rem minmax(0, 1fr);
+  gap: ${spacing.space8};
+  align-items: center;
+  min-height: 1.7rem;
+
+  @media (min-width: 120rem) {
+    min-height: 2rem;
+  }
+`;
+
+const PeriodBadge = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const SubjectBlock = styled.span<{
+  $status?: "EXCHANGED" | "CANCELLED";
+  $empty: boolean;
+  $period: number;
+}>`
+  display: grid;
+  align-items: center;
+  justify-self: end;
+  box-sizing: border-box;
+  width: 6.4rem;
+  min-height: ${({ $status }) => ($status === "EXCHANGED" ? "2rem" : "1.25rem")};
+  padding: 0 ${spacing.space8};
+  border-radius: ${radii.radius999};
+  background-color: ${({ $status, $empty, $period }) => {
+    if ($status === "EXCHANGED") return "#eee7ff";
+    if ($status === "CANCELLED") return "#fde4e2";
+    return $empty ? "#f1f3f2" : DEFAULT_PERIOD_COLORS[$period as PeriodNumber];
+  }};
+  color: ${({ $status, $empty, $period }) => {
+    if ($status === "EXCHANGED") return "#6846c9";
+    if ($status === "CANCELLED") return colors.notice;
+    return $empty ? "#7c8581" : (PERIOD_COLOR_TEXT[$period as PeriodNumber] ?? "#1f2b28");
+  }};
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+
+  @media (min-width: 120rem) {
+    width: 8.4rem;
+    height: 1.4rem;
+  }
+`;
+
+const SubjectNameText = styled.span`
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ExchangeText = styled.span`
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const InlineNotice = styled.p`
+  margin: 0 0 ${spacing.space16};
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ModalDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 31rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ModalHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+`;
+
+const ModalTitle = styled.h2`
+  margin: 0;
+  color: #111111;
+  font-size: ${typography.fontSize18};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalDescription = styled.p`
+  margin: ${spacing.space4} 0 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+`;
+
+const CloseButton = styled.button`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #64706c;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+const ModalPeriodList = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const ModalPeriodCard = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+  padding: ${spacing.space12};
+  border: 1px solid ${colors.border};
+  border-radius: ${radii.radius12};
+  background-color: #fcfcfc;
+`;
+
+const ModalPeriodHeading = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalPeriodSubject = styled.p`
+  margin: 0;
+  color: #111111;
+  font-size: ${typography.fontSize16};
+  font-weight: 900;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalPeriodTime = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalStatusText = styled.p<{ $status: "EXCHANGED" | "CANCELLED" }>`
+  margin: 0;
+  color: ${({ $status }) => ($status === "EXCHANGED" ? "#6846c9" : colors.notice)};
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/staff/class-management/weekly-schedule/weeklyScheduleState.test.ts
+++ b/components/staff/class-management/weekly-schedule/weeklyScheduleState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { DailyScheduleSummaryResponseDto } from "@/api/dailySchedule/dailySchedule.dto";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+import { buildScheduleOverrides, getWeekRange } from "./weeklyScheduleState";
+
+const BASE_SUBJECTS: SubjectDetailResponseDto[] = [
+  {
+    id: 1,
+    classroomId: 10,
+    dayOfWeek: "MONDAY",
+    period: 1,
+    name: "국어",
+    teacherName: "김교사",
+  },
+];
+
+describe("weeklyScheduleState", () => {
+  it("marks a period as exchanged when the actual teacher changes", () => {
+    const lessons: LessonSummaryResponseDto[] = [
+      {
+        lessonId: 100,
+        classroomId: 10,
+        date: "2026-06-15",
+        period: 1,
+        teacherName: "이교사",
+        subjectName: "국어",
+        exchangeWithDate: "2026-06-17",
+      },
+    ];
+
+    const overrides = buildScheduleOverrides(BASE_SUBJECTS, lessons, [], 10, "2026-06-15");
+
+    expect(overrides.get(1)).toEqual({
+      status: "EXCHANGED",
+      teacherName: "이교사",
+      subjectName: "국어",
+      relatedDate: "2026-06-17",
+    });
+  });
+
+  it("marks all registered periods as cancelled when the daily schedule is cancelled", () => {
+    const dailySchedules: DailyScheduleSummaryResponseDto[] = [
+      {
+        dailyScheduleId: 1,
+        lessonDate: "2026-06-15",
+        classroomId: 10,
+        classroomName: "장미반",
+        teacherId: 20,
+        teacherName: "김교사",
+        activityStartTime: "19:00:00",
+        activityEndTime: "21:00:00",
+        status: "CANCELLED",
+        lessonCount: 1,
+      },
+    ];
+
+    const overrides = buildScheduleOverrides(BASE_SUBJECTS, [], dailySchedules, 10, "2026-06-15");
+
+    expect(overrides.get(1)).toMatchObject({
+      status: "CANCELLED",
+      teacherName: "김교사",
+    });
+  });
+
+  it("returns the iso week range for the given anchor date", () => {
+    expect(getWeekRange(new Date("2026-06-18T09:00:00+09:00"))).toEqual({
+      from: "2026-06-15",
+      to: "2026-06-21",
+    });
+  });
+});

--- a/components/staff/class-management/weekly-schedule/weeklyScheduleState.ts
+++ b/components/staff/class-management/weekly-schedule/weeklyScheduleState.ts
@@ -1,0 +1,141 @@
+import dayjs from "dayjs";
+import isoWeek from "dayjs/plugin/isoWeek";
+import type { DailyScheduleSummaryResponseDto } from "@/api/dailySchedule/dailySchedule.dto";
+import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import type { SubjectDayOfWeek, SubjectDetailResponseDto } from "@/api/subject/subject.dto";
+
+dayjs.extend(isoWeek);
+
+export const WEEKDAY_COLUMNS: { value: SubjectDayOfWeek; label: string; isoWeekday: number }[] = [
+  { value: "MONDAY", label: "월", isoWeekday: 1 },
+  { value: "TUESDAY", label: "화", isoWeekday: 2 },
+  { value: "WEDNESDAY", label: "수", isoWeekday: 3 },
+  { value: "THURSDAY", label: "목", isoWeekday: 4 },
+  { value: "FRIDAY", label: "금", isoWeekday: 5 },
+];
+
+export const WEEKEND_COLUMNS: { value: SubjectDayOfWeek; label: string; isoWeekday: number }[] = [
+  { value: "SATURDAY", label: "토", isoWeekday: 6 },
+  { value: "SUNDAY", label: "일", isoWeekday: 7 },
+];
+
+export const DISPLAY_PERIODS = [1, 2, 3] as const;
+
+export type WeeklyScheduleStatus = "EXCHANGED" | "CANCELLED";
+
+export type WeeklyScheduleOverride = {
+  status: WeeklyScheduleStatus;
+  teacherName?: string;
+  subjectName?: string;
+  relatedDate?: string;
+};
+
+type LessonWithExchangeFields = LessonSummaryResponseDto & {
+  status?: string;
+  exchangeDate?: string;
+  exchangeWithDate?: string;
+  exchangedDate?: string;
+  exchangedFromDate?: string;
+  exchangedToDate?: string;
+  originalLessonDate?: string;
+  targetLessonDate?: string;
+};
+
+export function getWeekRange(anchorDate = new Date()) {
+  const anchor = dayjs(anchorDate);
+  return {
+    from: anchor.startOf("isoWeek").format("YYYY-MM-DD"),
+    to: anchor.endOf("isoWeek").format("YYYY-MM-DD"),
+  };
+}
+
+export function getDateForColumn(weekStartDate: string, isoWeekday: number) {
+  return dayjs(weekStartDate).isoWeekday(isoWeekday).format("YYYY-MM-DD");
+}
+
+export function getSubjectsForCell(
+  subjects: SubjectDetailResponseDto[],
+  classroomId: number | null,
+  dayOfWeek: SubjectDayOfWeek,
+) {
+  if (classroomId == null) return [];
+
+  return subjects
+    .filter((subject) => subject.classroomId === classroomId && subject.dayOfWeek === dayOfWeek)
+    .sort((a, b) => (a.period ?? 0) - (b.period ?? 0));
+}
+
+export function getPeriodSubject(subjects: SubjectDetailResponseDto[], period: number) {
+  return subjects.find((subject) => subject.period === period);
+}
+
+export function buildScheduleOverrides(
+  cellSubjects: SubjectDetailResponseDto[],
+  lessons: LessonSummaryResponseDto[],
+  dailySchedules: DailyScheduleSummaryResponseDto[],
+  classroomId: number | null,
+  date: string,
+) {
+  const overrides = new Map<number, WeeklyScheduleOverride>();
+  if (classroomId == null) return overrides;
+
+  const dailySchedule = dailySchedules.find(
+    (schedule) => schedule.classroomId === classroomId && schedule.lessonDate === date,
+  );
+
+  if (dailySchedule?.status === "CANCELLED") {
+    for (const subject of cellSubjects) {
+      if (typeof subject.period === "number") {
+        overrides.set(subject.period, {
+          status: "CANCELLED",
+          teacherName: dailySchedule.teacherName,
+        });
+      }
+    }
+  }
+
+  for (const lesson of lessons as LessonWithExchangeFields[]) {
+    if (lesson.classroomId !== classroomId || lesson.date !== date || typeof lesson.period !== "number") {
+      continue;
+    }
+
+    if (lesson.status === "CANCELED" || lesson.status === "CANCELLED") {
+      overrides.set(lesson.period, {
+        status: "CANCELLED",
+        teacherName: lesson.teacherName,
+        subjectName: lesson.subjectName,
+      });
+      continue;
+    }
+
+    const baseSubject = getPeriodSubject(cellSubjects, lesson.period);
+    const hasTeacherChanged =
+      Boolean(baseSubject?.teacherName && lesson.teacherName) &&
+      baseSubject?.teacherName !== lesson.teacherName;
+    const hasSubjectChanged =
+      Boolean(baseSubject?.name && lesson.subjectName) && baseSubject?.name !== lesson.subjectName;
+
+    if (hasTeacherChanged || hasSubjectChanged) {
+      overrides.set(lesson.period, {
+        status: "EXCHANGED",
+        teacherName: lesson.teacherName,
+        subjectName: lesson.subjectName,
+        relatedDate: getExchangeRelatedDate(lesson),
+      });
+    }
+  }
+
+  return overrides;
+}
+
+function getExchangeRelatedDate(lesson: LessonWithExchangeFields) {
+  return (
+    lesson.exchangeWithDate ??
+    lesson.exchangeDate ??
+    lesson.exchangedDate ??
+    lesson.exchangedFromDate ??
+    lesson.exchangedToDate ??
+    lesson.originalLessonDate ??
+    lesson.targetLessonDate
+  );
+}

--- a/components/staff/common/ListPanel.tsx
+++ b/components/staff/common/ListPanel.tsx
@@ -26,6 +26,7 @@ export type ListPanelRow = {
 };
 
 type ListPanelTone = "default" | "journal" | "finance" | "archive";
+type ListPanelLineTone = "default" | "muted";
 
 type ListPanelProps = {
   title: string;
@@ -39,6 +40,7 @@ type ListPanelProps = {
   showMineOnlyToggle?: boolean;
   emptyMessage?: string;
   headerTone?: ListPanelTone;
+  lineTone?: ListPanelLineTone;
   writeTone?: ListPanelTone;
   showClassColumn?: boolean;
   classHeader?: string;
@@ -83,6 +85,7 @@ export default function ListPanel({
   showMineOnlyToggle = true,
   emptyMessage = "목록이 없습니다.",
   headerTone = "default",
+  lineTone = "default",
   writeTone,
   showClassColumn = true,
   classHeader = "반",
@@ -118,23 +121,40 @@ export default function ListPanel({
         <Table>
           <thead>
             <tr>
-              <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone}>
+              <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone} $lineTone={lineTone}>
                 no.
               </Th>
               {showClassColumn ? (
-                <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
+                <Th
+                  $width720="7.125rem"
+                  $width1080="10.75rem"
+                  $tone={headerTone}
+                  $lineTone={lineTone}
+                >
                   {classHeader}
                 </Th>
               ) : null}
-              <Th $tone={headerTone}>제목</Th>
-              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
+              <Th $tone={headerTone} $lineTone={lineTone}>
+                제목
+              </Th>
+              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone} $lineTone={lineTone}>
                 작성자
               </Th>
-              <Th $width720="10.875rem" $width1080="16.3125rem" $tone={headerTone}>
+              <Th
+                $width720="10.875rem"
+                $width1080="16.3125rem"
+                $tone={headerTone}
+                $lineTone={lineTone}
+              >
                 작성일
               </Th>
               {showStatusColumn ? (
-                <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
+                <Th
+                  $width720="5rem"
+                  $width1080="7.375rem"
+                  $tone={headerTone}
+                  $lineTone={lineTone}
+                >
                   {statusHeader}
                 </Th>
               ) : null}
@@ -144,7 +164,7 @@ export default function ListPanel({
           <tbody>
             {rows.length > 0 ? (
               rows.map((row) => (
-                <Tr key={row.id} $tone={headerTone}>
+                <Tr key={row.id} $tone={headerTone} $lineTone={lineTone}>
                   <Td $width720="3.75rem" $width1080="5.5rem" $isNotice={row.isNotice}>
                     {row.no}
                   </Td>
@@ -177,7 +197,7 @@ export default function ListPanel({
                 </Tr>
               ))
             ) : (
-              <Tr $tone={headerTone}>
+              <Tr $tone={headerTone} $lineTone={lineTone}>
                 <EmptyTd colSpan={columnCount}>{emptyMessage}</EmptyTd>
               </Tr>
             )}
@@ -396,11 +416,23 @@ const Table = styled.table`
   table-layout: fixed;
 `;
 
-const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanelTone }>`
+function resolveLineColor(lineTone: ListPanelLineTone, tone: ListPanelTone) {
+  if (lineTone === "muted" || tone === "finance" || tone === "archive") {
+    return colors.muted;
+  }
+
+  return "#6d6d6d";
+}
+
+const Th = styled.th<{
+  $width720?: string;
+  $width1080?: string;
+  $tone: ListPanelTone;
+  $lineTone: ListPanelLineTone;
+}>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
   padding: 0.625rem ${spacing.space12};
-  border-bottom: 1px solid
-    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
+  border-bottom: 1px solid ${({ $lineTone, $tone }) => resolveLineColor($lineTone, $tone)};
   font-size: ${typography.fontSize16};
   font-weight: 700;
   text-align: center;
@@ -413,9 +445,8 @@ const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanel
   }
 `;
 
-const Tr = styled.tr<{ $tone: ListPanelTone }>`
-  border-bottom: 1px solid
-    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
+const Tr = styled.tr<{ $tone: ListPanelTone; $lineTone: ListPanelLineTone }>`
+  border-bottom: 1px solid ${({ $lineTone, $tone }) => resolveLineColor($lineTone, $tone)};
 `;
 
 const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: boolean }>`

--- a/components/staff/common/ListPanel.tsx
+++ b/components/staff/common/ListPanel.tsx
@@ -26,7 +26,6 @@ export type ListPanelRow = {
 };
 
 type ListPanelTone = "default" | "journal" | "finance" | "archive";
-type ListPanelLineTone = "default" | "muted";
 
 type ListPanelProps = {
   title: string;
@@ -40,7 +39,6 @@ type ListPanelProps = {
   showMineOnlyToggle?: boolean;
   emptyMessage?: string;
   headerTone?: ListPanelTone;
-  lineTone?: ListPanelLineTone;
   writeTone?: ListPanelTone;
   showClassColumn?: boolean;
   classHeader?: string;
@@ -85,7 +83,6 @@ export default function ListPanel({
   showMineOnlyToggle = true,
   emptyMessage = "목록이 없습니다.",
   headerTone = "default",
-  lineTone = "default",
   writeTone,
   showClassColumn = true,
   classHeader = "반",
@@ -121,40 +118,23 @@ export default function ListPanel({
         <Table>
           <thead>
             <tr>
-              <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone} $lineTone={lineTone}>
+              <Th $width720="3.75rem" $width1080="5.5rem" $tone={headerTone}>
                 no.
               </Th>
               {showClassColumn ? (
-                <Th
-                  $width720="7.125rem"
-                  $width1080="10.75rem"
-                  $tone={headerTone}
-                  $lineTone={lineTone}
-                >
+                <Th $width720="7.125rem" $width1080="10.75rem" $tone={headerTone}>
                   {classHeader}
                 </Th>
               ) : null}
-              <Th $tone={headerTone} $lineTone={lineTone}>
-                제목
-              </Th>
-              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone} $lineTone={lineTone}>
+              <Th $tone={headerTone}>제목</Th>
+              <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                 작성자
               </Th>
-              <Th
-                $width720="10.875rem"
-                $width1080="16.3125rem"
-                $tone={headerTone}
-                $lineTone={lineTone}
-              >
+              <Th $width720="10.875rem" $width1080="16.3125rem" $tone={headerTone}>
                 작성일
               </Th>
               {showStatusColumn ? (
-                <Th
-                  $width720="5rem"
-                  $width1080="7.375rem"
-                  $tone={headerTone}
-                  $lineTone={lineTone}
-                >
+                <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                   {statusHeader}
                 </Th>
               ) : null}
@@ -164,7 +144,7 @@ export default function ListPanel({
           <tbody>
             {rows.length > 0 ? (
               rows.map((row) => (
-                <Tr key={row.id} $tone={headerTone} $lineTone={lineTone}>
+                <Tr key={row.id} $tone={headerTone}>
                   <Td $width720="3.75rem" $width1080="5.5rem" $isNotice={row.isNotice}>
                     {row.no}
                   </Td>
@@ -175,7 +155,7 @@ export default function ListPanel({
                   ) : null}
                   <TitleTd>
                     <TitleLink href={row.detailHref}>
-                      <TitleContent>
+                      <TitleContent $isPinned={Boolean(row.isPinned)}>
                         {row.isPinned ? (
                           <PinIcon aria-label="고정 게시물" size={16} stroke={2.25} />
                         ) : null}
@@ -197,7 +177,7 @@ export default function ListPanel({
                 </Tr>
               ))
             ) : (
-              <Tr $tone={headerTone} $lineTone={lineTone}>
+              <Tr $tone={headerTone}>
                 <EmptyTd colSpan={columnCount}>{emptyMessage}</EmptyTd>
               </Tr>
             )}
@@ -416,27 +396,16 @@ const Table = styled.table`
   table-layout: fixed;
 `;
 
-function resolveLineColor(lineTone: ListPanelLineTone, tone: ListPanelTone) {
-  if (lineTone === "muted" || tone === "finance" || tone === "archive") {
-    return colors.muted;
-  }
-
-  return "#6d6d6d";
-}
-
-const Th = styled.th<{
-  $width720?: string;
-  $width1080?: string;
-  $tone: ListPanelTone;
-  $lineTone: ListPanelLineTone;
-}>`
+const Th = styled.th<{ $width720?: string; $width1080?: string; $tone: ListPanelTone }>`
   width: ${({ $width720 }) => $width720 ?? "auto"};
   padding: 0.625rem ${spacing.space12};
-  border-bottom: 1px solid ${({ $lineTone, $tone }) => resolveLineColor($lineTone, $tone)};
+  border-bottom: 1px solid
+    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
   font-size: ${typography.fontSize16};
   font-weight: 700;
   text-align: center;
   white-space: nowrap;
+  vertical-align: middle;
 
   @media (min-width: 120rem) {
     width: ${({ $width1080, $width720 }) => $width1080 ?? $width720 ?? "auto"};
@@ -445,8 +414,9 @@ const Th = styled.th<{
   }
 `;
 
-const Tr = styled.tr<{ $tone: ListPanelTone; $lineTone: ListPanelLineTone }>`
-  border-bottom: 1px solid ${({ $lineTone, $tone }) => resolveLineColor($lineTone, $tone)};
+const Tr = styled.tr<{ $tone: ListPanelTone }>`
+  border-bottom: 1px solid
+    ${({ $tone }) => ($tone === "finance" || $tone === "archive" ? colors.muted : "#6d6d6d")};
 `;
 
 const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: boolean }>`
@@ -457,6 +427,7 @@ const Td = styled.td<{ $width720?: string; $width1080?: string; $isNotice?: bool
   font-weight: ${({ $isNotice }) => ($isNotice ? 700 : 400)};
   text-align: center;
   white-space: nowrap;
+  vertical-align: middle;
 
   @media (min-width: 120rem) {
     width: ${({ $width1080, $width720 }) => $width1080 ?? $width720 ?? "auto"};
@@ -479,6 +450,7 @@ const EmptyTd = styled.td`
 `;
 
 const TitleLink = styled(Link)`
+  display: block;
   color: ${colors.text};
   text-decoration: none;
 
@@ -487,23 +459,30 @@ const TitleLink = styled(Link)`
   }
 `;
 
-const TitleContent = styled.span`
-  display: inline-flex;
-  align-items: center;
-  gap: ${spacing.space8};
+const TitleContent = styled.span<{ $isPinned: boolean }>`
+  position: relative;
+  display: block;
   max-width: 100%;
+  padding-left: ${({ $isPinned }) => ($isPinned ? "1.75rem" : "0")};
+`;
+
+const PinIcon = styled(IconPinFilled)`
+  position: absolute;
+  left: 0;
+  top: 50%;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  color: ${colors.point};
+  transform: translateY(-50%);
 `;
 
 const TitleText = styled.span`
+  display: block;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-`;
-
-const PinIcon = styled(IconPinFilled)`
-  flex: 0 0 auto;
-  color: ${colors.point};
 `;
 
 const BottomRow = styled.div<{ $hasToggle: boolean; $hasSearch: boolean }>`
@@ -652,7 +631,6 @@ const StatusBadge = styled.span<{
   align-items: center;
   justify-content: center;
   min-width: 3.5rem;
-
   font-size: ${typography.fontSize14};
 
   color: ${({ $status }) => {

--- a/components/staff/common/StaffSidebar.tsx
+++ b/components/staff/common/StaffSidebar.tsx
@@ -11,6 +11,7 @@ const staffSections = [
   {
     title: "수업 관리",
     items: [
+      { label: "시간표", href: "/staff/class-management/weekly-schedule" },
       { label: "수업 일지", href: "/staff/class-management" },
       { label: "수업 교환 신청", href: "/staff/class-management/exchange-request" },
       { label: "수업 결강 신청", href: "/staff/class-management/absence-request" },
@@ -53,7 +54,9 @@ function isCurrentStaffPath(pathname: string, href: string) {
     return (
       pathname === href ||
       pathname === "/staff/class-management/class-journal" ||
-      /^\/staff\/class\/(?!(exchange|absence)$)[^/]+$/.test(pathname)
+      /^\/staff\/class-management\/(?!(weekly-schedule|exchange-request|absence-request)(\/|$))[^/]+$/.test(
+        pathname,
+      )
     );
   }
 

--- a/components/staff/common/StaffSidebar.tsx
+++ b/components/staff/common/StaffSidebar.tsx
@@ -12,7 +12,7 @@ const staffSections = [
     title: "수업 관리",
     items: [
       { label: "시간표", href: "/staff/class-management/weekly-schedule" },
-      { label: "수업 일지", href: "/staff/class-management" },
+      { label: "수업 일지", href: "/staff/class-management/class-journal" },
       { label: "수업 교환 신청", href: "/staff/class-management/exchange-request" },
       { label: "수업 결강 신청", href: "/staff/class-management/absence-request" },
     ],
@@ -50,10 +50,10 @@ const adminSection = {
 type StaffSection = (typeof staffSections)[number];
 
 function isCurrentStaffPath(pathname: string, href: string) {
-  if (href === "/staff/class-management") {
+  if (href === "/staff/class-management/class-journal") {
     return (
       pathname === href ||
-      pathname === "/staff/class-management/class-journal" ||
+      pathname.startsWith("/staff/class-management/class-journal/") ||
       /^\/staff\/class-management\/(?!(weekly-schedule|exchange-request|absence-request)(\/|$))[^/]+$/.test(
         pathname,
       )

--- a/mocks/home.ts
+++ b/mocks/home.ts
@@ -19,9 +19,9 @@ export const headerMenus: HeaderDropdownMenu[] = [
   },
   {
     label: "교원",
-    href: "/staff/class-management",
+    href: "/staff/class-management/weekly-schedule",
     items: [
-      { label: "수업 관리", href: "/staff/class-management" },
+      { label: "수업 관리", href: "/staff/class-management/weekly-schedule" },
       { label: "재무 관리", href: "/staff/finance-management" },
       { label: "자료실", href: "/staff/archive/school-rules" },
       { label: "게시판", href: "/staff/board" },

--- a/utils/classJournalHref.ts
+++ b/utils/classJournalHref.ts
@@ -4,5 +4,5 @@ export function buildClassJournalHref(page: number, keyword = "", mine = false) 
   if (keyword.trim()) params.set("keyword", keyword.trim());
   if (mine) params.set("mine", "1");
   const query = params.toString();
-  return query ? `/staff/class-management?${query}` : "/staff/class-management";
+  return query ? `/staff/class-management/class-journal?${query}` : "/staff/class-management/class-journal";
 }

--- a/utils/mapClassJournalDetailView.ts
+++ b/utils/mapClassJournalDetailView.ts
@@ -57,7 +57,7 @@ export function buildUpdateJournalBody(
 function formatAttendanceStatus(status?: string) {
   if (status === "PRESENT") return "O";
   if (status === "ABSENT") return "X";
-  if (status === "LATE") return "△";
+  if (status === "LATE") return "X";
   return "";
 }
 


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 수업 관리 섹션 - 주간 시간표 추가

   <img width="1898" height="863" alt="스크린샷 2026-06-17 015513" src="https://github.com/user-attachments/assets/0c154b1a-05b8-4932-b68d-6d0b327b7bd7" />

3. 수업 일지 작성 가능 조건과 제출 오류를 수정
   \- `/api/v1/subjects/me`의 `dayOfWeek` 기준으로 오늘 담당 과목이 있으면 수업 일지 작성이 가능하도록 수정하였습니다.
   \- `lessons/me`가 비어 있어도 오늘 과목이 있으면 입력을 막지 않도록 정리하였습니다.
   \- `dailyScheduleDetail`이 비어 있는 경우에도 `lessons/me`의 `lessonId`를 fallback으로 사용해 `lessonJournals`가 비어 전송되지 않도록 수정하였습니다.
   \- 메모가 하나도 없을 때는 서버 400 이전에 프론트에서 검증 메시지로 차단하였습니다.

4. 수업 일지 화면의 계정 전환/권한 표시 문제를 수정
   \- 로그인 사용자별로 React Query key를 분리하고 `refetchOnMount: "always"`를 적용해 계정 전환 후 stale 데이터가 남지 않도록 수정하였습니다.
   \- 수업 일지 상세의 수정/삭제 버튼은 관리자 또는 작성자 본인에게만 표시되도록 권한 조건 추가하였습니다.
   \- 출석 미체크 표시는 세모 대신 `X`로 통일하였습니다.

5. 결강 신청서 작성 화면 스타일을 수업 교환 신청서와 정렬
   \- 결강 신청서의 헤더/입력 행/날짜 입력/드롭다운/작성자 표시구성을 교환 신청서와 같은 톤으로 조정하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #135 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
