### PR TITLE
[BUG] 메인 페이지 - 1080px 화면에서 로그인 정보 오기입 안내 문구 위치 수정

### DIFF
--- a/components/home/LoginCard.tsx
+++ b/components/home/LoginCard.tsx
@@ -263,6 +263,11 @@ const ErrorText = styled.p<{ $visible: boolean }>`
   font-weight: 600;
   line-height: ${typography.lineHeight150};
   visibility: ${({ $visible }) => ($visible ? "visible" : "hidden")};
+
+  @media (min-width: 120rem) {
+    top: calc(10.375rem + ${spacing.space8});
+    font-size: ${typography.fontSize18};
+  }
 `;
 
 const Input = styled(AuthInput)`


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

메인 페이지의 1080px 화면에서, 로그인 정보 오기입 시 표시되는 안내 문구 위치를 수정하였습니다.

<img width="587" height="475" alt="스크린샷 2026-06-21 045435" src="https://github.com/user-attachments/assets/d77e8635-6172-41f1-9453-6a129d594760" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #147 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
