### PR TITLE
[FEAT] 교원 시간표의 교환/결강 상태 표시 기능 추가

### DIFF
--- a/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
+++ b/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
@@ -118,7 +118,7 @@ function formatSubjectName(subject?: SubjectDetailResponseDto, override?: Weekly
 
 function formatExchangeDescription(override: WeeklyScheduleOverride) {
   if (override.status !== "EXCHANGED") return "";
-  if (!override.relatedDate) return "교환된 수업";
+  if (!override.relatedDate) return "교환";
   return `${override.relatedDate} 수업과 교환`;
 }
 
@@ -224,7 +224,7 @@ function ScheduleTable({
                     <ScheduleCellButton
                       key={`${classroomId}-${column.value}`}
                       type="button"
-                      $hasStatus={Boolean(firstOverride)}
+                      $status={firstOverride?.status}
                       onClick={() =>
                         onSelectCell({
                           classroomName: classroom.name ?? "이름 없음",
@@ -236,18 +236,20 @@ function ScheduleTable({
                         })
                       }
                     >
-                      {firstOverride ? (
-                        <StatusPill $status={firstOverride.status}>
-                          {firstOverride.status === "EXCHANGED" ? "교환" : "결강"}
-                        </StatusPill>
-                      ) : null}
-                      {hasRegisteredSubject ? (
-                        <TeacherName $assigned={hasTeacher}>
-                          {getTeacherName(cellSubjects, firstOverride)}
-                        </TeacherName>
-                      ) : (
-                        <EmptyText>담당 교사 미배정</EmptyText>
-                      )}
+                      <TeacherRow>
+                        {firstOverride ? (
+                          <StatusPill $status={firstOverride.status}>
+                            {firstOverride.status === "EXCHANGED" ? "교환" : "결강"}
+                          </StatusPill>
+                        ) : null}
+                        {hasRegisteredSubject ? (
+                          <TeacherName $assigned={hasTeacher}>
+                            {getTeacherName(cellSubjects, firstOverride)}
+                          </TeacherName>
+                        ) : (
+                          <EmptyText>담당 교사 미배정</EmptyText>
+                        )}
+                      </TeacherRow>
                       <PeriodList>
                         {DISPLAY_PERIODS.map((period) => {
                           const subject = getPeriodSubject(cellSubjects, period);
@@ -264,9 +266,6 @@ function ScheduleTable({
                                 <SubjectNameText>
                                   {formatSubjectName(subject, override)}
                                 </SubjectNameText>
-                                {override?.status === "EXCHANGED" ? (
-                                  <ExchangeText>{formatExchangeDescription(override)}</ExchangeText>
-                                ) : null}
                               </SubjectBlock>
                             </PeriodItem>
                           );
@@ -467,7 +466,7 @@ export default function WeeklySchedulePageClient() {
                   {period.startTime ? <ModalPeriodTime>{period.startTime}</ModalPeriodTime> : null}
                   {period.status === "EXCHANGED" ? (
                     <ModalStatusText $status="EXCHANGED">
-                      교환 · {period.exchangeDescription ?? "교환된 수업"}
+                      교환 · {period.exchangeDescription ?? "교환"}
                     </ModalStatusText>
                   ) : null}
                   {period.status === "CANCELLED" ? (
@@ -741,25 +740,29 @@ const ClassroomType = styled.span`
   line-height: ${typography.lineHeight130};
 `;
 
-const ScheduleCellButton = styled.button<{ $hasStatus: boolean }>`
-  position: relative;
+const ScheduleCellButton = styled.button<{ $status?: "EXCHANGED" | "CANCELLED" }>`
   display: grid;
   align-content: start;
   gap: ${spacing.space4};
   min-height: 7rem;
-  padding: ${({ $hasStatus }) =>
-    $hasStatus
-      ? `1.5rem ${spacing.space12} ${spacing.space8}`
-      : `${spacing.space8} ${spacing.space12}`};
+  padding: ${spacing.space8} ${spacing.space12};
   border: 0;
   border-top: 1px solid ${colors.borderStrong};
   border-left: 1px solid ${colors.borderStrong};
-  background-color: ${colors.white};
+  background-color: ${({ $status }) => {
+    if ($status === "EXCHANGED") return "#f4efff";
+    if ($status === "CANCELLED") return "#fff4f3";
+    return colors.white;
+  }};
   text-align: left;
   cursor: pointer;
 
   &:hover {
-    background-color: #fbfcfb;
+    background-color: ${({ $status }) => {
+      if ($status === "EXCHANGED") return "#efe8ff";
+      if ($status === "CANCELLED") return "#ffeceb";
+      return "#fbfcfb";
+    }};
   }
 
   &:focus-visible {
@@ -768,13 +771,19 @@ const ScheduleCellButton = styled.button<{ $hasStatus: boolean }>`
   }
 `;
 
+const TeacherRow = styled.div`
+  position: relative;
+  min-height: 1.5rem;
+`;
+
 const StatusPill = styled.span<{ $status: "EXCHANGED" | "CANCELLED" }>`
   position: absolute;
-  top: ${spacing.space8};
-  left: ${spacing.space8};
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   min-height: 1.125rem;
+  border: 1px solid ${({ $status }) => ($status === "EXCHANGED" ? "#d7cafc" : "#f3b8b2")};
   border-radius: ${radii.radius999};
   background-color: ${({ $status }) => ($status === "EXCHANGED" ? "#eee7ff" : "#fde4e2")};
   padding: 0 ${spacing.space8};
@@ -786,6 +795,7 @@ const StatusPill = styled.span<{ $status: "EXCHANGED" | "CANCELLED" }>`
 
 const TeacherName = styled.p<{ $assigned: boolean }>`
   margin: 0;
+  padding-top: 0.15rem;
   color: ${({ $assigned }) => ($assigned ? "#111" : colors.muted)};
   font-size: ${typography.fontSize14};
   font-weight: ${({ $assigned }) => ($assigned ? 900 : 700)};
@@ -796,8 +806,9 @@ const TeacherName = styled.p<{ $assigned: boolean }>`
 
 const EmptyText = styled.p`
   margin: 0;
+  padding-top: 0.15rem;
   color: ${colors.muted};
-  font-size: ${typography.fontSize13};
+  font-size: ${typography.fontSize14};
   font-weight: 700;
   line-height: ${typography.lineHeight130};
   text-align: center;
@@ -837,16 +848,14 @@ const SubjectBlock = styled.span<{
   justify-self: end;
   box-sizing: border-box;
   width: 6.4rem;
-  min-height: ${({ $status }) => ($status === "EXCHANGED" ? "2rem" : "1.25rem")};
+  min-height: ${({ $status }) => ($status === "EXCHANGED" ? "1.25rem" : "1.25rem")};
   padding: 0 ${spacing.space8};
   border-radius: ${radii.radius999};
   background-color: ${({ $status, $empty, $period }) => {
-    if ($status === "EXCHANGED") return "#eee7ff";
     if ($status === "CANCELLED") return "#fde4e2";
     return $empty ? "#f1f3f2" : DEFAULT_PERIOD_COLORS[$period as PeriodNumber];
   }};
   color: ${({ $status, $empty, $period }) => {
-    if ($status === "EXCHANGED") return "#6846c9";
     if ($status === "CANCELLED") return colors.notice;
     return $empty ? "#7c8581" : (PERIOD_COLOR_TEXT[$period as PeriodNumber] ?? "#1f2b28");
   }};
@@ -866,17 +875,6 @@ const SubjectNameText = styled.span`
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const ExchangeText = styled.span`
-  display: block;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-  font-size: 0.625rem;
-  font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;

--- a/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
+++ b/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
@@ -10,6 +10,8 @@ import type { ClassroomListItemDto, ClassroomType } from "@/api/classroom/classr
 import { getDailySchedules } from "@/api/dailySchedule/dailySchedule.api";
 import { getLessons } from "@/api/lesson/lesson.api";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import { getAbsenceRequests } from "@/api/request/request.api";
+import type { AbsenceRequestResponseDto } from "@/api/request/request.dto";
 import { getSubjects } from "@/api/subject/subject.api";
 import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
 import {
@@ -69,6 +71,7 @@ type ScheduleTableProps = {
   weekStartDate: string;
   lessons: Awaited<ReturnType<typeof getLessons>>;
   dailySchedules: Awaited<ReturnType<typeof getDailySchedules>>["content"];
+  absenceRequests: AbsenceRequestResponseDto[];
   onSelectCell: (selection: ScheduleCellSelection) => void;
 };
 
@@ -164,6 +167,7 @@ function ScheduleTable({
   weekStartDate,
   lessons,
   dailySchedules,
+  absenceRequests,
   onSelectCell,
 }: ScheduleTableProps) {
   return (
@@ -195,6 +199,7 @@ function ScheduleTable({
                     cellSubjects,
                     lessons,
                     dailySchedules,
+                    absenceRequests,
                     classroomId,
                     date,
                   );
@@ -314,6 +319,11 @@ export default function WeeklySchedulePageClient() {
     queryFn: () => getDailySchedules({ page: 0, size: 100 }),
     enabled: isAuthenticated,
   });
+  const absenceRequestsQuery = useQuery({
+    queryKey: [...queryKeys.requests.absenceList(), "weekly-schedule", weekRange.from, weekRange.to],
+    queryFn: () => getAbsenceRequests({ status: "APPROVED", page: 0, size: 100 }),
+    enabled: isAuthenticated,
+  });
 
   const classrooms = useMemo(
     () => sortClassrooms(classroomsQuery.data?.content ?? []),
@@ -330,13 +340,25 @@ export default function WeeklySchedulePageClient() {
       ),
     [dailySchedulesQuery.data?.content, weekRange.from, weekRange.to],
   );
+  const approvedAbsenceRequests = useMemo(
+    () =>
+      (absenceRequestsQuery.data?.content ?? []).filter(
+        (request) =>
+          request.lessonDate &&
+          request.lessonDate >= weekRange.from &&
+          request.lessonDate <= weekRange.to &&
+          request.status === "APPROVED",
+      ),
+    [absenceRequestsQuery.data?.content, weekRange.from, weekRange.to],
+  );
 
   const weekdayClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKDAY"));
   const weekendClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKEND"));
   const hasClassrooms = weekdayClassrooms.length > 0 || weekendClassrooms.length > 0;
   const isBaseLoading = classroomsQuery.isLoading || subjectsQuery.isLoading;
   const isBaseError = classroomsQuery.isError || subjectsQuery.isError;
-  const hasScheduleOverlayError = lessonsQuery.isError || dailySchedulesQuery.isError;
+  const hasScheduleOverlayError =
+    lessonsQuery.isError || dailySchedulesQuery.isError || absenceRequestsQuery.isError;
 
   const openDatePicker = () => {
     const input = datePickerRef.current;
@@ -420,6 +442,7 @@ export default function WeeklySchedulePageClient() {
                 weekStartDate={weekRange.from}
                 lessons={lessonsQuery.isError ? [] : (lessonsQuery.data ?? [])}
                 dailySchedules={dailySchedulesQuery.isError ? [] : dailySchedules}
+                absenceRequests={absenceRequestsQuery.isError ? [] : approvedAbsenceRequests}
                 onSelectCell={setSelectedCell}
               />
               <ScheduleTable
@@ -430,6 +453,7 @@ export default function WeeklySchedulePageClient() {
                 weekStartDate={weekRange.from}
                 lessons={lessonsQuery.isError ? [] : (lessonsQuery.data ?? [])}
                 dailySchedules={dailySchedulesQuery.isError ? [] : dailySchedules}
+                absenceRequests={absenceRequestsQuery.isError ? [] : approvedAbsenceRequests}
                 onSelectCell={setSelectedCell}
               />
             </ScheduleContentTrack>
@@ -848,15 +872,13 @@ const SubjectBlock = styled.span<{
   justify-self: end;
   box-sizing: border-box;
   width: 6.4rem;
-  min-height: ${({ $status }) => ($status === "EXCHANGED" ? "1.25rem" : "1.25rem")};
+  min-height: 1.25rem;
   padding: 0 ${spacing.space8};
   border-radius: ${radii.radius999};
   background-color: ${({ $status, $empty, $period }) => {
-    if ($status === "CANCELLED") return "#fde4e2";
     return $empty ? "#f1f3f2" : DEFAULT_PERIOD_COLORS[$period as PeriodNumber];
   }};
   color: ${({ $status, $empty, $period }) => {
-    if ($status === "CANCELLED") return colors.notice;
     return $empty ? "#7c8581" : (PERIOD_COLOR_TEXT[$period as PeriodNumber] ?? "#1f2b28");
   }};
   font-size: ${typography.fontSize13};

--- a/components/staff/class-management/weekly-schedule/weeklyScheduleState.test.ts
+++ b/components/staff/class-management/weekly-schedule/weeklyScheduleState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { DailyScheduleSummaryResponseDto } from "@/api/dailySchedule/dailySchedule.dto";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import type { AbsenceRequestResponseDto } from "@/api/request/request.dto";
 import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
 import { buildScheduleOverrides, getWeekRange } from "./weeklyScheduleState";
 
@@ -29,7 +30,7 @@ describe("weeklyScheduleState", () => {
       },
     ];
 
-    const overrides = buildScheduleOverrides(BASE_SUBJECTS, lessons, [], 10, "2026-06-15");
+    const overrides = buildScheduleOverrides(BASE_SUBJECTS, lessons, [], [], 10, "2026-06-15");
 
     expect(overrides.get(1)).toEqual({
       status: "EXCHANGED",
@@ -55,7 +56,26 @@ describe("weeklyScheduleState", () => {
       },
     ];
 
-    const overrides = buildScheduleOverrides(BASE_SUBJECTS, [], dailySchedules, 10, "2026-06-15");
+    const overrides = buildScheduleOverrides(BASE_SUBJECTS, [], dailySchedules, [], 10, "2026-06-15");
+
+    expect(overrides.get(1)).toMatchObject({
+      status: "CANCELLED",
+      teacherName: "김교사",
+    });
+  });
+
+  it("marks registered periods as cancelled when an approved absence request exists", () => {
+    const absenceRequests: AbsenceRequestResponseDto[] = [
+      {
+        id: 1,
+        classroomId: 10,
+        lessonDate: "2026-06-15",
+        requestedByName: "김교사",
+        status: "APPROVED",
+      },
+    ];
+
+    const overrides = buildScheduleOverrides(BASE_SUBJECTS, [], [], absenceRequests, 10, "2026-06-15");
 
     expect(overrides.get(1)).toMatchObject({
       status: "CANCELLED",

--- a/components/staff/class-management/weekly-schedule/weeklyScheduleState.ts
+++ b/components/staff/class-management/weekly-schedule/weeklyScheduleState.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import isoWeek from "dayjs/plugin/isoWeek";
 import type { DailyScheduleSummaryResponseDto } from "@/api/dailySchedule/dailySchedule.dto";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
+import type { AbsenceRequestResponseDto } from "@/api/request/request.dto";
 import type { SubjectDayOfWeek, SubjectDetailResponseDto } from "@/api/subject/subject.dto";
 
 dayjs.extend(isoWeek);
@@ -73,6 +74,7 @@ export function buildScheduleOverrides(
   cellSubjects: SubjectDetailResponseDto[],
   lessons: LessonSummaryResponseDto[],
   dailySchedules: DailyScheduleSummaryResponseDto[],
+  absenceRequests: AbsenceRequestResponseDto[],
   classroomId: number | null,
   date: string,
 ) {
@@ -82,13 +84,44 @@ export function buildScheduleOverrides(
   const dailySchedule = dailySchedules.find(
     (schedule) => schedule.classroomId === classroomId && schedule.lessonDate === date,
   );
+  const approvedAbsenceRequest = absenceRequests.find(
+    (request) =>
+      request.classroomId === classroomId &&
+      request.lessonDate === date &&
+      request.status === "APPROVED",
+  );
 
   if (dailySchedule?.status === "CANCELLED") {
+    if (cellSubjects.length === 0) {
+      overrides.set(DISPLAY_PERIODS[0], {
+        status: "CANCELLED",
+        teacherName: dailySchedule.teacherName,
+      });
+    }
+
     for (const subject of cellSubjects) {
       if (typeof subject.period === "number") {
         overrides.set(subject.period, {
           status: "CANCELLED",
           teacherName: dailySchedule.teacherName,
+        });
+      }
+    }
+  }
+
+  if (approvedAbsenceRequest) {
+    if (cellSubjects.length === 0) {
+      overrides.set(DISPLAY_PERIODS[0], {
+        status: "CANCELLED",
+        teacherName: approvedAbsenceRequest.requestedByName,
+      });
+    }
+
+    for (const subject of cellSubjects) {
+      if (typeof subject.period === "number" && !overrides.has(subject.period)) {
+        overrides.set(subject.period, {
+          status: "CANCELLED",
+          teacherName: approvedAbsenceRequest.requestedByName,
         });
       }
     }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

교원 시간표에서 수업 교환 및 결강 상태를 확인할 수 있도록 표시 기능을 추가하였습니다.
현재는 기존 API들을 조합하여 임시로 구현한 상태이며, 추후 백엔드 스펙이 개선되면 해당 구조에 맞춰 재수정할 예정입니다.

<img width="1897" height="862" alt="image" src="https://github.com/user-attachments/assets/ac66544b-3431-4e4e-b7cd-480309fb2e93" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #139 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
