### PR TITLE
[FEAT] 콘텐츠 상호작용 기능 개선

### DIFF
--- a/api/siteContent/siteContent.api.test.ts
+++ b/api/siteContent/siteContent.api.test.ts
@@ -20,7 +20,7 @@ describe("siteContent.api", () => {
   it("returns public site content sections", async () => {
     server.use(
       http.get(`${API_BASE_URL}/api/v1/site-contents/history`, () => {
-        return HttpResponse.json({ history: [{ id: 1, title: "개교" }] });
+        return HttpResponse.json({ history: [{ id: 1, title: "개교", historyDate: "2026-06-21" }] });
       }),
       http.get(`${API_BASE_URL}/api/v1/site-contents/departments`, () => {
         return HttpResponse.json({
@@ -62,7 +62,7 @@ describe("siteContent.api", () => {
       }),
       http.put(`${API_BASE_URL}/api/v1/site-contents/history/1`, async ({ request }) => {
         observedHistoryBody = await request.json();
-        return HttpResponse.json({ id: 1, title: "수정 연혁" });
+        return HttpResponse.json({ id: 1, title: "2026.06.21", historyDate: "2026-06-21" });
       }),
     );
 
@@ -76,7 +76,7 @@ describe("siteContent.api", () => {
       groupId: "weekendMorning",
       description: ["오전"],
     });
-    await updateHistory({ historyId: 1 }, { title: "수정 연혁" });
+    await updateHistory({ historyId: 1 }, { title: "2026.06.21", historyDate: "2026-06-21" });
 
     expect(observedDepartmentBody).toEqual({
       title: "교무부",
@@ -88,6 +88,6 @@ describe("siteContent.api", () => {
       groupId: "weekendMorning",
       description: ["오전"],
     });
-    expect(observedHistoryBody).toEqual({ title: "수정 연혁" });
+    expect(observedHistoryBody).toEqual({ title: "2026.06.21", historyDate: "2026-06-21" });
   });
 });

--- a/api/siteContent/siteContent.dto.ts
+++ b/api/siteContent/siteContent.dto.ts
@@ -1,20 +1,33 @@
+export interface SiteHistoryLinkRequestDto {
+  label: string;
+  href: string;
+}
+
+export interface SiteHistoryLinkResponseDto {
+  id?: number;
+  label?: string;
+  href?: string;
+}
+
 export interface SiteHistoryPhotoRequestDto {
-  url: string;
+  id?: number;
+  fileId?: string;
+  src: string;
   alt?: string;
 }
 
 export interface SiteHistoryPhotoResponseDto {
   id?: number;
-  url?: string;
+  src?: string;
   alt?: string;
 }
 
 export interface SiteHistoryResponseDto {
   id?: number;
   title?: string;
+  historyDate?: string;
   detail?: string;
-  linkLabel?: string;
-  linkHref?: string;
+  links?: SiteHistoryLinkResponseDto[];
   photos?: SiteHistoryPhotoResponseDto[];
 }
 
@@ -24,9 +37,9 @@ export interface SiteHistoriesResponseDto {
 
 export interface UpsertSiteHistoryRequestDto {
   title: string;
+  historyDate: string;
   detail?: string;
-  linkLabel?: string;
-  linkHref?: string;
+  links?: SiteHistoryLinkRequestDto[];
   photos?: SiteHistoryPhotoRequestDto[];
 }
 

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -13,6 +13,7 @@ import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
 import {
+  createUser,
   getAssignablePermissions,
   getTeacherContacts,
   getUsers,
@@ -71,6 +72,71 @@ describe("user.api", () => {
     });
   });
 
+  it("updates the current user with resident registration number prefix in the expected PATCH body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.patch(`${API_BASE_URL}/api/v1/users/me`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          ...USER_LIST_RESPONSE.content[0],
+          residentRegistrationNumberPrefix: "900101",
+        });
+      }),
+    );
+
+    const response = await updateCurrentUser({
+      residentRegistrationNumberPrefix: "900101",
+    });
+
+    expect(response.residentRegistrationNumberPrefix).toBe("900101");
+    expect(observedBody).toEqual({
+      residentRegistrationNumberPrefix: "900101",
+    });
+  });
+
+  it("creates a user with resident registration number prefix in the expected POST body", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/users`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          ...USER_LIST_RESPONSE.content[0],
+          id: 2,
+          name: "Teacher Two",
+        });
+      }),
+    );
+
+    const response = await createUser({
+      email: "teacher2@example.com",
+      nickname: "teacher-2",
+      password: "password123!",
+      name: "Teacher Two",
+      phoneNumber: "010-3333-4444",
+      residentRegistrationNumberPrefix: "900101",
+      role: "VOLUNTEER",
+      departmentId: 1,
+    });
+
+    expect(response.id).toBe(2);
+    expect(observedBody).toEqual({
+      email: "teacher2@example.com",
+      nickname: "teacher-2",
+      password: "password123!",
+      name: "Teacher Two",
+      phoneNumber: "010-3333-4444",
+      residentRegistrationNumberPrefix: "900101",
+      role: "VOLUNTEER",
+      departmentId: 1,
+    });
+  });
+
   it("updates a user with departmentId in the expected PATCH body", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
@@ -92,6 +158,7 @@ describe("user.api", () => {
         name: "Teacher One",
         email: "teacher1@example.com",
         phoneNumber: "010-2222-3333",
+        residentRegistrationNumberPrefix: "900101",
         role: "VOLUNTEER",
         departmentId: 2,
       },
@@ -102,6 +169,7 @@ describe("user.api", () => {
       name: "Teacher One",
       email: "teacher1@example.com",
       phoneNumber: "010-2222-3333",
+      residentRegistrationNumberPrefix: "900101",
       role: "VOLUNTEER",
       departmentId: 2,
     });

--- a/api/user/user.dto.ts
+++ b/api/user/user.dto.ts
@@ -113,6 +113,7 @@ export interface CreateUserRequestDto {
   password: string;
   name: string;
   phoneNumber?: string;
+  residentRegistrationNumberPrefix?: string;
   role?: UserRole;
   departmentId?: number | null;
 }
@@ -123,6 +124,7 @@ export interface UpdateUserRequestDto {
   phoneNumber?: string;
   email?: string;
   password?: string;
+  residentRegistrationNumberPrefix?: string;
   role?: UserRole;
   departmentId?: number | null;
 }

--- a/app/staff/class-management/absence-request/[postId]/page.tsx
+++ b/app/staff/class-management/absence-request/[postId]/page.tsx
@@ -28,7 +28,7 @@ export default function AbsencePostPage() {
   const params = useParams<{ postId: string }>();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { status: authStatus } = useAuthSession();
+  const { user, status: authStatus } = useAuthSession();
   const isAuthenticated = authStatus === "authenticated";
   const postId = Number(params.postId);
   const isValidPostId = Number.isInteger(postId) && postId > 0;
@@ -75,15 +75,24 @@ export default function AbsencePostPage() {
   const detailTitle = isLoading ? "불러오는 중..." : data?.title ?? "-";
   const isPendingRequest = data?.status === "PENDING";
   const detailStatusTone = normalizeStatusTone(data?.status);
+  const isAdmin = isAuthenticated && user?.role === "ADMIN";
+  const isRequester =
+    isAuthenticated &&
+    typeof user?.id === "number" &&
+    typeof data?.requestedById === "number" &&
+    user.id === data.requestedById;
+  const canManageRequest = isAdmin || isRequester;
+  const canEditRequest = isPendingRequest && canManageRequest;
+  const canDeleteRequest = isPendingRequest && canManageRequest;
 
   const handleDelete = async () => {
-    if (!isValidPostId || !isPendingRequest || deleteAbsenceMutation.isPending) return;
+    if (!isValidPostId || !canDeleteRequest || deleteAbsenceMutation.isPending) return;
     if (!window.confirm("결강 신청서를 삭제하시겠습니까?")) return;
     deleteAbsenceMutation.mutate({ requestId: postId });
   };
 
   const handleStartEdit = () => {
-    if (!isPendingRequest) return;
+    if (!canEditRequest) return;
     setEditTitle(data?.title ?? "");
     setEditReason(data?.reason ?? "");
     setIsEditing(true);
@@ -110,33 +119,46 @@ export default function AbsencePostPage() {
   return (
     <PageWrapper>
       <TopButtonRow>
-        <Button
-          type="button"
-          $variant="danger"
-          onClick={handleDelete}
-          disabled={!isPendingRequest || deleteAbsenceMutation.isPending}
-        >
-          {deleteAbsenceMutation.isPending ? "삭제 중..." : "삭제"}
-        </Button>
-        {isEditing ? (
+        {canManageRequest ? (
           <>
             <Button
               type="button"
-              $variant="edit"
-              onClick={handleCancelEdit}
-              disabled={updateAbsenceMutation.isPending}
+              $variant="danger"
+              onClick={handleDelete}
+              disabled={!canDeleteRequest || deleteAbsenceMutation.isPending}
             >
-              취소
+              {deleteAbsenceMutation.isPending ? "삭제 중..." : "삭제"}
             </Button>
-            <Button type="button" onClick={handleSaveEdit} disabled={updateAbsenceMutation.isPending}>
-              {updateAbsenceMutation.isPending ? "저장 중..." : "저장"}
-            </Button>
+            {isEditing ? (
+              <>
+                <Button
+                  type="button"
+                  $variant="edit"
+                  onClick={handleCancelEdit}
+                  disabled={updateAbsenceMutation.isPending}
+                >
+                  취소
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleSaveEdit}
+                  disabled={updateAbsenceMutation.isPending}
+                >
+                  {updateAbsenceMutation.isPending ? "저장 중..." : "저장"}
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                $variant="edit"
+                onClick={handleStartEdit}
+                disabled={!canEditRequest}
+              >
+                수정
+              </Button>
+            )}
           </>
-        ) : (
-          <Button type="button" $variant="edit" onClick={handleStartEdit} disabled={!isPendingRequest}>
-            수정
-          </Button>
-        )}
+        ) : null}
         <Button type="button" $variant="neutral" onClick={() => router.push("/staff/class-management/absence-request")}>
           목록
         </Button>

--- a/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
+++ b/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
+  LessonExchangeProposalDto,
   LessonExchangeProposalRequestDto,
   UpdateLessonExchangeRequestDto,
 } from "@/api/lessonExchange/lessonExchange.dto";
@@ -14,10 +15,13 @@ import {
   createLessonExchangeProposal,
   getLessonExchangeRequestDetail,
   getLessonExchangeProposals,
+  updateLessonExchangeProposal,
   updateLessonExchangeRequest,
+  withdrawLessonExchangeProposal,
 } from "@/api/lessonExchange/lessonExchange.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 import {
   normalizeLessonExchangeExpiresAtForApi,
   parseKoreanShortDateToIsoDate,
@@ -40,6 +44,7 @@ function normalizeLessonDateForApi(value: string): string | undefined {
 }
 
 interface ProposalFormValues {
+  className: string;
   lessonDate: string;
   content: string;
 }
@@ -73,6 +78,7 @@ export function useExchangePostPage() {
 
   const proposalForm = useForm<ProposalFormValues>({
     defaultValues: {
+      className: "",
       lessonDate: "",
       content: "",
     },
@@ -95,6 +101,15 @@ export function useExchangePostPage() {
 
   const [isEditing, setIsEditing] = useState(false);
   const [isChangingExchangeTarget, setIsChangingExchangeTarget] = useState(false);
+  const [editingProposalId, setEditingProposalId] = useState<number | null>(null);
+  const [proposalRemovalActionLabel, setProposalRemovalActionLabel] = useState<
+    "삭제" | "철회"
+  >("삭제");
+  const [editingProposalValues, setEditingProposalValues] = useState<ProposalFormValues>({
+    className: "",
+    lessonDate: "",
+    content: "",
+  });
 
   const createProposalMutation = useMutation({
     mutationFn: (body: LessonExchangeProposalRequestDto) =>
@@ -150,6 +165,55 @@ export function useExchangePostPage() {
     },
     onError: (error) => {
       window.alert(error instanceof Error ? error.message : "교환 제안 수락에 실패했습니다.");
+    },
+  });
+
+  const updateProposalMutation = useMutation({
+    mutationFn: ({
+      proposalId,
+      body,
+    }: {
+      proposalId: number;
+      body: LessonExchangeProposalRequestDto;
+    }) => updateLessonExchangeProposal({ requestId: postId, proposalId }, body),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeProposals(postId),
+      });
+      setEditingProposalId(null);
+      setEditingProposalValues({
+        className: "",
+        lessonDate: "",
+        content: "",
+      });
+      window.alert("교환 제안이 수정되었습니다.");
+    },
+    onError: (error) => {
+      window.alert(error instanceof Error ? error.message : "교환 제안 수정에 실패했습니다.");
+    },
+  });
+
+  const withdrawProposalMutation = useMutation({
+    mutationFn: (proposalId: number) =>
+      withdrawLessonExchangeProposal({ requestId: postId, proposalId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.requests.lessonExchangeProposals(postId),
+      });
+      setEditingProposalId(null);
+      setEditingProposalValues({
+        className: "",
+        lessonDate: "",
+        content: "",
+      });
+      window.alert(`교환 제안이 ${proposalRemovalActionLabel}되었습니다.`);
+    },
+    onError: (error) => {
+      window.alert(
+        error instanceof Error
+          ? error.message
+          : `교환 제안 ${proposalRemovalActionLabel}에 실패했습니다.`,
+      );
     },
   });
 
@@ -264,6 +328,81 @@ export function useExchangePostPage() {
     acceptProposalMutation.mutate(proposalId);
   };
 
+  const canManageProposal = (proposal: LessonExchangeProposalDto) =>
+    isAuthenticated &&
+    typeof user?.id === "number" &&
+    typeof proposal.proposedById === "number" &&
+    user.id === proposal.proposedById &&
+    (proposal.status === "ACTIVE" || proposal.status == null);
+
+  const canWithdrawAcceptedProposal = (proposal: LessonExchangeProposalDto) =>
+    isApplicant &&
+    proposal.status === "ACCEPTED" &&
+    uiStatus === "COMPLETED";
+
+  const startProposalEdit = (proposal: LessonExchangeProposalDto) => {
+    if (!proposal.id || !canManageProposal(proposal)) {
+      return;
+    }
+
+    setEditingProposalId(proposal.id);
+    setEditingProposalValues({
+      className: proposal.classroomName ?? "",
+      lessonDate: formatUtcToKstShortDate(proposal.lessonDate) || "",
+      content: proposal.content ?? "",
+    });
+  };
+
+  const cancelProposalEdit = () => {
+    if (updateProposalMutation.isPending) {
+      return;
+    }
+
+    setEditingProposalId(null);
+    setEditingProposalValues({
+      className: "",
+      lessonDate: "",
+      content: "",
+    });
+  };
+
+  const saveProposalEdit = (proposalId: number) => {
+    const lessonDate = normalizeLessonDateForApi(editingProposalValues.lessonDate);
+    const content = editingProposalValues.content.trim();
+
+    if (!lessonDate) {
+      window.alert("수업 일자를 입력해 주세요.");
+      return;
+    }
+
+    if (!content) {
+      window.alert("내용을 입력해 주세요.");
+      return;
+    }
+
+    updateProposalMutation.mutate({
+      proposalId,
+      body: {
+        lessonDate,
+        content,
+      },
+    });
+  };
+
+  const deleteProposal = (proposalId: number) => {
+    if (!window.confirm("이 교환 제안을 삭제할까요?")) return;
+
+    setProposalRemovalActionLabel("삭제");
+    withdrawProposalMutation.mutate(proposalId);
+  };
+
+  const withdrawAcceptedProposal = (proposalId: number) => {
+    if (!window.confirm("이 교환 제안을 철회할까요?")) return;
+
+    setProposalRemovalActionLabel("철회");
+    withdrawProposalMutation.mutate(proposalId);
+  };
+
   const changeExchangeTarget = () => {
     if (!window.confirm("교환 대상을 변경할까요?")) return;
 
@@ -272,8 +411,29 @@ export function useExchangePostPage() {
 
   const request = requestQuery.data;
   const requestStatus = request?.status;
+  const teacherAssignments = user?.teacherAssignments ?? [];
+  const assignmentClassNames = Array.from(
+    new Set(
+      teacherAssignments
+        .map((assignment) => assignment.classroomName?.trim() ?? "")
+        .filter((name) => name.length > 0),
+    ),
+  );
+  const hasMultipleProposalClassNames = assignmentClassNames.length > 1;
+  const proposalClassName = assignmentClassNames.length === 1 ? assignmentClassNames[0] : "";
+  const matchesApplicantId =
+    typeof user?.id === "number" &&
+    typeof request?.requestedById === "number" &&
+    user.id === request.requestedById;
+  const matchesApplicantName = Boolean(
+    request?.requestedByName &&
+      [user?.name, user?.nickname, user?.email].some(
+        (candidate) => candidate != null && candidate === request.requestedByName,
+      ),
+  );
   const isApplicant =
-    user?.id != null && request?.requestedById != null && user.id === request.requestedById;
+    (matchesApplicantId && (!request?.requestedByName || matchesApplicantName)) ||
+    (request?.requestedById == null && matchesApplicantName);
 
   const uiStatus =
     isChangingExchangeTarget && requestStatus === "COMPLETED" ? "APPROVED" : requestStatus;
@@ -320,6 +480,9 @@ export function useExchangePostPage() {
     requestError: requestQuery.isError,
 
     isApplicant,
+    assignmentClassNames,
+    hasMultipleProposalClassNames,
+    proposalClassName,
     showProposalSection,
     showProposalMessage,
     proposalMessage,
@@ -342,12 +505,24 @@ export function useExchangePostPage() {
     isUpdating: updateRequestMutation.isPending,
     isCreatingProposal: createProposalMutation.isPending,
     isAcceptingProposal: acceptProposalMutation.isPending,
+    isUpdatingProposal: updateProposalMutation.isPending,
+    isDeletingProposal: withdrawProposalMutation.isPending,
+    editingProposalId,
+    editingProposalValues,
 
     startEdit,
     cancelEdit,
     saveEdit,
     submitProposal,
     acceptProposal,
+    canManageProposal,
+    canWithdrawAcceptedProposal,
+    startProposalEdit,
+    cancelProposalEdit,
+    saveProposalEdit,
+    deleteProposal,
+    withdrawAcceptedProposal,
+    setEditingProposalValues,
     changeExchangeTarget,
     deleteRequest,
     backToList,

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -101,6 +101,7 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { toBirthDateInputValue, toResidentRegistrationNumberPrefix } from "@/utils/birthDate";
 
 const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "dashboard", label: "대시보드" },
@@ -184,6 +185,7 @@ const emptyUserForm: UserFormState = {
   password: "",
   name: "",
   phoneNumber: "",
+  birthDate: "",
   role: "VOLUNTEER",
   departmentId: "",
 };
@@ -290,6 +292,8 @@ function mapCreateUserFormToPayload(form: UserFormState) {
     password: form.password,
     name,
     phoneNumber: form.phoneNumber.trim() || undefined,
+    residentRegistrationNumberPrefix:
+      toResidentRegistrationNumberPrefix(form.birthDate) || undefined,
     role: form.role,
     departmentId: form.departmentId ? (toNumber(form.departmentId) ?? null) : null,
   };
@@ -300,6 +304,8 @@ function mapUpdateUserFormToPayload(form: UserFormState) {
     email: form.email.trim(),
     name: form.name.trim(),
     phoneNumber: form.phoneNumber.trim() || undefined,
+    residentRegistrationNumberPrefix:
+      toResidentRegistrationNumberPrefix(form.birthDate) || undefined,
     role: form.role,
     departmentId: form.departmentId ? (toNumber(form.departmentId) ?? null) : null,
   };
@@ -816,6 +822,7 @@ export default function AdminDashboardPage() {
       password: "",
       name: item.name ?? "",
       phoneNumber: item.phoneNumber ?? "",
+      birthDate: toBirthDateInputValue(item.residentRegistrationNumberPrefix),
       role: item.role ?? "VOLUNTEER",
       departmentId:
         item.departmentId !== null && item.departmentId !== undefined

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -21,6 +21,7 @@ export type UserFormState = {
   password: string;
   name: string;
   phoneNumber: string;
+  birthDate: string;
   role: UserRole;
   departmentId: string;
 };

--- a/components/admin/users/AdminUsersSection.tsx
+++ b/components/admin/users/AdminUsersSection.tsx
@@ -28,6 +28,7 @@ import {
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { toBirthDateInputValue } from "@/utils/birthDate";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 const USERS_PER_PAGE = 11;
@@ -202,6 +203,8 @@ export function AdminUsersSection({
       password: "",
       name: detail?.name ?? userForm.name,
       phoneNumber: detail?.phoneNumber ?? userForm.phoneNumber,
+      birthDate:
+        toBirthDateInputValue(detail?.residentRegistrationNumberPrefix) || userForm.birthDate,
       role: detail?.role ?? userForm.role,
       departmentId:
         detail?.departmentId !== null && detail?.departmentId !== undefined
@@ -212,6 +215,53 @@ export function AdminUsersSection({
     });
     setIsUserEditing(false);
   }
+
+  function startEditing() {
+    const detail = userDetailQuery.data;
+
+    if (detail) {
+      setUserForm((current) => ({
+        email: detail.email ?? current.email,
+        nickname: detail.nickname ?? current.nickname,
+        password: "",
+        name: detail.name ?? current.name,
+        phoneNumber: detail.phoneNumber ?? current.phoneNumber,
+        birthDate:
+          toBirthDateInputValue(detail.residentRegistrationNumberPrefix) || current.birthDate,
+        role: detail.role ?? current.role,
+        departmentId:
+          detail.departmentId !== null && detail.departmentId !== undefined
+            ? String(detail.departmentId)
+            : typeof detail.department?.id === "number"
+              ? String(detail.department.id)
+              : current.departmentId,
+      }));
+    }
+
+    setIsUserEditing(true);
+  }
+
+  const detailForm =
+    userDetailQuery.data && !isUserEditing
+      ? {
+          email: userDetailQuery.data.email ?? userForm.email,
+          nickname: userDetailQuery.data.nickname ?? userForm.nickname,
+          password: "",
+          name: userDetailQuery.data.name ?? userForm.name,
+          phoneNumber: userDetailQuery.data.phoneNumber ?? userForm.phoneNumber,
+          birthDate:
+            toBirthDateInputValue(userDetailQuery.data.residentRegistrationNumberPrefix) ||
+            userForm.birthDate,
+          role: userDetailQuery.data.role ?? userForm.role,
+          departmentId:
+            userDetailQuery.data.departmentId !== null &&
+            userDetailQuery.data.departmentId !== undefined
+              ? String(userDetailQuery.data.departmentId)
+              : typeof userDetailQuery.data.department?.id === "number"
+                ? String(userDetailQuery.data.department.id)
+                : userForm.departmentId,
+        }
+      : userForm;
 
   function handleUserListSectionClick(event: MouseEvent<HTMLElement>) {
     if (!isDetailOpen) {
@@ -353,7 +403,7 @@ export function AdminUsersSection({
                   ) : (
                     <DetailFormView>
                       <UserFields
-                        form={userForm}
+                        form={detailForm}
                         departments={departments}
                         disabled
                         setUserForm={setUserForm}
@@ -553,7 +603,7 @@ export function AdminUsersSection({
                           onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();
-                            setIsUserEditing(true);
+                            startEditing();
                           }}
                         >
                           수정
@@ -725,6 +775,20 @@ function UserFields({
             setUserForm((current) => ({
               ...current,
               phoneNumber: formatPhoneNumber(event.target.value),
+            }))
+          }
+        />
+      </Label>
+      <Label>
+        생년월일
+        <TextInput
+          type="date"
+          value={form.birthDate}
+          disabled={disabled}
+          onChange={(event) =>
+            setUserForm((current) => ({
+              ...current,
+              birthDate: event.target.value,
             }))
           }
         />

--- a/components/auth/MyPage.tsx
+++ b/components/auth/MyPage.tsx
@@ -9,6 +9,11 @@ import type { UpdateSelfRequestDto, UserResponseDto } from "@/api/user/user.dto"
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import {
+  formatBirthDate,
+  toBirthDateInputValue,
+  toResidentRegistrationNumberPrefix,
+} from "@/utils/birthDate";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 type EditableProfileForm = {
@@ -25,34 +30,6 @@ function getDisplayValue(value: string | number | null | undefined, fallback: st
   }
 
   return String(value);
-}
-
-function formatBirthDate(prefix?: string) {
-  if (!prefix || !/^\d{6}$/.test(prefix)) {
-    return "등록된 생년월일이 없습니다.";
-  }
-
-  const yearPrefix = Number(prefix.slice(0, 2)) > 30 ? "19" : "20";
-  return `${yearPrefix}${prefix.slice(0, 2)}.${prefix.slice(2, 4)}.${prefix.slice(4, 6)}`;
-}
-
-function toBirthDateInputValue(prefix?: string) {
-  if (!prefix || !/^\d{6}$/.test(prefix)) {
-    return "";
-  }
-
-  const yearPrefix = Number(prefix.slice(0, 2)) > 30 ? "19" : "20";
-  return `${yearPrefix}${prefix.slice(0, 2)}-${prefix.slice(2, 4)}-${prefix.slice(4, 6)}`;
-}
-
-function toResidentRegistrationNumberPrefix(date: string) {
-  const [year, month, day] = date.split("-");
-
-  if (!year || !month || !day) {
-    return "";
-  }
-
-  return `${year.slice(-2)}${month}${day}`;
 }
 
 function formatRole(role?: string) {

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
+import styled from "styled-components";
 import { signup } from "@/api/auth/auth.api";
 import {
   Field,
@@ -13,11 +14,13 @@ import {
   SubmitButton,
 } from "@/components/auth/AuthFormParts";
 import AuthShell from "@/components/auth/AuthShell";
+import { colors } from "@/styles/tokens";
 import { toResidentRegistrationNumberPrefix } from "@/utils/birthDate";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 type RegisterFormState = {
   password: string;
+  confirmPassword: string;
   name: string;
   email: string;
   birthDate: string;
@@ -26,6 +29,7 @@ type RegisterFormState = {
 
 const initialState: RegisterFormState = {
   password: "",
+  confirmPassword: "",
   name: "",
   email: "",
   birthDate: "",
@@ -37,10 +41,19 @@ export default function RegisterForm() {
   const [form, setForm] = useState(initialState);
   const [statusMessage, setStatusMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const passwordMatchState =
+    form.confirmPassword.length === 0
+      ? "idle"
+      : form.password === form.confirmPassword
+        ? "matched"
+        : "mismatched";
+  const isPasswordConfirmed =
+    form.confirmPassword.length > 0 && form.password === form.confirmPassword;
 
   const canSubmit =
     form.email.trim().length > 0 &&
     form.password.length >= 8 &&
+    isPasswordConfirmed &&
     form.name.trim().length > 0 &&
     form.birthDate.length > 0;
 
@@ -48,6 +61,9 @@ export default function RegisterForm() {
     event.preventDefault();
 
     if (!canSubmit || isSubmitting) {
+      if (form.confirmPassword.length > 0 && !isPasswordConfirmed) {
+        setStatusMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+      }
       return;
     }
 
@@ -98,7 +114,7 @@ export default function RegisterForm() {
 
           <Field>
             <Label htmlFor="register-password">비밀번호</Label>
-            <Input
+            <PasswordInput
               id="register-password"
               name="password"
               type="password"
@@ -110,6 +126,25 @@ export default function RegisterForm() {
               }
               required
               minLength={8}
+              $matchState={passwordMatchState}
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="register-confirm-password">비밀번호 확인</Label>
+            <PasswordInput
+              id="register-confirm-password"
+              name="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              placeholder="비밀번호를 한 번 더 입력"
+              value={form.confirmPassword}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, confirmPassword: event.target.value }))
+              }
+              required
+              minLength={8}
+              $matchState={passwordMatchState}
             />
           </Field>
 
@@ -162,14 +197,18 @@ export default function RegisterForm() {
           </Field>
         </FieldGroup>
 
-        <Status
+        <RegisterStatus
           role="status"
           aria-live="polite"
           $tone={statusMessage.startsWith("회원가입 정보") ? "error" : "default"}
-          $visible={Boolean(statusMessage)}
+          $matchState={passwordMatchState}
+          $visible={Boolean(statusMessage) || form.confirmPassword.length > 0}
         >
-          {statusMessage}
-        </Status>
+          {statusMessage ||
+            (form.confirmPassword.length > 0 && !isPasswordConfirmed
+              ? "비밀번호와 비밀번호 확인이 일치하지 않습니다."
+              : " ")}
+        </RegisterStatus>
 
         <SubmitButton type="submit" disabled={!canSubmit || isSubmitting}>
           {isSubmitting ? "가입 중" : "회원가입"}
@@ -178,3 +217,41 @@ export default function RegisterForm() {
     </AuthShell>
   );
 }
+
+const PasswordInput = styled(Input)<{ $matchState: "idle" | "matched" | "mismatched" }>`
+  border-color: ${({ $matchState }) =>
+    $matchState === "matched"
+      ? colors.point
+      : $matchState === "mismatched"
+        ? "#e5a19b"
+        : colors.border};
+  background-color: ${({ $matchState }) =>
+    $matchState === "matched"
+      ? "#f4faef"
+      : $matchState === "mismatched"
+        ? "#fff6f5"
+        : colors.white};
+
+  &:focus {
+    border-color: ${({ $matchState }) =>
+      $matchState === "matched" ? colors.point : $matchState === "mismatched" ? "#de8c85" : colors.point};
+    outline: 2px solid
+      ${({ $matchState }) =>
+        $matchState === "matched"
+          ? colors.pointSoft
+          : $matchState === "mismatched"
+            ? "#f8d8d4"
+            : colors.pointSoft};
+  }
+`;
+
+const RegisterStatus = styled(Status)<{
+  $matchState: "idle" | "matched" | "mismatched";
+}>`
+  color: ${({ $tone, $matchState }) =>
+    $matchState === "mismatched"
+      ? "#d98882"
+      : $tone === "error"
+        ? colors.notice
+        : "#52604c"};
+`;

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -13,6 +13,7 @@ import {
   SubmitButton,
 } from "@/components/auth/AuthFormParts";
 import AuthShell from "@/components/auth/AuthShell";
+import { toResidentRegistrationNumberPrefix } from "@/utils/birthDate";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 type RegisterFormState = {
@@ -30,16 +31,6 @@ const initialState: RegisterFormState = {
   birthDate: "",
   phoneNumber: "",
 };
-
-function toResidentRegistrationNumberPrefix(date: string) {
-  const [year, month, day] = date.split("-");
-
-  if (!year || !month || !day) {
-    return "";
-  }
-
-  return `${year.slice(-2)}${month}${day}`;
-}
 
 export default function RegisterForm() {
   const router = useRouter();

--- a/components/info/events/EventDetailPageClient.tsx
+++ b/components/info/events/EventDetailPageClient.tsx
@@ -3,6 +3,7 @@
 import { IconDownload } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import styled from "styled-components";
 import { deletePost, getPost } from "@/api/post/post.api";
 import ToastViewerField from "@/components/admin/posts/ToastViewerField";
 import EventDocumentLayout from "@/components/info/events/EventDocumentLayout";
@@ -25,6 +26,7 @@ import {
 } from "@/components/staff/board/BoardDocument.styles";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
+import { colors, typography } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 type EventDetailPageClientProps = {
@@ -80,27 +82,28 @@ export default function EventDetailPageClient({ postId, channelId }: EventDetail
   return (
     <EventDocumentLayout>
       <DocumentSection>
-        <Toolbar>
-          <ActionLink href="/info/events" $variant="muted">
-            목록
-          </ActionLink>
-
-          {canManagePost ? (
-            <ToolbarRight>
-              <ActionButton
-                type="button"
-                $variant="danger"
-                disabled={!hasChannelId || deletePostMutation.isPending}
-                onClick={() => deletePostMutation.mutate()}
-              >
-                삭제
-              </ActionButton>
-              <ActionLink href={editHref} $variant="edit">
-                수정
-              </ActionLink>
-            </ToolbarRight>
-          ) : null}
-        </Toolbar>
+        <ActionToolbar>
+          <ToolbarRight>
+            {canManagePost ? (
+              <>
+                <ActionLink href={editHref} $variant="edit">
+                  수정
+                </ActionLink>
+                <ActionButton
+                  type="button"
+                  $variant="danger"
+                  disabled={!hasChannelId || deletePostMutation.isPending}
+                  onClick={() => deletePostMutation.mutate()}
+                >
+                  삭제
+                </ActionButton>
+              </>
+            ) : null}
+            <ActionLink href="/info/events" $variant="muted">
+              목록
+            </ActionLink>
+          </ToolbarRight>
+        </ActionToolbar>
 
         {stateMessage ? <StateMessage>{stateMessage}</StateMessage> : null}
 
@@ -137,7 +140,7 @@ export default function EventDetailPageClient({ postId, channelId }: EventDetail
                 );
               })
             ) : (
-              <StateMessage>등록된 자료가 없습니다.</StateMessage>
+              <EmptyAttachmentText>등록된 자료가 없습니다.</EmptyAttachmentText>
             )}
           </FileList>
         </ContentStack>
@@ -145,3 +148,17 @@ export default function EventDetailPageClient({ postId, channelId }: EventDetail
     </EventDocumentLayout>
   );
 }
+
+const ActionToolbar = styled(Toolbar)`
+  justify-content: flex-end;
+`;
+
+const EmptyAttachmentText = styled.span`
+  color: ${colors.placeholder};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;

--- a/components/info/history/HistoryPage.tsx
+++ b/components/info/history/HistoryPage.tsx
@@ -40,13 +40,14 @@ type HistoryPhoto = {
 type HistoryItem = {
   id: number;
   title: string;
+  historyDate?: string;
   detail?: string;
   links?: HistoryLink[];
   photos?: HistoryPhoto[];
 };
 
 type HistoryFormState = {
-  title: string;
+  historyDate: string;
   detail: string;
   linkLabel: string;
   linkHref: string;
@@ -61,7 +62,7 @@ const sidebarItems = [
 ];
 
 const emptyForm: HistoryFormState = {
-  title: "",
+  historyDate: "",
   detail: "",
   linkLabel: "",
   linkHref: "",
@@ -75,19 +76,33 @@ function normalizeHref(href: string) {
   return `https://${trimmed}`;
 }
 
+function formatHistoryDateLabel(historyDate: string) {
+  return historyDate.replaceAll("-", ".");
+}
+
+function getHistorySortTime(item: SiteHistoryResponseDto) {
+  const value = item.historyDate ?? item.title ?? "";
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+  const time = new Date(normalized).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
 function mapHistoryItem(item: SiteHistoryResponseDto): HistoryItem | null {
   if (typeof item.id !== "number" || !item.title) return null;
-  const linkHref = normalizeHref(item.linkHref ?? "");
+  const primaryLink = item.links?.[0];
+  const linkHref = normalizeHref(primaryLink?.href ?? "");
+  const historyDate = item.historyDate ?? undefined;
 
   return {
     id: item.id,
-    title: item.title,
+    title: historyDate ? formatHistoryDateLabel(historyDate) : item.title,
+    historyDate,
     detail: item.detail || undefined,
     links: linkHref
       ? [
           {
             id: `link-${item.id}`,
-            label: item.linkLabel ?? "",
+            label: primaryLink?.label ?? "",
             href: linkHref,
           },
         ]
@@ -95,14 +110,14 @@ function mapHistoryItem(item: SiteHistoryResponseDto): HistoryItem | null {
     photos: item.photos?.map((photo, index) => ({
       id: String(photo.id ?? `${item.id}-${index}`),
       alt: photo.alt ?? item.title ?? "연혁 사진",
-      src: photo.url ?? "",
+      src: photo.src ?? "",
     })),
   };
 }
 
 function itemToForm(item: HistoryItem): HistoryFormState {
   return {
-    title: item.title,
+    historyDate: item.historyDate ?? "",
     detail: item.detail ?? "",
     linkLabel: item.links?.[0]?.label ?? "",
     linkHref: item.links?.[0]?.href === "#" ? "" : item.links?.[0]?.href ?? "",
@@ -140,13 +155,12 @@ export default function HistoryPage() {
   const [isEditorOpen, setIsEditorOpen] = useState(false);
 
   const items = useMemo(
-    () => historiesQuery.data?.history?.map(mapHistoryItem).filter((item): item is HistoryItem => item !== null) ?? [],
+    () =>
+      [...(historiesQuery.data?.history ?? [])]
+        .sort((left, right) => getHistorySortTime(left) - getHistorySortTime(right))
+        .map(mapHistoryItem)
+        .filter((item): item is HistoryItem => item !== null) ?? [],
     [historiesQuery.data],
-  );
-
-  const editingItem = useMemo(
-    () => items.find((item) => item.id === editingItemId) ?? null,
-    [editingItemId, items],
   );
 
   const refreshHistory = () => queryClient.invalidateQueries({ queryKey: queryKeys.siteContent.history() });
@@ -241,19 +255,22 @@ export default function HistoryPage() {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const title = form.title.trim();
-    if (!title) return;
+    const historyDate = form.historyDate.trim();
+    if (!historyDate) return;
 
     const linkHref = normalizeHref(form.linkHref);
+    const title = formatHistoryDateLabel(historyDate);
     const body = {
       title,
+      historyDate,
       detail: form.detail.trim() || undefined,
-      linkLabel: linkHref ? form.linkLabel.trim() : undefined,
-      linkHref: linkHref || undefined,
+      links: linkHref
+        ? [{ label: form.linkLabel.trim(), href: linkHref }]
+        : undefined,
       photos: form.photos.length > 0
         ? form.photos
             .filter((photo) => photo.src)
-            .map((photo) => ({ url: photo.src, alt: photo.alt || title }))
+            .map((photo) => ({ src: photo.src, alt: photo.alt || title }))
         : undefined,
     };
 
@@ -396,12 +413,12 @@ export default function HistoryPage() {
 
             <EditorForm onSubmit={handleSubmit}>
               <Field>
-                <FieldLabel htmlFor="history-title">내용</FieldLabel>
+                <FieldLabel htmlFor="history-title">날짜</FieldLabel>
                 <Input
                   id="history-title"
-                  value={form.title}
-                  onChange={(event) => updateForm("title", event.target.value)}
-                  placeholder="예: 2026년 3월 새 행사 진행"
+                  type="date"
+                  value={form.historyDate}
+                  onChange={(event) => updateForm("historyDate", event.target.value)}
                   required
                 />
               </Field>

--- a/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentDetailPage.tsx
@@ -6,12 +6,15 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import styled, { css } from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
-import { deletePost, getPost, updatePost } from "@/api/post/post.api";
+import { deletePost, getPost, pinPost, updatePost } from "@/api/post/post.api";
 import ToastEditorField from "@/components/admin/posts/ToastEditorField";
 import ToastViewerField from "@/components/admin/posts/ToastViewerField";
 import { resolveArchiveChannel } from "@/components/staff/archive/archive-document-section/archiveDocumentChannels";
+import BoardCommentSection from "@/components/staff/board/BoardCommentSection";
 import {
   ActionLink,
+  CheckboxInput,
+  CheckboxLabel,
   ContentStack,
   DocumentSection,
   DownloadBadge,
@@ -20,6 +23,7 @@ import {
   FileList,
   Label,
   MetaBar,
+  OptionRow,
   StateMessage,
   Toolbar,
   ToolbarRight,
@@ -53,6 +57,8 @@ export default function ArchiveDocumentDetailPage({
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState("");
   const [editContent, setEditContent] = useState("");
+  const [editAllowComment, setEditAllowComment] = useState(true);
+  const [editIsPinned, setEditIsPinned] = useState(false);
   const [editFiles, setEditFiles] = useState<File[]>([]);
 
   const channelsQuery = useQuery({
@@ -120,7 +126,6 @@ export default function ArchiveDocumentDetailPage({
 
       const title = editTitle.trim();
       const contentHtml = editContent.trim();
-      const allowComment = false;
       const uploadArchiveDocument = getUploadArchiveDocument(config.category);
 
       if (uploadArchiveDocument && editFiles.length > 0) {
@@ -130,18 +135,26 @@ export default function ArchiveDocumentDetailPage({
           channelId,
           title,
           contentHtml,
-          allowComment,
+          allowComment: editAllowComment,
+          isPinned: editIsPinned,
           files: editFiles,
           uploadDocument: uploadArchiveDocument,
           sortOrderStart: attachments.length,
           errorLabel: config.title,
+          initialPinned: visiblePost?.isPinned ?? false,
         });
       }
 
-      return updatePost(
+      const updatedPost = await updatePost(
         { channelId, postId },
-        { title, contentHtml, status: "PUBLISHED", allowComment },
+        { title, contentHtml, status: "PUBLISHED", allowComment: editAllowComment },
       );
+
+      if (editIsPinned !== (visiblePost?.isPinned ?? false)) {
+        await pinPost({ channelId, postId }, { isPinned: editIsPinned });
+      }
+
+      return updatedPost;
     },
     onSuccess: async (updatedPost) => {
       setIsEditing(false);
@@ -184,6 +197,8 @@ export default function ArchiveDocumentDetailPage({
 
     setEditTitle(visiblePost.title ?? "");
     setEditContent(visiblePost.contentHtml ?? "");
+    setEditAllowComment(visiblePost.allowComment ?? true);
+    setEditIsPinned(visiblePost.isPinned ?? false);
     setEditFiles([]);
     setIsEditing(true);
   }
@@ -192,6 +207,8 @@ export default function ArchiveDocumentDetailPage({
     setIsEditing(false);
     setEditTitle("");
     setEditContent("");
+    setEditAllowComment(true);
+    setEditIsPinned(false);
     setEditFiles([]);
   }
 
@@ -280,6 +297,27 @@ export default function ArchiveDocumentDetailPage({
           <FieldBox>{author}</FieldBox>
         )}
 
+        {isEditing ? (
+          <OptionRow>
+            <CheckboxLabel>
+              <CheckboxInput
+                type="checkbox"
+                checked={editIsPinned}
+                onChange={(event) => setEditIsPinned(event.target.checked)}
+              />
+              <span>게시물 고정</span>
+            </CheckboxLabel>
+            <CheckboxLabel>
+              <CheckboxInput
+                type="checkbox"
+                checked={editAllowComment}
+                onChange={(event) => setEditAllowComment(event.target.checked)}
+              />
+              <span>댓글 허용</span>
+            </CheckboxLabel>
+          </OptionRow>
+        ) : null}
+
         <Label>설명</Label>
         {isEditing ? (
           <EditorBox>
@@ -342,6 +380,10 @@ export default function ArchiveDocumentDetailPage({
             )}
           </FileList>
         )}
+
+        {hasChannelId && visiblePost?.allowComment !== false ? (
+          <BoardCommentSection channelId={channelId} postId={postId} />
+        ) : null}
       </ContentStack>
     </DocumentSection>
   );

--- a/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentFormPage.tsx
@@ -6,15 +6,18 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { getChannels } from "@/api/channel/channel.api";
-import { createPost, getPost, updatePost } from "@/api/post/post.api";
+import { createPost, getPost, pinPost, updatePost } from "@/api/post/post.api";
 import ToastEditorField from "@/components/admin/posts/ToastEditorField";
 import { resolveArchiveChannel } from "@/components/staff/archive/archive-document-section/archiveDocumentChannels";
 import {
   ActionButton,
+  CheckboxInput,
+  CheckboxLabel,
   DocumentSection,
   Form,
   HiddenFileInput,
   Label,
+  OptionRow,
   PageTitle,
   StateMessage,
   Toolbar,
@@ -45,6 +48,8 @@ export default function ArchiveDocumentFormPage({
   const isEditMode = typeof editPostId === "number" && typeof editChannelId === "number";
   const [title, setTitle] = useState<string | undefined>(undefined);
   const [description, setDescription] = useState<string | undefined>(undefined);
+  const [isPinned, setIsPinned] = useState<boolean | undefined>(undefined);
+  const [allowComment, setAllowComment] = useState<boolean | undefined>(undefined);
   const [files, setFiles] = useState<File[]>([]);
 
   const channelsQuery = useQuery({
@@ -70,6 +75,8 @@ export default function ArchiveDocumentFormPage({
   const visibleTitle = title ?? postDetailQuery.data?.title ?? "";
   const visibleAuthor = postDetailQuery.data?.authorName ?? currentUserName;
   const visibleDescription = description ?? postDetailQuery.data?.contentHtml ?? "";
+  const visibleIsPinned = isPinned ?? postDetailQuery.data?.isPinned ?? false;
+  const visibleAllowComment = allowComment ?? postDetailQuery.data?.allowComment ?? true;
   const existingAttachments = postDetailQuery.data?.attachments ?? [];
   const canManagePost =
     !isEditMode ||
@@ -90,7 +97,6 @@ export default function ArchiveDocumentFormPage({
 
       const title = visibleTitle.trim();
       const contentHtml = visibleDescription.trim();
-      const allowComment = false;
       const uploadArchiveDocument = getUploadArchiveDocument(config.category);
       const sortOrderStart = isEditMode ? existingAttachments.length : 0;
 
@@ -99,23 +105,44 @@ export default function ArchiveDocumentFormPage({
           channelId,
           title,
           contentHtml,
-          allowComment,
+          allowComment: visibleAllowComment,
+          isPinned: visibleIsPinned,
           files,
           uploadDocument: uploadArchiveDocument,
           sortOrderStart,
           errorLabel: config.title,
           ...(isEditMode
-            ? { mode: "update", postId: editPostId }
+            ? {
+                mode: "update",
+                postId: editPostId,
+                initialPinned: postDetailQuery.data?.isPinned ?? false,
+              }
             : { mode: "create" }),
         });
       }
 
-      return isEditMode
-        ? updatePost(
+      if (isEditMode) {
+        const updatedPost = await updatePost(
             { channelId, postId: editPostId },
-            { title, contentHtml, status: "PUBLISHED", allowComment },
-          )
-        : createPost({ channelId }, { title, contentHtml, status: "PUBLISHED", allowComment });
+            { title, contentHtml, status: "PUBLISHED", allowComment: visibleAllowComment },
+          );
+
+        if (visibleIsPinned !== (postDetailQuery.data?.isPinned ?? false)) {
+          await pinPost({ channelId, postId: editPostId }, { isPinned: visibleIsPinned });
+        }
+
+        return updatedPost;
+      }
+
+      return createPost({
+        channelId,
+      }, {
+        title,
+        contentHtml,
+        status: "PUBLISHED",
+        allowComment: visibleAllowComment,
+        isPinned: visibleIsPinned,
+      });
     },
     onSuccess: async (post) => {
       await Promise.all([
@@ -183,6 +210,25 @@ export default function ArchiveDocumentFormPage({
           value={visibleAuthor}
           readOnly
         />
+
+        <OptionRow>
+          <CheckboxLabel>
+            <CheckboxInput
+              type="checkbox"
+              checked={visibleIsPinned}
+              onChange={(event) => setIsPinned(event.target.checked)}
+            />
+            <span>게시물 고정</span>
+          </CheckboxLabel>
+          <CheckboxLabel>
+            <CheckboxInput
+              type="checkbox"
+              checked={visibleAllowComment}
+              onChange={(event) => setAllowComment(event.target.checked)}
+            />
+            <span>댓글 허용</span>
+          </CheckboxLabel>
+        </OptionRow>
 
         <Label as="label" htmlFor={`${config.category}-description`}>
           설명

--- a/components/staff/archive/archive-document-section/ArchiveDocumentListPage.tsx
+++ b/components/staff/archive/archive-document-section/ArchiveDocumentListPage.tsx
@@ -34,6 +34,10 @@ function getPostTime(post: PostSummaryResponseDto) {
   return Number.isNaN(time) ? 0 : time;
 }
 
+function isPinnedPost(post: PostSummaryResponseDto) {
+  return Boolean(post.isPinned);
+}
+
 export default function ArchiveDocumentListPage({
   config,
   initialPage,
@@ -101,7 +105,11 @@ export default function ArchiveDocumentListPage({
             post.authorName === user?.email),
       );
     })
-    .sort((a, b) => getPostTime(b) - getPostTime(a));
+    .sort((a, b) => {
+      const pinnedDiff = Number(isPinnedPost(b)) - Number(isPinnedPost(a));
+      if (pinnedDiff !== 0) return pinnedDiff;
+      return getPostTime(b) - getPostTime(a);
+    });
 
   const totalPages = Math.max(1, Math.ceil(filteredPosts.length / ARCHIVE_DOCUMENTS_PER_PAGE));
   const currentPage = requestedPage > totalPages ? 1 : requestedPage;
@@ -122,6 +130,7 @@ export default function ArchiveDocumentListPage({
     date: formatUtcToKstShortDate(post.createdAt ?? post.updatedAt),
     status: "",
     detailHref: `${config.listPath}/${post.id ?? ""}?channelId=${post.channelId ?? channelId}`,
+    isPinned: post.isPinned,
   }));
 
   const emptyMessage = postsQuery.isLoading

--- a/components/staff/archive/archive-document-section/archiveDocumentUpload.ts
+++ b/components/staff/archive/archive-document-section/archiveDocumentUpload.ts
@@ -1,5 +1,5 @@
 import type { FileUploadResponseDto } from "@/api/file/file.dto";
-import { attachPostFile, createPost, publishPost, updatePost } from "@/api/post/post.api";
+import { attachPostFile, createPost, pinPost, publishPost, updatePost } from "@/api/post/post.api";
 import type { PostDetailResponseDto } from "@/api/post/post.dto";
 import {
   uploadDocumentFormsDocument,
@@ -30,11 +30,12 @@ type PublishArchivePostWithNewFilesParams = {
   title: string;
   contentHtml: string;
   allowComment: boolean;
+  isPinned: boolean;
   files: File[];
   uploadDocument: UploadArchiveDocumentFn;
   sortOrderStart: number;
   errorLabel: string;
-} & ({ mode: "create" } | { mode: "update"; postId: number });
+} & ({ mode: "create" } | { mode: "update"; postId: number; initialPinned: boolean });
 
 /** DRAFT 저장 → Drive 메타 등록 → 첨부 연동 → 발행 */
 export async function publishArchivePostWithNewFiles(
@@ -45,6 +46,7 @@ export async function publishArchivePostWithNewFiles(
     title,
     contentHtml,
     allowComment,
+    isPinned,
     files,
     uploadDocument,
     sortOrderStart,
@@ -77,5 +79,14 @@ export async function publishArchivePostWithNewFiles(
     );
   }
 
-  return publishPost({ channelId, postId: draftPost.id }, publishBody);
+  const publishedPost = await publishPost({ channelId, postId: draftPost.id }, publishBody);
+
+  const shouldUpdatePinned =
+    params.mode === "create" ? isPinned : isPinned !== params.initialPinned;
+
+  if (shouldUpdatePinned) {
+    await pinPost({ channelId, postId: draftPost.id }, { isPinned });
+  }
+
+  return publishedPost;
 }

--- a/components/staff/archive/meeting-records/MeetingRecordDetailPage.tsx
+++ b/components/staff/archive/meeting-records/MeetingRecordDetailPage.tsx
@@ -25,6 +25,7 @@ import {
   ToolbarRight,
   ViewerBox,
 } from "@/components/staff/archive/meeting-records/MeetingRecordDocument.styles";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
@@ -35,6 +36,7 @@ type MeetingRecordDetailPageProps = {
 export default function MeetingRecordDetailPage({ recordId }: MeetingRecordDetailPageProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { user, status: authStatus } = useAuthSession();
   const [isEditing, setIsEditing] = useState(false);
   const {
     data: meetingRecord,
@@ -53,6 +55,12 @@ export default function MeetingRecordDetailPage({ recordId }: MeetingRecordDetai
       router.replace("/staff/archive/meeting-records");
     },
   });
+  const canManageRecord =
+    authStatus === "authenticated" &&
+    (user?.role === "ADMIN" ||
+      (typeof user?.id === "number" &&
+        typeof meetingRecord?.authorId === "number" &&
+        user.id === meetingRecord.authorId));
 
   if (isEditing && meetingRecord) {
     return (
@@ -69,22 +77,26 @@ export default function MeetingRecordDetailPage({ recordId }: MeetingRecordDetai
     <DocumentSection>
       <Toolbar>
         <ToolbarRight>
-          <ActionButton
-            type="button"
-            $variant="danger"
-            disabled={!meetingRecord || deleteMutation.isPending}
-            onClick={() => deleteMutation.mutate()}
-          >
-            {deleteMutation.isPending ? "삭제 중" : "삭제"}
-          </ActionButton>
-          <ActionButton
-            type="button"
-            $variant="edit"
-            disabled={!meetingRecord}
-            onClick={() => setIsEditing(true)}
-          >
-            수정
-          </ActionButton>
+          {canManageRecord ? (
+            <>
+              <ActionButton
+                type="button"
+                $variant="danger"
+                disabled={!meetingRecord || deleteMutation.isPending}
+                onClick={() => deleteMutation.mutate()}
+              >
+                {deleteMutation.isPending ? "삭제 중" : "삭제"}
+              </ActionButton>
+              <ActionButton
+                type="button"
+                $variant="edit"
+                disabled={!meetingRecord}
+                onClick={() => setIsEditing(true)}
+              >
+                수정
+              </ActionButton>
+            </>
+          ) : null}
           <ActionLink href="/staff/archive/meeting-records" $variant="muted">
             목록
           </ActionLink>

--- a/components/staff/board/BoardCommentSection.tsx
+++ b/components/staff/board/BoardCommentSection.tsx
@@ -1,0 +1,759 @@
+"use client";
+
+import { IconCornerDownRight } from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import styled from "styled-components";
+import {
+  createComment,
+  deleteComment,
+  getComments,
+  updateComment,
+} from "@/api/comment/comment.api";
+import type { CommentResponseDto } from "@/api/comment/comment.dto";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+import { buildBoardCommentThread } from "./boardComments";
+
+type BoardCommentSectionProps = {
+  channelId: number;
+  postId: number;
+};
+
+export default function BoardCommentSection({ channelId, postId }: BoardCommentSectionProps) {
+  const queryClient = useQueryClient();
+  const { status, user } = useAuthSession();
+  const [commentDraft, setCommentDraft] = useState("");
+  const [replyDraft, setReplyDraft] = useState("");
+  const [openReplyCommentId, setOpenReplyCommentId] = useState<number | null>(null);
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+
+  const commentsQuery = useQuery({
+    queryKey: queryKeys.comments.boardDetail(channelId, postId),
+    queryFn: () => getComments({ channelId, postId }),
+    retry: false,
+  });
+
+  const commentThread = useMemo(
+    () => buildBoardCommentThread(commentsQuery.data ?? []),
+    [commentsQuery.data],
+  );
+
+  const createCommentMutation = useMutation({
+    mutationFn: ({ content, parentCommentId }: { content: string; parentCommentId?: number }) =>
+      createComment({ channelId, postId }, { content, parentCommentId }),
+    onSuccess: async (_, variables) => {
+      if (typeof variables.parentCommentId === "number") {
+        setReplyDraft("");
+        setOpenReplyCommentId(null);
+      } else {
+        setCommentDraft("");
+      }
+
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.boardDetail(channelId, postId),
+      });
+    },
+  });
+
+  const updateCommentMutation = useMutation({
+    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
+      updateComment({ channelId, postId, commentId }, { content }),
+    onSuccess: async () => {
+      setEditingCommentId(null);
+      setEditDraft("");
+
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.boardDetail(channelId, postId),
+      });
+    },
+  });
+
+  const deleteCommentMutation = useMutation({
+    mutationFn: (commentId: number) => deleteComment({ channelId, postId, commentId }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.comments.boardDetail(channelId, postId),
+      });
+    },
+  });
+
+  const isAuthenticated = status === "authenticated" && Boolean(user);
+  const totalCommentCount = commentThread.reduce(
+    (count, comment) => count + 1 + comment.replies.length,
+    0,
+  );
+  const stateMessage =
+    commentsQuery.isLoading && !commentsQuery.data
+      ? "댓글을 불러오는 중입니다."
+      : commentsQuery.isError
+        ? "댓글을 불러오지 못했습니다."
+        : createCommentMutation.isError
+          ? "댓글 등록에 실패했습니다."
+          : updateCommentMutation.isError
+            ? "댓글 수정에 실패했습니다."
+            : deleteCommentMutation.isError
+              ? "댓글 삭제에 실패했습니다."
+              : !isAuthenticated && status !== "loading"
+                ? "로그인 후 댓글을 작성할 수 있습니다."
+                : "";
+
+  const submitComment = (parentCommentId?: number) => {
+    const source = typeof parentCommentId === "number" ? replyDraft : commentDraft;
+    const content = source.trim();
+
+    if (!content || !isAuthenticated || createCommentMutation.isPending) {
+      return;
+    }
+
+    createCommentMutation.mutate({ content, parentCommentId });
+  };
+
+  const startEdit = (comment: CommentResponseDto) => {
+    setOpenReplyCommentId(null);
+    setReplyDraft("");
+    setEditingCommentId(comment.id ?? null);
+    setEditDraft(comment.content?.trim() ?? "");
+  };
+
+  const submitEdit = (commentId?: number) => {
+    const content = editDraft.trim();
+
+    if (
+      typeof commentId !== "number" ||
+      !content ||
+      !isAuthenticated ||
+      updateCommentMutation.isPending
+    ) {
+      return;
+    }
+
+    updateCommentMutation.mutate({ commentId, content });
+  };
+
+  return (
+    <Section>
+      <HeaderRow>
+        <SectionTitle>{`댓글 (${totalCommentCount})`}</SectionTitle>
+        <SubmitButton
+          type="button"
+          disabled={!isAuthenticated || !commentDraft.trim() || createCommentMutation.isPending}
+          onClick={() => submitComment()}
+        >
+          작성 완료
+        </SubmitButton>
+      </HeaderRow>
+
+      <CommentTextarea
+        placeholder={isAuthenticated ? "내용" : "로그인 후 댓글을 작성할 수 있습니다."}
+        value={commentDraft}
+        disabled={!isAuthenticated || createCommentMutation.isPending}
+        onChange={(event) => setCommentDraft(event.target.value)}
+      />
+
+      {stateMessage ? <StateText>{stateMessage}</StateText> : null}
+
+      {commentThread.length === 0 && !commentsQuery.isLoading && !commentsQuery.isError ? (
+        <StateText>아직 댓글이 없습니다.</StateText>
+      ) : null}
+
+      <CommentList>
+        {commentThread.map((comment) => (
+          <CommentGroup key={comment.id ?? `comment-${comment.createdAt}`}>
+            <CommentItem>
+              <CommentMeta>
+                <CommentAuthor>{comment.authorName ?? "익명"}</CommentAuthor>
+                <CommentDate>
+                  {formatUtcToKstShortDate(comment.createdAt ?? comment.updatedAt)}
+                </CommentDate>
+              </CommentMeta>
+              {editingCommentId === comment.id ? (
+                <EditWrap>
+                  <CommentTextarea
+                    placeholder="내용"
+                    value={editDraft}
+                    disabled={updateCommentMutation.isPending}
+                    onChange={(event) => setEditDraft(event.target.value)}
+                  />
+                  <ReplyActionRow>
+                    <TextActionButton
+                      type="button"
+                      onClick={() => {
+                        setEditingCommentId(null);
+                        setEditDraft("");
+                      }}
+                    >
+                      취소
+                    </TextActionButton>
+                    <SubmitButton
+                      type="button"
+                      disabled={!editDraft.trim() || updateCommentMutation.isPending}
+                      onClick={() => submitEdit(comment.id)}
+                    >
+                      수정 완료
+                    </SubmitButton>
+                  </ReplyActionRow>
+                </EditWrap>
+              ) : (
+                <CommentBodyRow>
+                  <CommentBody>{getCommentBody(comment)}</CommentBody>
+                </CommentBodyRow>
+              )}
+              {comment.status !== "DELETED" ? (
+                <ActionRow>
+                  <ManageActionGroup>
+                    {canManageComment(comment, user) ? (
+                      <>
+                        <TextActionButton
+                          type="button"
+                          $tone="muted"
+                          onClick={() => startEdit(comment)}
+                        >
+                          수정
+                        </TextActionButton>
+                        <TextActionButton
+                          type="button"
+                          $tone="danger"
+                          disabled={deleteCommentMutation.isPending}
+                          onClick={() => {
+                            if (typeof comment.id === "number") {
+                              deleteCommentMutation.mutate(comment.id);
+                            }
+                          }}
+                        >
+                          삭제
+                        </TextActionButton>
+                      </>
+                    ) : (
+                      <>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          수정
+                        </ActionGhostButton>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          삭제
+                        </ActionGhostButton>
+                      </>
+                    )}
+                  </ManageActionGroup>
+                  <ReplyActionButtonWrap>
+                    <TextActionButton
+                      type="button"
+                      disabled={!isAuthenticated}
+                      onClick={() =>
+                        setOpenReplyCommentId((current) =>
+                          current === comment.id ? null : (comment.id ?? null),
+                        )
+                      }
+                    >
+                      댓글 추가
+                    </TextActionButton>
+                  </ReplyActionButtonWrap>
+                </ActionRow>
+              ) : null}
+            </CommentItem>
+
+            {openReplyCommentId === comment.id && comment.status !== "DELETED" ? (
+              <ReplyComposerWrap>
+                <CommentTextarea
+                  placeholder={isAuthenticated ? "내용" : "로그인 후 댓글을 작성할 수 있습니다."}
+                  value={replyDraft}
+                  disabled={!isAuthenticated || createCommentMutation.isPending}
+                  onChange={(event) => setReplyDraft(event.target.value)}
+                />
+                <ReplyActionRow>
+                  <TextActionButton
+                    type="button"
+                    onClick={() => {
+                      setOpenReplyCommentId(null);
+                      setReplyDraft("");
+                    }}
+                  >
+                    취소
+                  </TextActionButton>
+                  <SubmitButton
+                    type="button"
+                    disabled={
+                      !isAuthenticated || !replyDraft.trim() || createCommentMutation.isPending
+                    }
+                    onClick={() => {
+                      if (typeof comment.id === "number") {
+                        submitComment(comment.id);
+                      }
+                    }}
+                  >
+                    작성 완료
+                  </SubmitButton>
+                </ReplyActionRow>
+              </ReplyComposerWrap>
+            ) : null}
+
+            {comment.replies.map((reply) => (
+              <CommentItem key={reply.id ?? `reply-${reply.createdAt}`}>
+                <ReplyMeta>
+                  <ReplyMetaArrow aria-hidden="true" stroke={1.8} />
+                  <CommentAuthor>{reply.authorName ?? "익명"}</CommentAuthor>
+                  <CommentDate>
+                    {formatUtcToKstShortDate(reply.createdAt ?? reply.updatedAt)}
+                  </CommentDate>
+                </ReplyMeta>
+                {editingCommentId === reply.id ? (
+                  <EditWrap $isReply>
+                    <CommentTextarea
+                      placeholder="내용"
+                      value={editDraft}
+                      disabled={updateCommentMutation.isPending}
+                      onChange={(event) => setEditDraft(event.target.value)}
+                    />
+                    <ReplyActionRow>
+                      <TextActionButton
+                        type="button"
+                        onClick={() => {
+                          setEditingCommentId(null);
+                          setEditDraft("");
+                        }}
+                      >
+                        취소
+                      </TextActionButton>
+                      <SubmitButton
+                        type="button"
+                        disabled={!editDraft.trim() || updateCommentMutation.isPending}
+                        onClick={() => submitEdit(reply.id)}
+                      >
+                        수정 완료
+                      </SubmitButton>
+                    </ReplyActionRow>
+                  </EditWrap>
+                ) : (
+                  <ReplyBodyRow>
+                    <CommentBody>
+                      {reply.status === "DELETED" ? (
+                        "삭제된 댓글입니다."
+                      ) : (
+                        <>
+                          <ReplyMention>@{comment.authorName ?? "익명"}</ReplyMention>{" "}
+                          {reply.content?.trim() || "내용이 없습니다."}
+                        </>
+                      )}
+                    </CommentBody>
+                  </ReplyBodyRow>
+                )}
+                {reply.status !== "DELETED" ? (
+                  <ReplyOnlyActionRow>
+                    {canManageComment(reply, user) ? (
+                      <>
+                        <TextActionButton
+                          type="button"
+                          $tone="muted"
+                          onClick={() => startEdit(reply)}
+                        >
+                          수정
+                        </TextActionButton>
+                        <TextActionButton
+                          type="button"
+                          $tone="danger"
+                          disabled={deleteCommentMutation.isPending}
+                          onClick={() => {
+                            if (typeof reply.id === "number") {
+                              deleteCommentMutation.mutate(reply.id);
+                            }
+                          }}
+                        >
+                          삭제
+                        </TextActionButton>
+                      </>
+                    ) : (
+                      <>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          수정
+                        </ActionGhostButton>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          삭제
+                        </ActionGhostButton>
+                      </>
+                    )}
+                  </ReplyOnlyActionRow>
+                ) : null}
+              </CommentItem>
+            ))}
+          </CommentGroup>
+        ))}
+      </CommentList>
+    </Section>
+  );
+}
+
+function getCommentBody(comment: CommentResponseDto) {
+  if (comment.status === "DELETED") {
+    return "삭제된 댓글입니다.";
+  }
+
+  return comment.content?.trim() || "내용이 없습니다.";
+}
+
+function canManageComment(
+  comment: CommentResponseDto,
+  user: {
+    id?: number;
+    role?: string;
+    name?: string;
+    nickname?: string;
+    email?: string;
+  } | null,
+) {
+  if (!user || comment.status === "DELETED") {
+    return false;
+  }
+
+  if (user.role === "ADMIN") {
+    return true;
+  }
+
+  if (typeof user.id === "number" && comment.authorId === user.id) {
+    return true;
+  }
+
+  const authorName = comment.authorName;
+
+  return Boolean(
+    authorName &&
+    (authorName === user.name || authorName === user.nickname || authorName === user.email),
+  );
+}
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space20};
+  margin-top: ${spacing.space8};
+  padding-top: ${spacing.space20};
+  border-top: 1px solid ${colors.border};
+
+  @media (min-width: 120rem) {
+    gap: 1.875rem;
+    padding-top: 1.875rem;
+  }
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${spacing.space16};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize20};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+const SubmitButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  border: 1px solid ${colors.point};
+  border-radius: ${radii.radius15};
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space20};
+  color: ${colors.point};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const CommentTextarea = styled.textarea`
+  width: 100%;
+  min-height: 7rem;
+  border: 1px solid ${colors.muted};
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space12};
+  color: ${colors.text};
+  font: inherit;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  resize: vertical;
+
+  &::placeholder {
+    color: ${colors.muted};
+  }
+
+  &:disabled {
+    background-color: ${colors.white};
+    color: ${colors.placeholder};
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 10.0625rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const StateText = styled.p`
+  margin: 0;
+  color: ${colors.placeholder};
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const CommentList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CommentGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CommentItem = styled.article`
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 0 ${spacing.space12};
+  border-bottom: 1px solid ${colors.border};
+
+  @media (min-width: 120rem) {
+    padding: 3rem 0 1.75rem;
+  }
+`;
+
+const CommentMeta = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: ${spacing.space8};
+  min-height: 1.75rem;
+  padding: 0 ${spacing.space12};
+  @media (min-width: 120rem) {
+    min-height: 1.75rem;
+    padding: 0 ${spacing.space20};
+    gap: ${spacing.space12};
+  }
+`;
+
+const ReplyMeta = styled(CommentMeta)`
+  position: relative;
+  padding-left: 3rem;
+
+  @media (min-width: 120rem) {
+    padding-left: 4.4375rem;
+  }
+`;
+
+const ReplyMetaArrow = styled(IconCornerDownRight)`
+  position: absolute;
+  left: ${spacing.space20};
+  top: 50%;
+  width: ${typography.fontSize14};
+  height: ${typography.fontSize14};
+  transform: translateY(-50%);
+  color: ${colors.text};
+  pointer-events: none;
+
+  @media (min-width: 120rem) {
+    left: ${spacing.space20};
+    width: ${typography.fontSize20};
+    height: ${typography.fontSize20};
+  }
+`;
+
+const CommentAuthor = styled.span`
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const CommentDate = styled.span`
+  color: ${colors.muted};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const CommentBodyRow = styled.div`
+  padding-left: ${spacing.space12};
+  margin-bottom: 1rem;
+
+  @media (min-width: 120rem) {
+    padding-left: ${spacing.space20};
+    margin-bottom: 1rem;
+  }
+`;
+
+const ReplyBodyRow = styled.div`
+  padding-left: 3rem;
+  margin-bottom: 1rem;
+
+  @media (min-width: 120rem) {
+    padding-left: 4.4375rem;
+    margin-bottom: 1rem;
+  }
+`;
+
+const EditWrap = styled.div<{ $isReply?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+  padding: 0 0 ${spacing.space12} ${({ $isReply }) => ($isReply ? "3rem" : spacing.space12)};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding: 0 0 ${spacing.space16} ${({ $isReply }) => ($isReply ? "4.4375rem" : spacing.space20)};
+  }
+`;
+
+const CommentBody = styled.p`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ReplyMention = styled.span`
+  color: ${colors.point};
+  font-weight: 700;
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space8};
+  padding-left: ${spacing.space12};
+  padding-right: ${spacing.space8};
+  margin-bottom: -${spacing.space8};
+
+  @media (min-width: 120rem) {
+    padding-right: ${spacing.space12};
+    margin-bottom: -${spacing.space20};
+  }
+`;
+
+const ManageActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space8};
+  min-width: 4.5rem;
+
+  @media (min-width: 120rem) {
+    min-width: 7rem;
+  }
+`;
+
+const ReplyActionButtonWrap = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const ReplyOnlyActionRow = styled(ActionRow)`
+  gap: ${spacing.space8};
+  padding-left: 3rem;
+
+  @media (min-width: 120rem) {
+    padding-left: 4.4375rem;
+  }
+`;
+
+const ReplyComposerWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+  padding: ${spacing.space12} 0 ${spacing.space20} 3rem;
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding: ${spacing.space16} 0 ${spacing.space20} 4.4375rem;
+  }
+`;
+
+const ReplyActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space12};
+`;
+
+const TextActionButton = styled.button<{ $tone?: "default" | "muted" | "danger" }>`
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: ${({ $tone }) =>
+    $tone === "muted" ? colors.placeholder : $tone === "danger" ? colors.notice : colors.point};
+  font-size: ${typography.fontSize13};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-position: from-font;
+  cursor: pointer;
+
+  &:not(:disabled):hover {
+    opacity: 0.72;
+  }
+
+  &:disabled {
+    color: ${colors.muted};
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const ActionGhostButton = styled(TextActionButton).attrs({
+  type: "button",
+  disabled: true,
+})`
+  visibility: hidden;
+  pointer-events: none;
+`;

--- a/components/staff/board/BoardCommentSection.tsx
+++ b/components/staff/board/BoardCommentSection.tsx
@@ -179,7 +179,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                     onChange={(event) => setEditDraft(event.target.value)}
                   />
                   <ReplyActionRow>
-                    <TextActionButton
+                    <SecondaryButton
                       type="button"
                       onClick={() => {
                         setEditingCommentId(null);
@@ -187,7 +187,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                       }}
                     >
                       취소
-                    </TextActionButton>
+                    </SecondaryButton>
                     <SubmitButton
                       type="button"
                       disabled={!editDraft.trim() || updateCommentMutation.isPending}
@@ -202,7 +202,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                   <CommentBody>{getCommentBody(comment)}</CommentBody>
                 </CommentBodyRow>
               )}
-              {comment.status !== "DELETED" ? (
+              {comment.status !== "DELETED" && editingCommentId !== comment.id ? (
                 <ActionRow>
                   <ManageActionGroup>
                     {canManageComment(comment, user) ? (
@@ -264,7 +264,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                   onChange={(event) => setReplyDraft(event.target.value)}
                 />
                 <ReplyActionRow>
-                  <TextActionButton
+                  <SecondaryButton
                     type="button"
                     onClick={() => {
                       setOpenReplyCommentId(null);
@@ -272,7 +272,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                     }}
                   >
                     취소
-                  </TextActionButton>
+                  </SecondaryButton>
                   <SubmitButton
                     type="button"
                     disabled={
@@ -308,7 +308,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                       onChange={(event) => setEditDraft(event.target.value)}
                     />
                     <ReplyActionRow>
-                      <TextActionButton
+                      <SecondaryButton
                         type="button"
                         onClick={() => {
                           setEditingCommentId(null);
@@ -316,7 +316,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                         }}
                       >
                         취소
-                      </TextActionButton>
+                      </SecondaryButton>
                       <SubmitButton
                         type="button"
                         disabled={!editDraft.trim() || updateCommentMutation.isPending}
@@ -340,7 +340,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                     </CommentBody>
                   </ReplyBodyRow>
                 )}
-                {reply.status !== "DELETED" ? (
+                {reply.status !== "DELETED" && editingCommentId !== reply.id ? (
                   <ReplyOnlyActionRow>
                     {canManageComment(reply, user) ? (
                       <>
@@ -477,6 +477,10 @@ const SubmitButton = styled.button`
   white-space: nowrap;
   cursor: pointer;
 
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+  }
+
   &:disabled {
     opacity: 0.45;
     cursor: not-allowed;
@@ -486,6 +490,21 @@ const SubmitButton = styled.button`
     min-height: 4rem;
     padding: ${spacing.space20} 1.875rem;
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const SecondaryButton = styled(SubmitButton)`
+  border-color: ${colors.border};
+  background-color: ${colors.white};
+  color: ${colors.placeholder};
+
+  &:not(:disabled):hover {
+    background-color: ${colors.background};
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 `;
 
@@ -636,11 +655,11 @@ const EditWrap = styled.div<{ $isReply?: boolean }>`
   display: flex;
   flex-direction: column;
   gap: ${spacing.space12};
-  padding: 0 0 ${spacing.space12} ${({ $isReply }) => ($isReply ? "3rem" : spacing.space12)};
+  padding-left: ${({ $isReply }) => ($isReply ? "3rem" : spacing.space12)};
 
   @media (min-width: 120rem) {
     gap: ${spacing.space20};
-    padding: 0 0 ${spacing.space16} ${({ $isReply }) => ($isReply ? "4.4375rem" : spacing.space20)};
+    padding-left: ${({ $isReply }) => ($isReply ? "4.4375rem" : spacing.space20)};
   }
 `;
 

--- a/components/staff/board/BoardDetailPageClient.tsx
+++ b/components/staff/board/BoardDetailPageClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { deletePost, getPost } from "@/api/post/post.api";
 import ToastViewerField from "@/components/admin/posts/ToastViewerField";
+import BoardCommentSection from "@/components/staff/board/BoardCommentSection";
 import BoardShell from "@/components/staff/board/BoardShell";
 import {
   ActionButton,
@@ -172,6 +173,10 @@ export default function BoardDetailPageClient({ postId, channelId }: BoardDetail
               <EmptyAttachmentText>첨부된 자료가 없습니다.</EmptyAttachmentText>
             )}
           </FileList>
+
+          {hasChannelId && visiblePost?.allowComment !== false ? (
+            <BoardCommentSection channelId={channelId} postId={postId} />
+          ) : null}
         </ContentStack>
       </DocumentSection>
     </BoardShell>

--- a/components/staff/board/boardComments.test.ts
+++ b/components/staff/board/boardComments.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildBoardCommentThread } from "./boardComments";
+
+describe("buildBoardCommentThread", () => {
+  it("groups replies under their parent comment in chronological order", () => {
+    const thread = buildBoardCommentThread([
+      {
+        id: 3,
+        parentCommentId: 1,
+        content: "reply",
+        createdAt: "2026-06-20T10:03:00",
+      },
+      {
+        id: 2,
+        parentCommentId: null,
+        content: "second root",
+        createdAt: "2026-06-20T10:02:00",
+      },
+      {
+        id: 1,
+        parentCommentId: null,
+        content: "first root",
+        createdAt: "2026-06-20T10:01:00",
+      },
+      {
+        id: 4,
+        parentCommentId: 1,
+        content: "second reply",
+        createdAt: "2026-06-20T10:04:00",
+      },
+    ]);
+
+    expect(thread).toHaveLength(2);
+    expect(thread[0]?.id).toBe(1);
+    expect(thread[0]?.replies.map((comment) => comment.id)).toEqual([3, 4]);
+    expect(thread[1]?.id).toBe(2);
+  });
+
+  it("keeps orphan replies at the root level", () => {
+    const thread = buildBoardCommentThread([
+      {
+        id: 9,
+        parentCommentId: 999,
+        content: "orphan reply",
+        createdAt: "2026-06-20T11:00:00",
+      },
+    ]);
+
+    expect(thread).toHaveLength(1);
+    expect(thread[0]).toMatchObject({ id: 9, parentCommentId: 999, replies: [] });
+  });
+});

--- a/components/staff/board/boardComments.ts
+++ b/components/staff/board/boardComments.ts
@@ -1,0 +1,74 @@
+import type { CommentResponseDto } from "@/api/comment/comment.dto";
+
+export type BoardCommentThreadItem = CommentResponseDto & {
+  replies: CommentResponseDto[];
+};
+
+function sortCommentsByCreatedAt<T extends CommentResponseDto>(comments: T[]) {
+  return [...comments].sort((left, right) => {
+    const leftTime = left.createdAt ? new Date(left.createdAt).getTime() : 0;
+    const rightTime = right.createdAt ? new Date(right.createdAt).getTime() : 0;
+
+    if (leftTime === rightTime) {
+      return (left.id ?? 0) - (right.id ?? 0);
+    }
+
+    return leftTime - rightTime;
+  });
+}
+
+export function buildBoardCommentThread(
+  comments: CommentResponseDto[],
+): BoardCommentThreadItem[] {
+  const sortedComments = sortCommentsByCreatedAt(comments);
+  const parentIds = new Set(
+    sortedComments
+      .filter((comment) => comment.parentCommentId == null)
+      .map((comment) => comment.id)
+      .filter((id): id is number => typeof id === "number"),
+  );
+  const threadMap = new Map<number, BoardCommentThreadItem>();
+  const rootComments: BoardCommentThreadItem[] = [];
+
+  sortedComments.forEach((comment) => {
+    const commentId = comment.id;
+
+    if (typeof commentId !== "number") {
+      rootComments.push({ ...comment, replies: [] });
+      return;
+    }
+
+    threadMap.set(commentId, { ...comment, replies: [] });
+  });
+
+  sortedComments.forEach((comment) => {
+    const commentId = comment.id;
+    const parentCommentId = comment.parentCommentId;
+
+    if (typeof commentId !== "number") {
+      return;
+    }
+
+    const current = threadMap.get(commentId);
+
+    if (!current) {
+      return;
+    }
+
+    if (parentCommentId == null || !parentIds.has(parentCommentId)) {
+      rootComments.push(current);
+      return;
+    }
+
+    const parent = threadMap.get(parentCommentId);
+
+    if (!parent) {
+      rootComments.push(current);
+      return;
+    }
+
+    parent.replies.push(current);
+  });
+
+  return rootComments;
+}

--- a/components/staff/class-management/exchange-request/ExchangeProposalList.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeProposalList.tsx
@@ -1,18 +1,44 @@
 "use client";
 
+import { useRef } from "react";
 import Link from "next/link";
+import { IconCalendarMonth } from "@tabler/icons-react";
 import styled from "styled-components";
 import type { LessonExchangeProposalDto } from "@/api/lessonExchange/lessonExchange.dto";
-import { layout, radii, spacing, typography } from "@/styles/tokens";
+import { FieldInput, FieldTextarea } from "@/components/common/FormField";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 
 interface ExchangeProposalListProps {
   acceptedHref: string | ((proposal: LessonExchangeProposalDto) => string);
   acceptLabel?: string;
+  withdrawAcceptedLabel?: string;
   showAcceptLink?: boolean;
   showCardTopBorder?: boolean;
   isAccepting?: boolean;
   onAcceptProposal?: (proposal: LessonExchangeProposalDto) => void;
+  canManageProposal?: (proposal: LessonExchangeProposalDto) => boolean;
+  canWithdrawAcceptedProposal?: (proposal: LessonExchangeProposalDto) => boolean;
+  editingProposalId?: number | null;
+  editingProposalValues?: {
+    className: string;
+    lessonDate: string;
+    content: string;
+  };
+  isUpdatingProposal?: boolean;
+  isDeletingProposal?: boolean;
+  onStartProposalEdit?: (proposal: LessonExchangeProposalDto) => void;
+  onCancelProposalEdit?: () => void;
+  onSaveProposalEdit?: (proposalId: number) => void;
+  onDeleteProposal?: (proposalId: number) => void;
+  onWithdrawAcceptedProposal?: (proposalId: number) => void;
+  onProposalEditValueChange?: (patch: {
+    className?: string;
+    lessonDate?: string;
+    content?: string;
+  }) => void;
+  assignmentClassNames?: string[];
+  proposalClassName?: string;
   proposals: LessonExchangeProposalDto[];
   proposalsLoading: boolean;
   proposalsError: boolean;
@@ -21,14 +47,52 @@ interface ExchangeProposalListProps {
 export function ExchangeProposalList({
   acceptedHref,
   acceptLabel = "제안 수락하기",
+  withdrawAcceptedLabel = "교환 제안 철회",
   showAcceptLink = true,
   showCardTopBorder = true,
   isAccepting = false,
   onAcceptProposal,
+  canManageProposal,
+  canWithdrawAcceptedProposal,
+  editingProposalId = null,
+  editingProposalValues,
+  isUpdatingProposal = false,
+  isDeletingProposal = false,
+  onStartProposalEdit,
+  onCancelProposalEdit,
+  onSaveProposalEdit,
+  onDeleteProposal,
+  onWithdrawAcceptedProposal,
+  onProposalEditValueChange,
+  assignmentClassNames = [],
+  proposalClassName = "",
   proposals,
   proposalsLoading,
   proposalsError,
 }: ExchangeProposalListProps) {
+  const lessonDateInputRef = useRef<HTMLInputElement>(null);
+
+  const handleOpenDatePicker = () => {
+    const dateInput = lessonDateInputRef.current;
+    if (!dateInput) return;
+
+    if (typeof dateInput.showPicker === "function") {
+      dateInput.showPicker();
+      return;
+    }
+
+    dateInput.click();
+  };
+
+  const handleLessonDateChange = (value: string) => {
+    if (!value) return;
+
+    const [year, month, day] = value.split("-");
+    onProposalEditValueChange?.({
+      lessonDate: `${year.slice(-2)}.${month}.${day}`,
+    });
+  };
+
   return (
     <ProposalList>
       {proposalsLoading ? (
@@ -45,42 +109,193 @@ export function ExchangeProposalList({
             typeof acceptedHref === "function" ? acceptedHref(proposal) : acceptedHref;
           const canShowAccept =
             showAcceptLink && (proposal.status === "ACTIVE" || proposal.status == null);
+          const canShowManageActions = canManageProposal?.(proposal) ?? false;
+          const canShowWithdrawAccepted = canWithdrawAcceptedProposal?.(proposal) ?? false;
+          const isEditingProposal =
+            typeof proposal.id === "number" && editingProposalId === proposal.id;
+          const shouldRenderFooter =
+            canShowAccept || canShowWithdrawAccepted || Boolean(canManageProposal);
 
           return (
             <ProposalCard key={proposal.id ?? index} $showTopBorder={showCardTopBorder}>
               <ProposalDate>{formatUtcToKstShortDate(proposal.createdAt) || "—"}</ProposalDate>
-              <ProposalMetaRow>
-                <ProposalMetaCell>
-                  <MetaLabel>반 이름</MetaLabel>
-                  <MetaValue>{proposal.classroomName ?? "—"}</MetaValue>
-                </ProposalMetaCell>
+              {isEditingProposal ? (
+                <ProposalEditForm>
+                  <FieldInput
+                    $tone="proposal"
+                    aria-label="작성자"
+                    placeholder="작성자"
+                    type="text"
+                    value={proposal.proposedByName ?? ""}
+                    readOnly
+                  />
 
-                <ProposalMetaCell>
-                  <MetaLabel>작성자</MetaLabel>
-                  <MetaValue>{proposal.proposedByName ?? "—"}</MetaValue>
-                </ProposalMetaCell>
-
-                <ProposalMetaCell>
-                  <MetaLabel>수업일자</MetaLabel>
-                  <MetaValue>{formatUtcToKstShortDate(proposal.lessonDate) || "—"}</MetaValue>
-                </ProposalMetaCell>
-              </ProposalMetaRow>
-
-              <ProposalContent>{proposal.content ?? "—"}</ProposalContent>
-
-              {canShowAccept ? (
-                <ProposalFooter>
-                  {onAcceptProposal ? (
-                    <AcceptButton
-                      type="button"
-                      disabled={isAccepting}
-                      onClick={() => onAcceptProposal(proposal)}
+                  {assignmentClassNames.length > 0 ? (
+                    <EditClassSelect
+                      aria-label="반 이름"
+                      value={editingProposalValues?.className ?? ""}
+                      onChange={(event) =>
+                        onProposalEditValueChange?.({ className: event.target.value })
+                      }
                     >
-                      {acceptLabel}
-                    </AcceptButton>
+                      <option value="" disabled>
+                        반을 선택해 주세요
+                      </option>
+                      {assignmentClassNames.map((name) => (
+                        <option key={name} value={name}>
+                          {name}
+                        </option>
+                      ))}
+                    </EditClassSelect>
                   ) : (
-                    <AcceptLink href={acceptHref}>{acceptLabel}</AcceptLink>
+                    <FieldInput
+                      $tone="proposal"
+                      aria-label="반 이름"
+                      placeholder="반 이름"
+                      type="text"
+                      value={editingProposalValues?.className || proposalClassName || ""}
+                      readOnly
+                    />
                   )}
+
+                  <DateRow onClick={handleOpenDatePicker}>
+                    <EditDateInput
+                      aria-label="수업 일자"
+                      placeholder="00.00.00"
+                      value={editingProposalValues?.lessonDate ?? ""}
+                      readOnly
+                      onClick={handleOpenDatePicker}
+                    />
+                    <HiddenNativeDateInput
+                      ref={lessonDateInputRef}
+                      type="date"
+                      onChange={(event) => handleLessonDateChange(event.target.value)}
+                      aria-hidden="true"
+                      tabIndex={-1}
+                    />
+                    <CalendarIconWrap aria-hidden="true">
+                      <IconCalendarMonth size={16} stroke={2} color={colors.white} />
+                    </CalendarIconWrap>
+                  </DateRow>
+
+                  <ProposalEditTextarea
+                    $tone="proposal"
+                    placeholder="내용"
+                    rows={6}
+                    value={editingProposalValues?.content ?? ""}
+                    onChange={(event) =>
+                      onProposalEditValueChange?.({ content: event.target.value })
+                    }
+                  />
+                </ProposalEditForm>
+              ) : (
+                <>
+                  <ProposalMetaRow>
+                    <ProposalMetaCell>
+                      <MetaLabel>작성자</MetaLabel>
+                      <MetaValue>{proposal.proposedByName ?? "—"}</MetaValue>
+                    </ProposalMetaCell>
+
+                    <ProposalMetaCell>
+                      <MetaLabel>반 이름</MetaLabel>
+                      <MetaValue>{proposal.classroomName ?? "—"}</MetaValue>
+                    </ProposalMetaCell>
+
+                    <ProposalMetaCell>
+                      <MetaLabel>수업일자</MetaLabel>
+                      <MetaValue>{formatUtcToKstShortDate(proposal.lessonDate) || "—"}</MetaValue>
+                    </ProposalMetaCell>
+                  </ProposalMetaRow>
+                  <ProposalContent>{proposal.content ?? "—"}</ProposalContent>
+                </>
+              )}
+
+              {shouldRenderFooter ? (
+                <ProposalFooter>
+                  <ManageActionGroup>
+                    {canShowManageActions ? (
+                      isEditingProposal ? (
+                        <>
+                          <ActionSecondaryButton
+                            type="button"
+                            disabled={isUpdatingProposal}
+                            onClick={onCancelProposalEdit}
+                          >
+                            취소
+                          </ActionSecondaryButton>
+                          {typeof proposal.id === "number" ? (
+                            <ActionPrimaryButton
+                              type="button"
+                              disabled={isUpdatingProposal}
+                              onClick={() => onSaveProposalEdit?.(proposal.id as number)}
+                            >
+                              {isUpdatingProposal ? "수정 중" : "수정 완료"}
+                            </ActionPrimaryButton>
+                          ) : null}
+                        </>
+                      ) : (
+                        <>
+                          <TextActionButton
+                            type="button"
+                            $tone="danger"
+                            disabled={isDeletingProposal}
+                            onClick={() => {
+                              if (typeof proposal.id === "number") {
+                                onDeleteProposal?.(proposal.id);
+                              }
+                            }}
+                          >
+                            {isDeletingProposal ? "삭제 중" : "삭제"}
+                          </TextActionButton>
+                          <TextActionButton
+                            type="button"
+                            onClick={() => onStartProposalEdit?.(proposal)}
+                          >
+                            수정
+                          </TextActionButton>
+                        </>
+                      )
+                    ) : !isEditingProposal ? (
+                      <>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          삭제
+                        </ActionGhostButton>
+                        <ActionGhostButton aria-hidden="true" tabIndex={-1}>
+                          수정
+                        </ActionGhostButton>
+                      </>
+                    ) : null}
+                  </ManageActionGroup>
+
+                  {canShowAccept ? (
+                    <AcceptActionGroup>
+                      {onAcceptProposal ? (
+                        <AcceptButton
+                          type="button"
+                          disabled={isAccepting}
+                          onClick={() => onAcceptProposal(proposal)}
+                        >
+                          {acceptLabel}
+                        </AcceptButton>
+                      ) : (
+                        <AcceptLink href={acceptHref}>{acceptLabel}</AcceptLink>
+                      )}
+                    </AcceptActionGroup>
+                  ) : canShowWithdrawAccepted ? (
+                    <AcceptActionGroup>
+                      <WithdrawAcceptedButton
+                        type="button"
+                        disabled={isDeletingProposal}
+                        onClick={() => {
+                          if (typeof proposal.id === "number") {
+                            onWithdrawAcceptedProposal?.(proposal.id);
+                          }
+                        }}
+                      >
+                        {isDeletingProposal ? "철회 중" : withdrawAcceptedLabel}
+                      </WithdrawAcceptedButton>
+                    </AcceptActionGroup>
+                  ) : null}
                 </ProposalFooter>
               ) : null}
             </ProposalCard>
@@ -112,13 +327,13 @@ const ProposalPlaceholder = styled.p`
 const ProposalCard = styled.article<{ $showTopBorder: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 0.8125rem;
-  padding-top: ${spacing.space20};
-  border-top: ${({ $showTopBorder }) => ($showTopBorder ? "0.5px solid #d3d3d3" : "0")};
+  gap: ${spacing.space8};
+  padding: 0 0.5rem ${spacing.space12};
+  border-bottom: 0.5px solid #d3d3d3;
 
   @media (min-width: 120rem) {
-    gap: ${spacing.space20};
-    padding-top: 1.875rem;
+    gap: ${spacing.space12};
+    padding: ${spacing.space8} 0.75rem 1.25rem;
   }
 `;
 
@@ -137,18 +352,32 @@ const ProposalMetaRow = styled.div`
   }
 `;
 
+const ProposalEditForm = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 const ProposalMetaCell = styled.div`
   display: flex;
   flex-flow: row wrap;
   align-items: center;
   gap: ${spacing.space8};
   min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space12};
+  padding: 0.625rem ${spacing.space12};
 
   @media (min-width: 120rem) {
     min-height: 4rem;
     gap: 0.625rem;
-    padding: ${spacing.space20};
+    padding: 0.875rem ${spacing.space20};
   }
 `;
 
@@ -176,14 +405,15 @@ const MetaValue = styled.span`
 `;
 
 const ProposalContent = styled.div`
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space12};
+  padding: 0rem ${spacing.space12};
   font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
+  white-space: pre-wrap;
+  margin-bottom: 1.5rem;
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20};
+    padding: 0rem ${spacing.space20};
+    margin-bottom: 2rem;
     font-size: ${typography.fontSize20};
   }
 `;
@@ -192,11 +422,36 @@ const ProposalFooter = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: ${spacing.space20};
+  gap: ${spacing.space12};
   padding-left: ${spacing.space12};
+  margin-bottom: -${spacing.space8};
 
   @media (min-width: 120rem) {
     padding-left: ${spacing.space20};
+    margin-bottom: -${spacing.space12};
+  }
+`;
+
+const ManageActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${spacing.space12};
+  min-width: 5rem;
+
+  @media (min-width: 120rem) {
+    min-width: 7.5rem;
+  }
+`;
+
+const AcceptActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 6.5rem;
+
+  @media (min-width: 120rem) {
+    min-width: 9rem;
   }
 `;
 
@@ -243,4 +498,210 @@ const AcceptButton = styled.button`
     opacity: 0.5;
     cursor: not-allowed;
   }
+`;
+
+const WithdrawAcceptedButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: ${colors.notice};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  cursor: pointer;
+
+  &:not(:disabled):hover {
+    opacity: 0.72;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const EditClassSelect = styled.select`
+  min-width: 0;
+  width: 100%;
+  min-height: 2.6875rem;
+  border: 0.5px solid #c0c0c0;
+  background: #ffffff;
+  padding: 0.8125rem ${spacing.space12};
+  padding-right: 2rem;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  appearance: none;
+  outline: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #8c8c8c 50%),
+    linear-gradient(135deg, #8c8c8c 50%, transparent 50%);
+  background-position:
+    calc(100% - 1rem) calc(50% - 2px),
+    calc(100% - 0.6875rem) calc(50% - 2px);
+  background-size:
+    0.375rem 0.375rem,
+    0.375rem 0.375rem;
+  background-repeat: no-repeat;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const TextActionButton = styled.button<{ $tone?: "default" | "danger" }>`
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: ${({ $tone }) => ($tone === "danger" ? colors.notice : "#b3b3b3")};
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+  cursor: pointer;
+
+  &:not(:disabled):hover {
+    color: ${({ $tone }) => ($tone === "danger" ? colors.notice : colors.point)};
+    opacity: 0.72;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ActionGhostButton = styled(TextActionButton).attrs({
+  type: "button",
+  disabled: true,
+})`
+  visibility: hidden;
+  pointer-events: none;
+`;
+
+const ActionPillButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6875rem;
+  border-radius: ${radii.radius15};
+  padding: 0.8125rem ${spacing.space20};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20} 1.875rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ActionSecondaryButton = styled(ActionPillButton)`
+  border: 1px solid ${colors.border};
+  background: ${colors.white};
+  color: ${colors.placeholder};
+
+  &:not(:disabled):hover {
+    background: ${colors.background};
+  }
+`;
+
+const ActionPrimaryButton = styled(ActionPillButton)`
+  border: 1px solid ${colors.point};
+  background: ${colors.white};
+  color: ${colors.point};
+
+  &:not(:disabled):hover {
+    background: ${colors.pointSoft};
+  }
+`;
+
+const DateRow = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-width: 0;
+  min-height: 2.6875rem;
+  padding: 0.4375rem ${spacing.space12};
+  border: 0.5px solid #c0c0c0;
+  background: #ffffff;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: 0.625rem ${spacing.space20};
+  }
+`;
+
+const EditDateInput = styled.input`
+  width: 100%;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  &::placeholder {
+    color: #9c9c9c;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const HiddenNativeDateInput = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+`;
+
+const CalendarIconWrap = styled.span`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-left: ${spacing.space8};
+  border-radius: 50%;
+  background: ${colors.point};
+
+  @media (min-width: 120rem) {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+`;
+
+const ProposalEditTextarea = styled(FieldTextarea)`
+  grid-column: 1 / -1;
+  background: #ffffff;
 `;

--- a/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
+++ b/components/staff/class-management/exchange-request/ExchangeRequestPage.tsx
@@ -83,20 +83,37 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
                 <ProposalForm id="exchange-proposal-form" onSubmit={page.submitProposal}>
                   <FieldInput
                     $tone="proposal"
-                    aria-label="반 이름"
-                    placeholder="반 이름"
-                    type="text"
-                    value={page.user?.role ?? ""} //TODO: dto 반이름
-                    readOnly
-                  />
-                  <FieldInput
-                    $tone="proposal"
                     aria-label="작성자"
                     placeholder="작성자"
                     type="text"
                     value={page.user?.name ?? ""}
                     readOnly
                   />
+                  {page.assignmentClassNames.length > 0 ? (
+                    <ProposalSelect
+                      aria-label="반 이름"
+                      value={page.proposalForm.watch("className")}
+                      {...page.proposalForm.register("className")}
+                    >
+                      <option value="" disabled>
+                        반을 선택해 주세요
+                      </option>
+                      {page.assignmentClassNames.map((name) => (
+                        <option key={name} value={name}>
+                          {name}
+                        </option>
+                      ))}
+                    </ProposalSelect>
+                  ) : (
+                    <FieldInput
+                      $tone="proposal"
+                      aria-label="반 이름"
+                      placeholder="반 이름"
+                      type="text"
+                      value={page.proposalClassName}
+                      readOnly
+                    />
+                  )}
                   <DateRow>
                     <DateInput
                       aria-label="수업 일자"
@@ -140,9 +157,16 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
                 <ExchangeProposalList
                   acceptedHref={`/staff/class-management/exchange-request/${page.postId}`}
                   acceptLabel={page.canChangeExchangeTarget ? "교환 대상 변경하기" : "제안 수락하기"}
+                  withdrawAcceptedLabel="교환 제안 철회"
                   showAcceptLink={page.canAcceptProposal || page.canChangeExchangeTarget}
                   showCardTopBorder={!page.canChangeExchangeTarget}
                   isAccepting={page.isAcceptingProposal}
+                  canManageProposal={page.canManageProposal}
+                  canWithdrawAcceptedProposal={page.canWithdrawAcceptedProposal}
+                  editingProposalId={page.editingProposalId}
+                  editingProposalValues={page.editingProposalValues}
+                  isUpdatingProposal={page.isUpdatingProposal}
+                  isDeletingProposal={page.isDeletingProposal}
                   onAcceptProposal={
                     page.canChangeExchangeTarget
                       ? () => page.changeExchangeTarget()
@@ -150,6 +174,16 @@ export function ExchangeRequestPage({ page }: ExchangeRequestPageProps) {
                           if (proposal.id) page.acceptProposal(proposal.id);
                         }
                   }
+                  onStartProposalEdit={page.startProposalEdit}
+                  onCancelProposalEdit={page.cancelProposalEdit}
+                  onSaveProposalEdit={page.saveProposalEdit}
+                  onDeleteProposal={page.deleteProposal}
+                  onWithdrawAcceptedProposal={page.withdrawAcceptedProposal}
+                  onProposalEditValueChange={(patch) =>
+                    page.setEditingProposalValues((current) => ({ ...current, ...patch }))
+                  }
+                  assignmentClassNames={page.assignmentClassNames}
+                  proposalClassName={page.proposalClassName}
                   proposals={page.proposals}
                   proposalsLoading={page.proposalsLoading}
                   proposalsError={page.proposalsError}
@@ -236,6 +270,37 @@ const ProposalForm = styled.form`
 
   @media (max-width: ${layout.breakpointMobile}) {
     grid-template-columns: 1fr;
+  }
+`;
+
+const ProposalSelect = styled.select`
+  width: 100%;
+  min-width: 0;
+  min-height: 2.6875rem;
+  border: 0.5px solid #c0c0c0;
+  background: #ffffff;
+  padding: 0.8125rem ${spacing.space12};
+  padding-right: 2rem;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight130};
+  appearance: none;
+  outline: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #8c8c8c 50%),
+    linear-gradient(135deg, #8c8c8c 50%, transparent 50%);
+  background-position:
+    calc(100% - 1rem) calc(50% - 2px),
+    calc(100% - 0.6875rem) calc(50% - 2px);
+  background-size:
+    0.375rem 0.375rem,
+    0.375rem 0.375rem;
+  background-repeat: no-repeat;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
   }
 `;
 

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -360,10 +360,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     typeof user?.id === "number" &&
     typeof request?.requestedById === "number" &&
     user.id === request.requestedById;
+  const isAdmin = authStatus === "authenticated" && user?.role === "ADMIN";
+  const canManageRequest = isAdmin || isRequester;
   const canManagePurchaseReport =
-    authStatus === "authenticated" && (user?.role === "ADMIN" || isRequester);
-  const canEditRequest = request?.status === "PENDING" && isRequester;
-  const canDeleteRequest = request?.status === "PENDING" && isRequester;
+    authStatus === "authenticated" && canManageRequest;
+  const canEditRequest = request?.status === "PENDING" && canManageRequest;
+  const canDeleteRequest = request?.status === "PENDING" && canManageRequest;
   const canShowReportForm = request?.status === "APPROVED" && isRequester;
   const canEditPurchaseReport = request?.status === "PURCHASED" && canManagePurchaseReport;
   const canShowReportEditor = canShowReportForm || isReportEditing;
@@ -507,24 +509,36 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
               </>
             ) : (
               <>
-                <ActionButton
-                  type="button"
-                  $variant="danger"
-                  disabled={!canDeleteRequest || deleteMutation.isPending || isLoading}
-                  title={canDeleteRequest ? undefined : "대기 중인 본인 작성 글만 삭제할 수 있습니다."}
-                  onClick={() => deleteMutation.mutate()}
-                >
-                  {deleteMutation.isPending ? "삭제 중" : "삭제"}
-                </ActionButton>
-                <ActionButton
-                  type="button"
-                  $variant="edit"
-                  disabled={!canEditRequest}
-                  title={canEditRequest ? undefined : "대기 중인 본인 작성 글만 수정할 수 있습니다."}
-                  onClick={startEditing}
-                >
-                  수정
-                </ActionButton>
+                {canManageRequest ? (
+                  <>
+                    <ActionButton
+                      type="button"
+                      $variant="danger"
+                      disabled={!canDeleteRequest || deleteMutation.isPending || isLoading}
+                      title={
+                        canDeleteRequest
+                          ? undefined
+                          : "관리자이거나 대기 중인 본인 작성 글만 삭제할 수 있습니다."
+                      }
+                      onClick={() => deleteMutation.mutate()}
+                    >
+                      {deleteMutation.isPending ? "삭제 중" : "삭제"}
+                    </ActionButton>
+                    <ActionButton
+                      type="button"
+                      $variant="edit"
+                      disabled={!canEditRequest}
+                      title={
+                        canEditRequest
+                          ? undefined
+                          : "관리자이거나 대기 중인 본인 작성 글만 수정할 수 있습니다."
+                      }
+                      onClick={startEditing}
+                    >
+                      수정
+                    </ActionButton>
+                  </>
+                ) : null}
                 <ListButton href="/staff/finance-management">목록</ListButton>
               </>
             )}

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -15,6 +15,10 @@ export const queryKeys = {
     boardDetail: (channelId: number, postId: number) =>
       ["posts", "board", "detail", { channelId, postId }] as const,
   },
+  comments: {
+    boardDetail: (channelId: number, postId: number) =>
+      ["comments", "board", "detail", { channelId, postId }] as const,
+  },
   lessons: {
     weekly: (from: string, to: string) => ["lessons", "weekly", { from, to }] as const,
     myWeekly: (from: string, to: string) => ["lessons", "me", "weekly", { from, to }] as const,

--- a/utils/birthDate.test.ts
+++ b/utils/birthDate.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatBirthDate,
+  toBirthDateInputValue,
+  toResidentRegistrationNumberPrefix,
+} from "./birthDate";
+
+describe("birthDate utils", () => {
+  it("formats resident registration number prefix to display birth date", () => {
+    expect(formatBirthDate("900101")).toBe("1990.01.01");
+    expect(formatBirthDate("250315")).toBe("2025.03.15");
+  });
+
+  it("maps resident registration number prefix to date input value", () => {
+    expect(toBirthDateInputValue("900101")).toBe("1990-01-01");
+    expect(toBirthDateInputValue("250315")).toBe("2025-03-15");
+  });
+
+  it("maps date input value to resident registration number prefix", () => {
+    expect(toResidentRegistrationNumberPrefix("1990-01-01")).toBe("900101");
+    expect(toResidentRegistrationNumberPrefix("2025-03-15")).toBe("250315");
+  });
+});

--- a/utils/birthDate.ts
+++ b/utils/birthDate.ts
@@ -1,0 +1,27 @@
+export function formatBirthDate(prefix?: string) {
+  if (!prefix || !/^\d{6}$/.test(prefix)) {
+    return "등록된 생년월일이 없습니다.";
+  }
+
+  const yearPrefix = Number(prefix.slice(0, 2)) > 30 ? "19" : "20";
+  return `${yearPrefix}${prefix.slice(0, 2)}.${prefix.slice(2, 4)}.${prefix.slice(4, 6)}`;
+}
+
+export function toBirthDateInputValue(prefix?: string) {
+  if (!prefix || !/^\d{6}$/.test(prefix)) {
+    return "";
+  }
+
+  const yearPrefix = Number(prefix.slice(0, 2)) > 30 ? "19" : "20";
+  return `${yearPrefix}${prefix.slice(0, 2)}-${prefix.slice(2, 4)}-${prefix.slice(4, 6)}`;
+}
+
+export function toResidentRegistrationNumberPrefix(date: string) {
+  const [year, month, day] = date.split("-");
+
+  if (!year || !month || !day) {
+    return "";
+  }
+
+  return `${year.slice(-2)}${month}${day}`;
+}


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 게시판 댓글 기능 구현
2. 인수인계서/시험 문제 자료/서류 양식 게시물에 댓글 기능 추가
3. 기관 정보 - 연혁 페이지 날짜 입력폼 추가 및 해당 필드 API 연동
4. 행사 정보 상세 버튼 순서 및 자료 안내 간격 조정
5. 수업 결강 신청/결제 신청/교학 회의록 상세 페이지의 수정/삭제 버튼 노출 범위 제한
6. 마이페이지 및 관리자 사용자 관리 페이지에 생년월일 입력폼 추가
7. 회원가입 시, 비밀번호 입력 검증폼 추가
8. 수업 교환 제안서의 UI 개선

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #145 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
