### PR TITLE
[FEAT] 반별 학생 등록 기능 추가

### DIFF
--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -26,6 +26,7 @@ import type {
   PostCreateState,
   PostEditState,
   PurchaseCreateState,
+  StudentCreateFormState,
   UserFormState,
 } from "@/components/admin/AdminDashboardTypes";
 import {
@@ -42,6 +43,12 @@ import {
   getClassrooms,
   updateClassroom,
 } from "@/api/classroom/classroom.api";
+import {
+  createStudent,
+  deleteStudent,
+  getStudents,
+  updateStudent,
+} from "@/api/student/student.api";
 import {
   addDepartmentPermission,
   createDepartment,
@@ -201,6 +208,12 @@ const emptyClassroomForm: ClassroomFormState = {
   description: "",
 };
 
+const emptyStudentCreateForm: StudentCreateFormState = {
+  name: "",
+  phoneNumber: "",
+  description: "",
+};
+
 const emptyPostEdit: PostEditState = {
   title: "",
   status: "PUBLISHED",
@@ -303,6 +316,18 @@ function mapChannelFormToPayload(form: ChannelFormState) {
   };
 }
 
+function mapStudentCreateFormToPayload(
+  form: StudentCreateFormState,
+  classroomId: number,
+) {
+  return {
+    name: form.name.trim(),
+    phoneNumber: form.phoneNumber.trim() || undefined,
+    description: form.description.trim() || undefined,
+    classroomIds: [classroomId],
+  };
+}
+
 function mapPostToEditState(post?: {
   title?: string;
   status?: PostStatus;
@@ -398,6 +423,8 @@ export default function AdminDashboardPage() {
   const [channelForm, setChannelForm] = useState<ChannelFormState>(emptyChannelForm);
   const [departmentForm, setDepartmentForm] = useState<DepartmentFormState>(emptyDepartmentForm);
   const [classroomForm, setClassroomForm] = useState<ClassroomFormState>(emptyClassroomForm);
+  const [studentCreateForm, setStudentCreateForm] =
+    useState<StudentCreateFormState>(emptyStudentCreateForm);
   const [postEdit, setPostEdit] = useState<PostEditState>(emptyPostEdit);
   const [isPostEditing, setIsPostEditing] = useState(false);
   const [isUserEditing, setIsUserEditing] = useState(false);
@@ -412,6 +439,7 @@ export default function AdminDashboardPage() {
   const [isClassroomEditing, setIsClassroomEditing] = useState(false);
   const [isClassroomCreateModalOpen, setIsClassroomCreateModalOpen] = useState(false);
   const [isClassroomDeleteConfirmOpen, setIsClassroomDeleteConfirmOpen] = useState(false);
+  const [isStudentCreateModalOpen, setIsStudentCreateModalOpen] = useState(false);
   const [isPostCreateModalOpen, setIsPostCreateModalOpen] = useState(false);
   const [isPurchaseCreateModalOpen, setIsPurchaseCreateModalOpen] = useState(false);
   const [postCreate, setPostCreate] = useState<PostCreateState>(emptyPostCreate);
@@ -435,6 +463,8 @@ export default function AdminDashboardPage() {
     setIsChannelDeleteConfirmOpen(false);
     setIsDepartmentDeleteConfirmOpen(false);
     setIsClassroomDeleteConfirmOpen(false);
+    setIsStudentCreateModalOpen(false);
+    setStudentCreateForm(emptyStudentCreateForm);
     setPostEdit(emptyPostEdit);
     setReviewNote("");
   }
@@ -578,6 +608,14 @@ export default function AdminDashboardPage() {
       ? queryKeys.admin.classroomDetail(selectedClassroomId)
       : ["admin", "classrooms", "detail", "none"],
     queryFn: () => getClassroomDetail({ id: selectedClassroomId ?? 0 }),
+    enabled: isAdmin && selectedClassroomId !== null,
+  });
+  const classroomStudentsQuery = useQuery({
+    queryKey:
+      selectedClassroomId !== null
+        ? queryKeys.students.list({ classroomId: selectedClassroomId })
+        : ["students", "list", "classroom", "none"],
+    queryFn: () => getStudents({ classroomId: selectedClassroomId ?? 0 }),
     enabled: isAdmin && selectedClassroomId !== null,
   });
   const purchaseDetailQuery = useQuery({
@@ -844,6 +882,8 @@ export default function AdminDashboardPage() {
     setSelectedClassroomId(item.id);
     setIsClassroomEditing(false);
     setIsClassroomDeleteConfirmOpen(false);
+    setIsStudentCreateModalOpen(false);
+    setStudentCreateForm(emptyStudentCreateForm);
     setClassroomForm({
       name: item.name ?? "",
       type: item.type ?? "WEEKDAY",
@@ -1155,6 +1195,56 @@ export default function AdminDashboardPage() {
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.classrooms() });
     },
     onError: (error) => notifyError(getErrorMessage(error, "분반 삭제에 실패했습니다.")),
+  });
+  const createStudentMutation = useMutation({
+    mutationFn: () => {
+      const classroomId = selectedClassroomId ?? 0;
+      return createStudent(mapStudentCreateFormToPayload(studentCreateForm, classroomId));
+    },
+    onSuccess: () => {
+      notifySuccess("학생을 등록했습니다.");
+      setIsStudentCreateModalOpen(false);
+      setStudentCreateForm(emptyStudentCreateForm);
+      if (selectedClassroomId !== null) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.students.list({ classroomId: selectedClassroomId }),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "학생 등록에 실패했습니다.")),
+  });
+  const deleteStudentMutation = useMutation({
+    mutationFn: (studentId: number) => deleteStudent({ studentId }),
+    onSuccess: () => {
+      notifySuccess("학생을 삭제했습니다.");
+      if (selectedClassroomId !== null) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.students.list({ classroomId: selectedClassroomId }),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "학생 삭제에 실패했습니다.")),
+  });
+  const updateStudentMutation = useMutation({
+    mutationFn: (payload: { studentId: number; form: StudentCreateFormState }) =>
+      updateStudent(
+        { studentId: payload.studentId },
+        {
+          name: payload.form.name.trim(),
+          phoneNumber: payload.form.phoneNumber.trim(),
+          description: payload.form.description.trim(),
+          classroomIds: selectedClassroomId !== null ? [selectedClassroomId] : undefined,
+        },
+      ),
+    onSuccess: () => {
+      notifySuccess("학생 정보를 수정했습니다.");
+      if (selectedClassroomId !== null) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.students.list({ classroomId: selectedClassroomId }),
+        });
+      }
+    },
+    onError: (error) => notifyError(getErrorMessage(error, "학생 수정에 실패했습니다.")),
   });
 
   const createPurchaseMutation = useMutation({
@@ -1536,21 +1626,30 @@ export default function AdminDashboardPage() {
               isClassroomEditing={isClassroomEditing}
               isClassroomCreateModalOpen={isClassroomCreateModalOpen}
               isClassroomDeleteConfirmOpen={isClassroomDeleteConfirmOpen}
+              isStudentCreateModalOpen={isStudentCreateModalOpen}
               classroomSearch={classroomSearch}
               classroomForm={classroomForm}
+              studentCreateForm={studentCreateForm}
               classroomsQuery={classroomsQuery}
               classroomDetailQuery={classroomDetailQuery}
+              classroomStudentsQuery={classroomStudentsQuery}
               createClassroomMutation={createClassroomMutation}
               updateClassroomMutation={updateClassroomMutation}
               deleteClassroomMutation={deleteClassroomMutation}
+              createStudentMutation={createStudentMutation}
+              deleteStudentMutation={deleteStudentMutation}
+              updateStudentMutation={updateStudentMutation}
               setSelectedClassroomId={setSelectedClassroomId}
               setIsClassroomEditing={setIsClassroomEditing}
               setIsClassroomCreateModalOpen={setIsClassroomCreateModalOpen}
               setIsClassroomDeleteConfirmOpen={setIsClassroomDeleteConfirmOpen}
+              setIsStudentCreateModalOpen={setIsStudentCreateModalOpen}
               setClassroomSearch={setClassroomSearch}
               setClassroomForm={setClassroomForm}
+              setStudentCreateForm={setStudentCreateForm}
               selectClassroom={selectClassroom}
               emptyClassroomForm={emptyClassroomForm}
+              emptyStudentCreateForm={emptyStudentCreateForm}
             />
           ) : null}
           {activeMenu === "lessons" ? <AdminLessonManagementSection /> : null}

--- a/components/admin/AdminDashboardSectionParts.tsx
+++ b/components/admin/AdminDashboardSectionParts.tsx
@@ -162,30 +162,19 @@ export const SectionHeaderRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: ${spacing.space12};
 `;
 
 export const SectionTitle = styled.h2`
-  margin: 0 0 ${spacing.space16};
   color: #050505;
   font-size: ${typography.fontSize18};
   font-weight: 900;
   line-height: ${typography.lineHeight130};
-
-  ${SectionHeaderRow} & {
-    margin-bottom: 0;
-  }
 `;
 
 export const SectionDescription = styled.p`
-  margin: -${spacing.space8} 0 ${spacing.space16};
   color: #64706c;
   font-size: ${typography.fontSize13};
   line-height: ${typography.lineHeight150};
-
-  ${SectionHeaderRow} + & {
-    margin-top: ${spacing.space8};
-  }
 `;
 
 export const ActionGrid = styled.div`

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -45,6 +45,12 @@ export type ClassroomFormState = {
   description: string;
 };
 
+export type StudentCreateFormState = {
+  name: string;
+  phoneNumber: string;
+  description: string;
+};
+
 export type PostEditState = {
   title: string;
   status: PostStatus;

--- a/components/admin/classes/AdminClassroomsSection.tsx
+++ b/components/admin/classes/AdminClassroomsSection.tsx
@@ -8,19 +8,28 @@ import type {
   ClassroomListItemDto,
   ClassroomType,
 } from "@/api/classroom/classroom.dto";
-import type { ClassroomFormState } from "@/components/admin/AdminDashboardTypes";
+import type { StudentListResponseDto } from "@/api/student/student.dto";
+import type {
+  ClassroomFormState,
+  StudentCreateFormState,
+} from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
   ControlRow,
   DangerButton,
   DataState,
   FormGrid,
+  InlineStatus,
   Label,
+  List,
+  ListItem,
   SectionCard,
+  SectionDescription,
   SectionHeaderRow,
   SectionTitle,
   SmallButton,
   Table,
+  TextArea,
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
@@ -38,27 +47,46 @@ type VoidMutationAction = {
   mutate: () => void;
 };
 
+type ValueMutationAction<TVariables> = {
+  isPending: boolean;
+  mutate: (variables: TVariables) => void;
+};
+
+type StudentFormMutationVariables = {
+  studentId: number;
+  form: StudentCreateFormState;
+};
+
 type AdminClassroomsSectionProps = {
   classrooms: ClassroomListItemDto[];
   selectedClassroomId: number | null;
   isClassroomEditing: boolean;
   isClassroomCreateModalOpen: boolean;
   isClassroomDeleteConfirmOpen: boolean;
+  isStudentCreateModalOpen: boolean;
   classroomSearch: string;
   classroomForm: ClassroomFormState;
+  studentCreateForm: StudentCreateFormState;
   classroomsQuery: QueryState;
   classroomDetailQuery: QueryState<ClassroomDetailResponseDto>;
+  classroomStudentsQuery: QueryState<StudentListResponseDto>;
   createClassroomMutation: VoidMutationAction;
   updateClassroomMutation: VoidMutationAction;
   deleteClassroomMutation: VoidMutationAction;
+  createStudentMutation: VoidMutationAction;
+  deleteStudentMutation: ValueMutationAction<number>;
+  updateStudentMutation: ValueMutationAction<StudentFormMutationVariables>;
   setSelectedClassroomId: Dispatch<SetStateAction<number | null>>;
   setIsClassroomEditing: Dispatch<SetStateAction<boolean>>;
   setIsClassroomCreateModalOpen: Dispatch<SetStateAction<boolean>>;
   setIsClassroomDeleteConfirmOpen: Dispatch<SetStateAction<boolean>>;
+  setIsStudentCreateModalOpen: Dispatch<SetStateAction<boolean>>;
   setClassroomSearch: Dispatch<SetStateAction<string>>;
   setClassroomForm: Dispatch<SetStateAction<ClassroomFormState>>;
+  setStudentCreateForm: Dispatch<SetStateAction<StudentCreateFormState>>;
   selectClassroom: (item: ClassroomListItemDto) => void;
   emptyClassroomForm: ClassroomFormState;
+  emptyStudentCreateForm: StudentCreateFormState;
 };
 
 function getClassroomTypeLabel(type?: ClassroomType) {
@@ -79,24 +107,41 @@ export function AdminClassroomsSection({
   isClassroomEditing,
   isClassroomCreateModalOpen,
   isClassroomDeleteConfirmOpen,
+  isStudentCreateModalOpen,
   classroomSearch,
   classroomForm,
+  studentCreateForm,
   classroomsQuery,
   classroomDetailQuery,
+  classroomStudentsQuery,
   createClassroomMutation,
   updateClassroomMutation,
   deleteClassroomMutation,
+  createStudentMutation,
+  deleteStudentMutation,
+  updateStudentMutation,
   setSelectedClassroomId,
   setIsClassroomEditing,
   setIsClassroomCreateModalOpen,
   setIsClassroomDeleteConfirmOpen,
+  setIsStudentCreateModalOpen,
   setClassroomSearch,
   setClassroomForm,
+  setStudentCreateForm,
   selectClassroom,
   emptyClassroomForm,
+  emptyStudentCreateForm,
 }: AdminClassroomsSectionProps) {
   const isDetailOpen = selectedClassroomId !== null;
   const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const [studentDeleteTarget, setStudentDeleteTarget] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
+  const [studentEditTarget, setStudentEditTarget] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
   const totalPages = Math.max(1, Math.ceil(classrooms.length / CLASSROOMS_PER_PAGE));
   const requestedPage = pagination.search === classroomSearch ? pagination.page : 1;
   const safeCurrentPage = Math.min(requestedPage, totalPages);
@@ -109,6 +154,10 @@ export function AdminClassroomsSection({
     setSelectedClassroomId(null);
     setIsClassroomEditing(false);
     setIsClassroomDeleteConfirmOpen(false);
+    setIsStudentCreateModalOpen(false);
+    setStudentCreateForm(emptyStudentCreateForm);
+    setStudentDeleteTarget(null);
+    setStudentEditTarget(null);
   }
 
   function openCreateModal() {
@@ -125,6 +174,63 @@ export function AdminClassroomsSection({
 
     setIsClassroomCreateModalOpen(false);
     setClassroomForm(emptyClassroomForm);
+  }
+
+  function openStudentCreateModal() {
+    setStudentEditTarget(null);
+    setStudentCreateForm(emptyStudentCreateForm);
+    setIsStudentCreateModalOpen(true);
+  }
+
+  function closeStudentCreateModal() {
+    if (createStudentMutation.isPending || updateStudentMutation.isPending) {
+      return;
+    }
+
+    setIsStudentCreateModalOpen(false);
+    setStudentCreateForm(emptyStudentCreateForm);
+    setStudentEditTarget(null);
+  }
+
+  function openStudentEditModal(student: StudentListResponseDto[number]) {
+    if (typeof student.id !== "number") {
+      return;
+    }
+
+    setStudentEditTarget({
+      id: student.id,
+      name: student.name?.trim() || "선택한 학생",
+    });
+    setStudentCreateForm({
+      name: student.name ?? "",
+      phoneNumber: student.phoneNumber ?? "",
+      description: student.description ?? "",
+    });
+    setIsStudentCreateModalOpen(true);
+  }
+
+  function openStudentDeleteConfirm(studentId: number, studentName?: string) {
+    setStudentDeleteTarget({
+      id: studentId,
+      name: studentName?.trim() || "선택한 학생",
+    });
+  }
+
+  function closeStudentDeleteConfirm() {
+    if (deleteStudentMutation.isPending) {
+      return;
+    }
+
+    setStudentDeleteTarget(null);
+  }
+
+  function confirmStudentDelete() {
+    if (!studentDeleteTarget) {
+      return;
+    }
+
+    deleteStudentMutation.mutate(studentDeleteTarget.id);
+    setStudentDeleteTarget(null);
   }
 
   function cancelEditing() {
@@ -150,6 +256,30 @@ export function AdminClassroomsSection({
     if (isLeftVisibleArea && !clickedClassroomRow) {
       closeClassroomDetail();
     }
+  }
+
+  const selectedClassroomName =
+    classroomDetailQuery.data?.name?.trim() || classroomForm.name.trim() || "선택된 분반";
+  const classroomStudents = classroomStudentsQuery.data ?? [];
+  const isStudentFormPending = createStudentMutation.isPending || updateStudentMutation.isPending;
+  const studentModalTitle = studentEditTarget ? "학생 수정" : "학생 등록";
+  const studentModalDescription = studentEditTarget
+    ? `${studentEditTarget.name} 학생 정보를 수정하세요.`
+    : `${selectedClassroomName}에 등록할 학생 정보를 입력하세요.`;
+
+  function submitStudentForm() {
+    if (studentEditTarget) {
+      updateStudentMutation.mutate({
+        studentId: studentEditTarget.id,
+        form: studentCreateForm,
+      });
+      setIsStudentCreateModalOpen(false);
+      setStudentCreateForm(emptyStudentCreateForm);
+      setStudentEditTarget(null);
+      return;
+    }
+
+    createStudentMutation.mutate();
   }
 
   return (
@@ -279,6 +409,65 @@ export function AdminClassroomsSection({
                       disabled={!isClassroomEditing || updateClassroomMutation.isPending}
                       setClassroomForm={setClassroomForm}
                     />
+                    <StudentSummarySection>
+                      <SectionHeaderRow>
+                        <SectionTitle>학생 목록</SectionTitle>
+                      </SectionHeaderRow>
+                      <SectionDescription>현재 분반에 등록된 학생 목록입니다.</SectionDescription>
+                      <DataState
+                        isLoading={classroomStudentsQuery.isLoading}
+                        isError={classroomStudentsQuery.isError}
+                        isEmpty={classroomStudents.length === 0}
+                        loadingLabel="학생 목록 불러오는 중"
+                        errorLabel="학생 목록을 불러오지 못했습니다."
+                        emptyLabel="등록된 학생이 없습니다."
+                        compact
+                      >
+                        <StudentList>
+                          {classroomStudents.map((student, index) => (
+                            <StudentListItem key={student.id ?? `${student.name}-${index}`}>
+                              <StudentCardMain>
+                                <StudentIdentity>
+                                  <strong>{student.name ?? "이름 없음"}</strong>
+                                  <span>
+                                    {student.phoneNumber?.trim()
+                                      ? student.phoneNumber
+                                      : "연락처 미등록"}
+                                  </span>
+                                </StudentIdentity>
+                                <StudentMeta>
+                                  {student.description ? (
+                                    <StudentDescription>{student.description}</StudentDescription>
+                                  ) : null}
+                                </StudentMeta>
+                              </StudentCardMain>
+                              {typeof student.id === "number" ? (
+                                <StudentRowActions>
+                                  <SmallButton
+                                    type="button"
+                                    disabled={
+                                      isStudentFormPending || deleteStudentMutation.isPending
+                                    }
+                                    onClick={() => openStudentEditModal(student)}
+                                  >
+                                    수정
+                                  </SmallButton>
+                                  <DangerButton
+                                    type="button"
+                                    disabled={deleteStudentMutation.isPending}
+                                    onClick={() =>
+                                      openStudentDeleteConfirm(student.id as number, student.name)
+                                    }
+                                  >
+                                    삭제
+                                  </DangerButton>
+                                </StudentRowActions>
+                              ) : null}
+                            </StudentListItem>
+                          ))}
+                        </StudentList>
+                      </DataState>
+                    </StudentSummarySection>
                   </DetailFormView>
 
                   <ButtonRow>
@@ -315,6 +504,13 @@ export function AdminClassroomsSection({
                         >
                           삭제
                         </DangerButton>
+                        <SmallButton
+                          type="button"
+                          disabled={!selectedClassroomId}
+                          onClick={openStudentCreateModal}
+                        >
+                          학생 등록
+                        </SmallButton>
                       </>
                     )}
                   </ButtonRow>
@@ -371,6 +567,88 @@ export function AdminClassroomsSection({
               </ButtonRow>
             </FormGrid>
           </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {isStudentCreateModalOpen ? (
+        <ModalBackdrop onMouseDown={closeStudentCreateModal}>
+          <ModalDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="student-create-modal-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ModalHeader>
+              <div>
+                <SectionTitle id="student-create-modal-title">{studentModalTitle}</SectionTitle>
+                <ModalDescription>{studentModalDescription}</ModalDescription>
+              </div>
+              <SmallButton
+                type="button"
+                disabled={isStudentFormPending}
+                onClick={closeStudentCreateModal}
+              >
+                닫기
+              </SmallButton>
+            </ModalHeader>
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                submitStudentForm();
+              }}
+            >
+              <StudentCreateFields
+                form={studentCreateForm}
+                disabled={isStudentFormPending}
+                setStudentCreateForm={setStudentCreateForm}
+              />
+              <ButtonRow>
+                <ClassroomActionButton
+                  type="submit"
+                  disabled={isStudentFormPending || !studentCreateForm.name.trim()}
+                >
+                  {studentEditTarget ? "저장" : "등록"}
+                </ClassroomActionButton>
+                <SmallButton
+                  type="button"
+                  disabled={isStudentFormPending}
+                  onClick={closeStudentCreateModal}
+                >
+                  취소
+                </SmallButton>
+              </ButtonRow>
+            </FormGrid>
+          </ModalDialog>
+        </ModalBackdrop>
+      ) : null}
+
+      {studentDeleteTarget ? (
+        <ModalBackdrop onMouseDown={closeStudentDeleteConfirm}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="student-delete-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="student-delete-confirm-title">학생 삭제</ConfirmTitle>
+            <ConfirmMessage>{studentDeleteTarget.name} 학생을 삭제하시겠습니까?</ConfirmMessage>
+            <ButtonRow>
+              <DangerButton
+                type="button"
+                disabled={deleteStudentMutation.isPending}
+                onClick={confirmStudentDelete}
+              >
+                확인
+              </DangerButton>
+              <SmallButton
+                type="button"
+                disabled={deleteStudentMutation.isPending}
+                onClick={closeStudentDeleteConfirm}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
         </ModalBackdrop>
       ) : null}
 
@@ -450,6 +728,57 @@ function ClassroomFields({ form, disabled, setClassroomForm }: ClassroomFieldsPr
           disabled={disabled}
           onChange={(event) =>
             setClassroomForm((current) => ({ ...current, description: event.target.value }))
+          }
+        />
+      </Label>
+    </>
+  );
+}
+
+type StudentCreateFieldsProps = {
+  form: StudentCreateFormState;
+  disabled: boolean;
+  setStudentCreateForm: Dispatch<SetStateAction<StudentCreateFormState>>;
+};
+
+function StudentCreateFields({ form, disabled, setStudentCreateForm }: StudentCreateFieldsProps) {
+  return (
+    <>
+      <Label>
+        이름
+        <TextInput
+          value={form.name}
+          disabled={disabled}
+          onChange={(event) =>
+            setStudentCreateForm((current) => ({ ...current, name: event.target.value }))
+          }
+          required
+        />
+      </Label>
+      <Label>
+        연락처
+        <TextInput
+          value={form.phoneNumber}
+          disabled={disabled}
+          placeholder="010-0000-0000"
+          onChange={(event) =>
+            setStudentCreateForm((current) => ({
+              ...current,
+              phoneNumber: event.target.value,
+            }))
+          }
+        />
+      </Label>
+      <Label>
+        비고
+        <TextArea
+          value={form.description}
+          disabled={disabled}
+          onChange={(event) =>
+            setStudentCreateForm((current) => ({
+              ...current,
+              description: event.target.value,
+            }))
           }
         />
       </Label>
@@ -623,6 +952,65 @@ const PanelContent = styled.div`
   gap: ${spacing.space12};
 `;
 
+const StudentSummarySection = styled.section`
+  display: grid;
+  gap: ${spacing.space8};
+  padding-top: ${spacing.space8};
+  border-top: 1px solid #e6e9e7;
+`;
+
+const StudentList = styled(List)`
+  margin: 0;
+`;
+
+const StudentListItem = styled(ListItem)`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: ${spacing.space12};
+`;
+
+const StudentCardMain = styled.div`
+  display: grid;
+`;
+
+const StudentIdentity = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  strong {
+    color: #111827;
+    font-size: ${typography.fontSize14};
+    line-height: ${typography.lineHeight130};
+  }
+
+  span {
+    color: #64706c;
+    font-size: ${typography.fontSize13};
+    line-height: ${typography.lineHeight130};
+  }
+`;
+
+const StudentMeta = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+  justify-items: start;
+`;
+
+const StudentDescription = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+`;
+
+const StudentRowActions = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: ${spacing.space8};
+`;
+
 const ClassroomSelect = styled.select`
   width: 100%;
   min-height: 2.375rem;
@@ -683,6 +1071,13 @@ const ModalHeader = styled.div`
   ${SectionTitle} {
     margin-bottom: 0;
   }
+`;
+
+const ModalDescription = styled.p`
+  margin: ${spacing.space4} 0 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
 `;
 
 const ConfirmDialog = styled(ModalDialog)`

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -156,12 +156,10 @@ export default function ClassJournalCreatePage() {
   const studentsQuery = useQuery({
     queryKey: queryKeys.students.list({
       classroomId: enrollmentClassroomId,
-      status: "ENROLLED",
     }),
     queryFn: () =>
       getStudents({
         classroomId: enrollmentClassroomId as number,
-        status: "ENROLLED",
       }),
     enabled: enrollmentClassroomId > 0,
     retry: false,


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 관리자 페이지 분반 관리 섹션에 "학생 관리 기능" 추가
   \- 분반 상세 화면에서 반별 학생 목록을 조회할 수 있도록 연동하였습니다.
   \- 학생 등록 모달을 추가해 반별 학생 등록이 가능하도록 하였습니다.
   \- 학생 목록별 수정/삭제 버튼을 추가하였습니다.
   \- 전화번호 및 비고를 빈 값으로 등록/수정할 때도 정상적으로 등록됩니다.

   <img width="1918" height="862" alt="스크린샷 2026-06-20 212754" src="https://github.com/user-attachments/assets/2c0ea8e5-7716-4cea-a987-65db10385bff" />

   <img width="1918" height="862" alt="스크린샷 2026-06-20 212819" src="https://github.com/user-attachments/assets/156309a1-d70e-4ce2-be61-fe3a9d4bc7b9" />

 2. 수업 일지 작성 페이지의 출석부에 학생 목록 자동 조회 기능 개선
   \- 수업 일지 작성 시, 해당 분반에 등록된 학생 목록을 자동으로 불러오도록 하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #143 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
