### PR TITLE
[FEAT] 교사 신청 기능 추가

### DIFF
--- a/app/(public)/apply/status/page.tsx
+++ b/app/(public)/apply/status/page.tsx
@@ -1,0 +1,5 @@
+import TeacherApplyStatusPage from "@/components/apply/TeacherApplyStatusPage";
+
+export default function ApplyStatusPage() {
+  return <TeacherApplyStatusPage />;
+}

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -15,6 +15,7 @@ import { AdminPostsSection } from "@/components/admin/posts/AdminPostsSection";
 import { AdminAbsenceRequestsSection } from "@/components/admin/absence-requests/AdminAbsenceRequestsSection";
 import { AdminLessonExchangeSection } from "@/components/admin/lesson-exchange/AdminLessonExchangeSection";
 import { AdminPurchasesSection } from "@/components/admin/purchase-requests/AdminPurchasesSection";
+import { AdminTeacherApplicationsSection } from "@/components/admin/teacher-applications/AdminTeacherApplicationsSection";
 import { AdminLessonManagementSection } from "@/components/admin/lesson-management/AdminLessonManagementSection";
 import { AdminUsersSection } from "@/components/admin/users/AdminUsersSection";
 import type {
@@ -114,6 +115,7 @@ const navigationItems: { key: AdminMenu; label: string }[] = [
   { key: "lessonExchange", label: "수업 교환 요청 관리" },
   { key: "absenceRequests", label: "결강 요청 관리" },
   { key: "purchases", label: "결제 요청 관리" },
+  { key: "teacherApplications", label: "교사 신청 관리" },
 ];
 
 const ADMIN_ACTIVE_MENU_STORAGE_KEY = "admin-active-menu";
@@ -1413,6 +1415,7 @@ export default function AdminDashboardPage() {
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
             activeMenu === "purchases" ||
+            activeMenu === "teacherApplications" ||
             activeMenu === "absenceRequests" ||
             activeMenu === "lessonExchange"
           }
@@ -1441,6 +1444,8 @@ export default function AdminDashboardPage() {
     posts: "채널별 게시물 목록을 조회하고, 게시물을 생성/수정/삭제할 수 있습니다.",
     purchases:
       "물품 구매 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 및 결제 확정 처리를 할 수 있습니다.",
+    teacherApplications:
+      "교사 신청 목록을 조회하고, 슬라이드 패널에서 지원서 상세 내용을 확인할 수 있습니다.",
     absenceRequests: "결강 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 처리를 할 수 있습니다.",
     lessonExchange:
       "수업 교환 요청 목록을 조회하고, 각 요청건에 대한 승인/반려 처리를 할 수 있습니다.",
@@ -1485,6 +1490,7 @@ export default function AdminDashboardPage() {
             activeMenu === "departments" ||
             activeMenu === "classrooms" ||
             activeMenu === "purchases" ||
+            activeMenu === "teacherApplications" ||
             activeMenu === "absenceRequests" ||
             activeMenu === "lessonExchange"
           }
@@ -1689,6 +1695,7 @@ export default function AdminDashboardPage() {
               emptyPurchaseCreate={emptyPurchaseCreate}
             />
           ) : null}
+          {activeMenu === "teacherApplications" ? <AdminTeacherApplicationsSection /> : null}
           <ToastContainer position="top-right" autoClose={2400} newestOnTop pauseOnHover />
         </AdminContent>
       </Main>

--- a/components/admin/AdminDashboardTypes.ts
+++ b/components/admin/AdminDashboardTypes.ts
@@ -12,6 +12,7 @@ export type AdminMenu =
   | "classrooms"
   | "lessons"
   | "purchases"
+  | "teacherApplications"
   | "absenceRequests"
   | "lessonExchange";
 

--- a/components/admin/teacher-applications/AdminTeacherApplicationsSection.tsx
+++ b/components/admin/teacher-applications/AdminTeacherApplicationsSection.tsx
@@ -1,0 +1,796 @@
+"use client";
+
+import { type MouseEvent, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import styled from "styled-components";
+import {
+  approveTeacherApplication,
+  getTeacherApplication,
+  getTeacherApplications,
+  rejectTeacherApplication,
+} from "@/api/teacherApplication/teacherApplication.api";
+import type { TeacherApplicationResponseDto, TeacherApplicationStatus } from "@/api/teacherApplication/teacherApplication.dto";
+import { updateUser } from "@/api/user/user.api";
+import {
+  formatTeacherApplicationPreference,
+  formatTeacherApplicationStatus,
+  getTeacherApplicationFields,
+} from "@/components/apply/teacherApplicationUtils";
+import {
+  ButtonRow,
+  ControlRow,
+  DangerButton,
+  DataState,
+  FormGrid,
+  List,
+  ListItem,
+  SectionCard,
+  SectionHeaderRow,
+  SectionTitle,
+  Select,
+  SmallButton,
+  Table,
+  TextArea,
+  TextInput,
+} from "@/components/admin/AdminDashboardSectionParts";
+import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+const APPLICATIONS_PER_PAGE = 10;
+
+function formatDateInput(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getApprovalPayload(application?: TeacherApplicationResponseDto) {
+  const today = new Date();
+  const nextYear = new Date(today);
+  nextYear.setFullYear(today.getFullYear() + 1);
+
+  return {
+    assignedSubjectIds:
+      typeof application?.preferredSubjectId === "number" ? [application.preferredSubjectId] : [],
+    teacherStartAt: formatDateInput(today),
+    teacherEndAt: formatDateInput(nextYear),
+    note: "관리자 승인",
+  };
+}
+
+export function AdminTeacherApplicationsSection() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<TeacherApplicationStatus | "">("");
+  const [keyword, setKeyword] = useState("");
+  const [selectedApplicationId, setSelectedApplicationId] = useState<number | null>(null);
+  const [pagination, setPagination] = useState({ page: 1, search: "" });
+  const [rejectNote, setRejectNote] = useState("");
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"approve" | "reject" | null>(null);
+  const isDetailOpen = selectedApplicationId !== null;
+
+  const listQuery = useQuery({
+    queryKey: queryKeys.teacherApplications.adminList({
+      keyword: keyword.trim() || undefined,
+      status: statusFilter || undefined,
+    }),
+    queryFn: () =>
+      getTeacherApplications({
+        keyword: keyword.trim() || undefined,
+        status: statusFilter || undefined,
+      }),
+  });
+
+  const detailQuery = useQuery({
+    queryKey: queryKeys.teacherApplications.adminDetail(selectedApplicationId ?? 0),
+    queryFn: () => getTeacherApplication({ applicationId: selectedApplicationId! }),
+    enabled: selectedApplicationId !== null,
+  });
+
+  const applications = useMemo(() => listQuery.data?.content ?? [], [listQuery.data?.content]);
+  const totalPages = Math.max(1, Math.ceil(applications.length / APPLICATIONS_PER_PAGE));
+  const paginationKey = `${statusFilter}:${keyword}`;
+  const requestedPage = pagination.search === paginationKey ? pagination.page : 1;
+  const safeCurrentPage = Math.min(requestedPage, totalPages);
+  const pagedApplications = applications.slice(
+    (safeCurrentPage - 1) * APPLICATIONS_PER_PAGE,
+    safeCurrentPage * APPLICATIONS_PER_PAGE,
+  );
+  const selectedApplication = detailQuery.data;
+  const fields = getTeacherApplicationFields(selectedApplication);
+  const canApprove =
+    selectedApplication?.status === "PENDING" &&
+    typeof selectedApplication.id === "number" &&
+    typeof selectedApplication.applicantId === "number";
+
+  const approveMutation = useMutation({
+    mutationFn: async (application: TeacherApplicationResponseDto) => {
+      if (typeof application.id !== "number" || typeof application.applicantId !== "number") {
+        throw new Error("승인에 필요한 신청자 정보가 없습니다.");
+      }
+
+      await approveTeacherApplication(
+        { applicationId: application.id },
+        getApprovalPayload(application),
+      );
+
+      await updateUser(
+        { userId: application.applicantId },
+        {
+          role: "VOLUNTEER",
+        },
+      );
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.adminList() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.adminDetail(selectedApplicationId ?? 0) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.users() }),
+      ]);
+      setConfirmAction(null);
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: async (application: TeacherApplicationResponseDto) => {
+      if (typeof application.id !== "number") {
+        throw new Error("반려에 필요한 신청 정보가 없습니다.");
+      }
+
+      await rejectTeacherApplication(
+        { applicationId: application.id },
+        { note: rejectNote.trim() || "관리자 반려" },
+      );
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.adminList() }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.teacherApplications.adminDetail(selectedApplicationId ?? 0),
+        }),
+      ]);
+      setConfirmAction(null);
+      setIsRejecting(false);
+      setRejectNote("");
+    },
+  });
+
+  function closeDetail() {
+    setSelectedApplicationId(null);
+    setRejectNote("");
+    setIsRejecting(false);
+    setConfirmAction(null);
+  }
+
+  function selectApplication(item: TeacherApplicationResponseDto) {
+    if (!item.id) {
+      return;
+    }
+
+    setSelectedApplicationId(item.id);
+    setRejectNote("");
+    setIsRejecting(false);
+    setConfirmAction(null);
+  }
+
+  function handleSearchChange(value: string) {
+    setKeyword(value);
+    setPagination({ page: 1, search: `${statusFilter}:${value}` });
+
+    if (isDetailOpen) {
+      closeDetail();
+    }
+  }
+
+  function handleStatusChange(value: TeacherApplicationStatus | "") {
+    setStatusFilter(value);
+    setPagination({ page: 1, search: `${value}:${keyword}` });
+
+    if (isDetailOpen) {
+      closeDetail();
+    }
+  }
+
+  function handleApprove() {
+    if (!selectedApplication || !canApprove || approveMutation.isPending) {
+      return;
+    }
+
+    approveMutation.mutate(selectedApplication);
+  }
+
+  function handleReject() {
+    if (
+      !selectedApplication ||
+      selectedApplication.status !== "PENDING" ||
+      rejectMutation.isPending ||
+      !rejectNote.trim()
+    ) {
+      return;
+    }
+
+    rejectMutation.mutate(selectedApplication);
+  }
+
+  function handleListSectionClick(event: MouseEvent<HTMLElement>) {
+    if (!isDetailOpen) {
+      return;
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const isLeftVisibleArea = event.clientX <= bounds.left + bounds.width * 0.25;
+    const clickedApplicationRow = (event.target as HTMLElement).closest("tbody tr");
+
+    if (isLeftVisibleArea && !clickedApplicationRow) {
+      closeDetail();
+    }
+  }
+
+  function runConfirmedAction() {
+    if (confirmAction === "approve") {
+      handleApprove();
+      return;
+    }
+
+    if (confirmAction === "reject") {
+      handleReject();
+    }
+  }
+
+  return (
+    <ApplicationsSection $isPanelOpen={isDetailOpen} onClick={handleListSectionClick}>
+      <SectionHeaderRow>
+        <SectionTitle>교사 신청 목록</SectionTitle>
+        <HeaderHeightSpacer aria-hidden="true" />
+      </SectionHeaderRow>
+
+      <ControlRow
+        as="form"
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <FilterSelect
+          value={statusFilter}
+          onChange={(event) => handleStatusChange(event.target.value as TeacherApplicationStatus | "")}
+          aria-label="교사 신청 상태 필터"
+        >
+          <option value="">전체</option>
+          <option value="PENDING">대기</option>
+          <option value="APPROVED">승인</option>
+          <option value="REJECTED">반려</option>
+          <option value="CANCELLED">취소</option>
+        </FilterSelect>
+        <TextInput
+          value={keyword}
+          onChange={(event) => handleSearchChange(event.target.value)}
+          placeholder="이름, 이메일, 연락처 검색"
+        />
+      </ControlRow>
+
+      <ApplicationListFrame>
+        <DataState
+          isLoading={listQuery.isLoading}
+          isError={listQuery.isError}
+          isEmpty={applications.length === 0}
+          loadingLabel="교사 신청 목록 불러오는 중"
+          errorLabel="교사 신청 목록을 불러오지 못했습니다."
+          emptyLabel="교사 신청 내역이 없습니다."
+        >
+          <Table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>이름</th>
+                <th>연락처</th>
+                <th>희망 수업</th>
+                <th>상태</th>
+                <th>신청일</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pagedApplications.map((item) => (
+                <tr key={item.id} onClick={() => selectApplication(item)}>
+                  <td>{item.id ?? "-"}</td>
+                  <td>{item.applicantName ?? "-"}</td>
+                  <td>{item.applicantPhoneNumber ?? "-"}</td>
+                  <td>{formatTeacherApplicationPreference(item)}</td>
+                  <td>{formatTeacherApplicationStatus(item.status)}</td>
+                  <td>{formatUtcToKstShortDate(item.createdAt) || "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </DataState>
+      </ApplicationListFrame>
+
+      <Pagination aria-label="페이지 이동">
+        <PageArrowButton
+          type="button"
+          aria-label="이전 페이지"
+          disabled={safeCurrentPage === 1}
+          onClick={() =>
+            setPagination({
+              page: Math.max(1, safeCurrentPage - 1),
+              search: paginationKey,
+            })
+          }
+        >
+          ◀
+        </PageArrowButton>
+        {Array.from({ length: totalPages }, (_, index) => {
+          const pageNumber = index + 1;
+
+          return (
+            <PageNumberButton
+              key={pageNumber}
+              type="button"
+              $isActive={pageNumber === safeCurrentPage}
+              aria-current={pageNumber === safeCurrentPage ? "page" : undefined}
+              onClick={() => setPagination({ page: pageNumber, search: paginationKey })}
+            >
+              {pageNumber}
+            </PageNumberButton>
+          );
+        })}
+        <PageArrowButton
+          type="button"
+          aria-label="다음 페이지"
+          disabled={safeCurrentPage === totalPages}
+          onClick={() =>
+            setPagination({
+              page: Math.min(totalPages, safeCurrentPage + 1),
+              search: paginationKey,
+            })
+          }
+        >
+          ▶
+        </PageArrowButton>
+      </Pagination>
+
+      {isDetailOpen ? (
+        <>
+          <PanelBackdrop aria-hidden="true" />
+          <SlidePanel aria-label="교사 신청 상세" onClick={(event) => event.stopPropagation()}>
+            <PanelHeader>
+              <ClosePanelButton type="button" aria-label="교사 신청 상세 닫기" onClick={closeDetail}>
+                <CloseIcon aria-hidden="true" />
+              </ClosePanelButton>
+              <SectionTitle>교사 신청 상세</SectionTitle>
+            </PanelHeader>
+
+            <DataState
+              isLoading={detailQuery.isLoading}
+              isError={detailQuery.isError}
+              isEmpty={!selectedApplicationId}
+              loadingLabel="교사 신청 상세 불러오는 중"
+              errorLabel="교사 신청 상세를 불러오지 못했습니다."
+              emptyLabel="교사 신청을 선택하세요."
+            >
+              <PanelContent>
+                <DetailBlock>
+                  <DetailBlockTitle>신청 정보</DetailBlockTitle>
+                  <List>
+                    <ListItem>
+                      <span>상태</span>
+                      <span>{formatTeacherApplicationStatus(selectedApplication?.status)}</span>
+                    </ListItem>
+                    <ListItem>
+                      <span>신청일</span>
+                      <span>{formatUtcToKstShortDate(selectedApplication?.createdAt) || "-"}</span>
+                    </ListItem>
+                    <ListItem>
+                      <span>검토자</span>
+                      <span>{selectedApplication?.reviewedByName ?? "-"}</span>
+                    </ListItem>
+                    <ListItem>
+                      <span>검토 메모</span>
+                      <span>{selectedApplication?.reviewNote?.trim() || "-"}</span>
+                    </ListItem>
+                  </List>
+                </DetailBlock>
+
+                <DetailBlock>
+                  <DetailBlockTitle>지원서 내용</DetailBlockTitle>
+                  <DetailFields>
+                    {fields.map((field) => (
+                      <FieldCard key={field.label}>
+                        <FieldLabel>{field.label}</FieldLabel>
+                        <FieldValue>{field.value}</FieldValue>
+                      </FieldCard>
+                    ))}
+                  </DetailFields>
+                </DetailBlock>
+
+                {selectedApplication?.status === "PENDING" ? (
+                  <ActionBlock>
+                    <FormGrid onSubmit={(event) => event.preventDefault()}>
+                      {isRejecting ? (
+                        <>
+                          <ReviewNoteLabel>검토 메모</ReviewNoteLabel>
+                          <RejectNoteTextArea
+                            value={rejectNote}
+                            placeholder="검토 메모를 입력해 주세요."
+                            disabled={rejectMutation.isPending}
+                            onChange={(event) => setRejectNote(event.target.value)}
+                            autoFocus
+                          />
+                        </>
+                      ) : null}
+                      <ButtonRow>
+                        {isRejecting ? (
+                          <>
+                            <DangerButton
+                              type="button"
+                              disabled={rejectMutation.isPending || !rejectNote.trim()}
+                              onClick={() => setConfirmAction("reject")}
+                            >
+                              확인
+                            </DangerButton>
+                            <SmallButton
+                              type="button"
+                              disabled={rejectMutation.isPending}
+                              onClick={() => {
+                                setIsRejecting(false);
+                                setRejectNote("");
+                              }}
+                            >
+                              취소
+                            </SmallButton>
+                          </>
+                        ) : (
+                          <>
+                            <ApproveButton
+                              type="button"
+                              disabled={!canApprove || approveMutation.isPending}
+                              onClick={() => setConfirmAction("approve")}
+                            >
+                              승인
+                            </ApproveButton>
+                            <DangerButton
+                              type="button"
+                              disabled={approveMutation.isPending || rejectMutation.isPending}
+                              onClick={() => setIsRejecting(true)}
+                            >
+                              반려
+                            </DangerButton>
+                          </>
+                        )}
+                      </ButtonRow>
+                    </FormGrid>
+                  </ActionBlock>
+                ) : null}
+              </PanelContent>
+            </DataState>
+          </SlidePanel>
+        </>
+      ) : null}
+
+      {confirmAction ? (
+        <ModalBackdrop onMouseDown={() => setConfirmAction(null)}>
+          <ConfirmDialog
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="teacher-application-action-confirm-title"
+            onMouseDown={(event) => event.stopPropagation()}
+          >
+            <ConfirmTitle id="teacher-application-action-confirm-title">교사 신청 처리</ConfirmTitle>
+            <ConfirmMessage>
+              {confirmAction === "approve" ? "승인하시겠습니까?" : "반려하시겠습니까?"}
+            </ConfirmMessage>
+            <ButtonRow>
+              <ApproveButton
+                type="button"
+                disabled={approveMutation.isPending || rejectMutation.isPending}
+                onClick={runConfirmedAction}
+              >
+                확인
+              </ApproveButton>
+              <SmallButton
+                type="button"
+                disabled={approveMutation.isPending || rejectMutation.isPending}
+                onClick={() => setConfirmAction(null)}
+              >
+                취소
+              </SmallButton>
+            </ButtonRow>
+          </ConfirmDialog>
+        </ModalBackdrop>
+      ) : null}
+    </ApplicationsSection>
+  );
+}
+
+const ApplicationsSection = styled(SectionCard)<{ $isPanelOpen: boolean }>`
+  position: relative;
+  display: grid;
+  align-content: start;
+  overflow: hidden;
+  box-shadow: ${({ $isPanelOpen }) => ($isPanelOpen ? "inset 0 0 0 1px #e6e9e7" : "none")};
+`;
+
+const HeaderHeightSpacer = styled.span`
+  display: inline-flex;
+  width: 0;
+  min-height: 2.25rem;
+`;
+
+const selectBase = `
+  width: 9.5rem;
+  min-width: 9.5rem;
+  max-width: 9.5rem;
+  flex: 0 0 9.5rem;
+  min-height: 2.375rem;
+  border: 1px solid ${colors.border};
+  border-radius: 0.375rem;
+  padding: 0 2.5rem 0 ${spacing.space12};
+  background-color: ${colors.white};
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+  color: #1f2b28;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  appearance: none;
+  outline: none;
+
+  &:focus {
+    border-color: ${colors.point};
+  }
+`;
+
+const FilterSelect = styled(Select)`
+  ${selectBase}
+  height: 2.375rem;
+`;
+
+const ApplicationListFrame = styled.div`
+  position: relative;
+  min-height: 22.35rem;
+  border-radius: 0.5rem;
+`;
+
+const Pagination = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: ${spacing.space16};
+  font-size: ${typography.fontSize16};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space16};
+    margin-top: ${spacing.space28};
+  }
+`;
+
+const PageArrowButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #666;
+  font: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+`;
+
+const PageNumberButton = styled.button<{ $isActive?: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: ${({ $isActive }) => ($isActive ? "#111" : "#9a9a9a")};
+  font: inherit;
+  font-size: ${typography.fontSize16};
+  font-weight: ${({ $isActive }) => ($isActive ? 700 : 400)};
+  cursor: pointer;
+`;
+
+const PanelBackdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background-color: rgba(17, 24, 39, 0.18);
+  pointer-events: none;
+  animation: fadeTeacherApplicationPanelBackdropIn 0.18s ease-out both;
+
+  @keyframes fadeTeacherApplicationPanelBackdropIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const SlidePanel = styled.aside`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: grid;
+  align-content: start;
+  gap: ${spacing.space12};
+  width: 75%;
+  max-height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  border-left: 1px solid #e6e9e7;
+  background-color: ${colors.white};
+  padding: 1.25rem 1rem;
+  box-shadow: -1rem 0 2rem rgba(17, 24, 39, 0.12);
+  animation: slideTeacherApplicationPanelIn 0.22s ease-out both;
+
+  @keyframes slideTeacherApplicationPanelIn {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (min-width: 120rem) {
+    padding: 2rem 1.75rem;
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    width: 88%;
+  }
+`;
+
+const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space8};
+`;
+
+const CloseIcon = styled.span`
+  display: block;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  mask: url("/chevron_right.svg") center / contain no-repeat;
+  -webkit-mask: url("/chevron_right.svg") center / contain no-repeat;
+`;
+
+const ClosePanelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: #1f2b28;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5fff0;
+    color: #5eb63a;
+  }
+`;
+
+const PanelContent = styled.div`
+  display: grid;
+  gap: ${spacing.space12};
+`;
+
+const ActionBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const DetailBlock = styled.div`
+  display: grid;
+  gap: ${spacing.space4};
+
+  ${List} {
+    margin: 0;
+  }
+`;
+
+const DetailBlockTitle = styled.h3`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const DetailFields = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+`;
+
+const FieldCard = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+  padding: ${spacing.space8};
+  border: 1px solid #e6e9e7;
+  border-radius: 0.375rem;
+  background-color: ${colors.white};
+`;
+
+const FieldLabel = styled.strong`
+  color: #1f2b28;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;
+
+const FieldValue = styled.div`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+  white-space: pre-wrap;
+`;
+
+const ApproveButton = styled(SmallButton)`
+  border-color: ${colors.point};
+  color: ${colors.point};
+
+  &:not(:disabled):hover {
+    background-color: ${colors.pointSoft};
+    color: ${colors.point};
+  }
+`;
+
+const RejectNoteTextArea = styled(TextArea)`
+  min-height: 6rem;
+  resize: none;
+  font-weight: 500;
+`;
+
+const ReviewNoteLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgb(0 0 0 / 42%);
+`;
+
+const ConfirmDialog = styled.div`
+  display: grid;
+  gap: ${spacing.space16};
+  width: min(100%, 24rem);
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
+  padding: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background-color: ${colors.white};
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 18%);
+`;
+
+const ConfirmTitle = styled.h3`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize16};
+  font-weight: 700;
+`;
+
+const ConfirmMessage = styled.p`
+  margin: 0;
+  color: #64706c;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+`;

--- a/components/apply/ApplyAction.tsx
+++ b/components/apply/ApplyAction.tsx
@@ -45,9 +45,22 @@ export const ApplyActionButton = styled.button`
   line-height: ${typography.lineHeight130};
   white-space: nowrap;
   cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 
-  &:hover {
+  &:not(:disabled):hover {
     background-color: ${colors.pointSoft};
+  }
+
+  &:disabled {
+    border-color: #c8d7cb;
+    background-color: #f5f7f5;
+    color: #9caf9f;
+    cursor: not-allowed;
+    opacity: 1;
   }
 
   @media (min-width: 120rem) {

--- a/components/apply/ApplyLayout.tsx
+++ b/components/apply/ApplyLayout.tsx
@@ -4,27 +4,45 @@ import { colors, layout, typography } from "@/styles/tokens";
 
 type ApplyLayoutProps = {
   children: React.ReactNode;
+  activeItem?: "apply" | "status";
 };
 
-export default function ApplyLayout({ children }: ApplyLayoutProps) {
+export default function ApplyLayout({ children, activeItem = "apply" }: ApplyLayoutProps) {
   return (
     <ApplyShell>
       <ApplyStage>
-        <ApplySidebar />
+        <ApplySidebar activeItem={activeItem} />
         <ApplyContent>{children}</ApplyContent>
       </ApplyStage>
     </ApplyShell>
   );
 }
 
-function ApplySidebar() {
+function ApplySidebar({ activeItem }: { activeItem: "apply" | "status" }) {
   return (
     <Sidebar>
       <SidebarHeader>신규 등록</SidebarHeader>
       <SidebarContent>
-        <ActiveLink href="/apply" aria-current="page">
-          교사 신청
-        </ActiveLink>
+        <SidebarList>
+          <SidebarItem>
+            <NavLink
+              href="/apply"
+              aria-current={activeItem === "apply" ? "page" : undefined}
+              $active={activeItem === "apply"}
+            >
+              교사 신청
+            </NavLink>
+          </SidebarItem>
+          <SidebarItem>
+            <NavLink
+              href="/apply/status"
+              aria-current={activeItem === "status" ? "page" : undefined}
+              $active={activeItem === "status"}
+            >
+              지원 현황
+            </NavLink>
+          </SidebarItem>
+        </SidebarList>
       </SidebarContent>
     </Sidebar>
   );
@@ -88,22 +106,46 @@ const SidebarHeader = styled.h1`
 `;
 
 const SidebarContent = styled.nav`
-  padding: 1.5rem 0 2.5rem;
+  padding: 1.75rem 0 2.5rem;
 
   @media (min-width: 120rem) {
-    padding: 2.25rem 0 3.75rem;
+    padding: 2.75rem 0 3.75rem;
   }
 `;
 
-const ActiveLink = styled(Link)`
+const SidebarList = styled.ul`
+  display: grid;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  @media (min-width: 120rem) {
+    gap: 0.625rem;
+  }
+`;
+
+const SidebarItem = styled.li`
+  display: block;
+`;
+
+const NavLink = styled(Link)<{ $active: boolean }>`
   display: block;
   padding: 0.25rem 1.625rem;
-  background-color: ${colors.point};
-  color: ${colors.white};
+  background-color: ${({ $active }) => ($active ? colors.point : "transparent")};
+  color: ${({ $active }) => ($active ? colors.white : colors.point)};
   font-size: ${typography.fontSize14};
-  font-weight: 500;
+  font-weight: 700;
   line-height: ${typography.lineHeight130};
   text-decoration: none;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    background-color: ${({ $active }) => ($active ? colors.point : "#eeeeee")};
+    color: ${({ $active }) => ($active ? colors.white : colors.text)};
+  }
 
   @media (min-width: 120rem) {
     padding: 0.3125rem 2.5rem;

--- a/components/apply/TeacherApplyFormPage.tsx
+++ b/components/apply/TeacherApplyFormPage.tsx
@@ -1,101 +1,334 @@
 "use client";
 
-import { type FormEvent } from "react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
-import ApplyLayout from "@/components/apply/ApplyLayout";
+import { createTeacherApplication, getAvailableTeacherSchedules, getMyTeacherApplication } from "@/api/teacherApplication/teacherApplication.api";
+import type { CreateTeacherApplicationRequestDto } from "@/api/teacherApplication/teacherApplication.dto";
 import { ApplyActionButton } from "@/components/apply/ApplyAction";
+import ApplyLayout from "@/components/apply/ApplyLayout";
+import { toTeacherScheduleOption } from "@/components/apply/teacherApplicationUtils";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
-import { formatPhoneNumber } from "@/utils/phoneNumber";
+import { toBirthDateInputValue } from "@/utils/birthDate";
 
-const subjectOptions = [
-  "개나리반 한글 - 화요일 19:00-22:00",
-  "민들레반 한글 - 금요일 19:00-22:00",
-  "국화반 국어 - 금요일 19:00-22:00",
-  "해바라기반 수학 - 금요일 19:00-22:00",
-  "스마트폰반 - 토요일 11:30-13:30",
-];
+type FormState = {
+  birthDate: string;
+  phoneNumber: string;
+  email: string;
+  address: string;
+  educationAndMajor: string;
+  preferredSubjectId: string;
+  motivation: string;
+  desiredTeacherImage: string;
+  meaningOfSharing: string;
+};
 
-const fields = [
-  { id: "birthDate", label: "생년 월일", placeholder: "00.00.00", type: "date" },
-  { id: "name", label: "이름", placeholder: "홍길동", type: "text" },
-  { id: "phone", label: "연락처", placeholder: "000-0000-0000", type: "tel" },
-  { id: "email", label: "이메일", placeholder: "이메일", type: "email" },
-  { id: "address", label: "주소", placeholder: "주소", type: "text" },
+const initialFormState: FormState = {
+  birthDate: "",
+  phoneNumber: "",
+  email: "",
+  address: "",
+  educationAndMajor: "",
+  preferredSubjectId: "",
+  motivation: "",
+  desiredTeacherImage: "",
+  meaningOfSharing: "",
+};
+
+const questions = [
   {
-    id: "education",
-    label: "최종 학력 및 전공",
-    placeholder: "학력, 전공 순으로 작성해주세요",
-    type: "text",
+    id: "motivation",
+    label: "금정열린배움터에 관심을 가지게 된 동기가 무엇입니까?",
+  },
+  {
+    id: "desiredTeacherImage",
+    label: "금정열린배움터에서 어떠한 선생님이 되시길 희망하십니까?",
+  },
+  {
+    id: "meaningOfSharing",
+    label: "지원자께서 생각하시는 '나눔' 의 의미를 간단하게 서술해 주십시오. (2~3문장 내외)",
   },
 ] as const;
 
-const questions = [
-  "금정열린배움터에 관심을 가지게 된 동기가 무엇입니까?",
-  "금정열린배움터에서 어떠한 선생님이 되시길 희망하십니까?",
-  "지원자께서 생각하시는 '나눔' 의 의미를 간단하게 서술해 주십시오. (2~3문장 내외)",
-];
-
 export default function TeacherApplyFormPage() {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { status, user } = useAuthSession();
+  const [form, setForm] = useState<FormState>(initialFormState);
+  const [submitError, setSubmitError] = useState("");
+  const [submitSuccess, setSubmitSuccess] = useState("");
+  const isAuthenticated = status === "authenticated";
+
+  useEffect(() => {
+    if (status === "unauthenticated" || status === "error") {
+      router.replace("/login");
+    }
+  }, [router, status]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    setForm((current) => ({
+      ...current,
+      birthDate: current.birthDate || toBirthDateInputValue(user?.residentRegistrationNumberPrefix),
+      email: current.email || user?.email || "",
+      phoneNumber: current.phoneNumber || user?.phoneNumber || "",
+    }));
+  }, [
+    isAuthenticated,
+    user?.email,
+    user?.phoneNumber,
+    user?.residentRegistrationNumberPrefix,
+  ]);
+
+  const applicationQuery = useQuery({
+    queryKey: queryKeys.teacherApplications.my(),
+    queryFn: getMyTeacherApplication,
+    enabled: isAuthenticated,
+  });
+
+  const schedulesQuery = useQuery({
+    queryKey: queryKeys.teacherApplications.availableSchedules(),
+    queryFn: getAvailableTeacherSchedules,
+    enabled: isAuthenticated,
+  });
+
+  const scheduleOptions = useMemo(
+    () =>
+      (schedulesQuery.data ?? [])
+        .map(toTeacherScheduleOption)
+        .filter(
+          (
+            option,
+          ): option is {
+            key: string;
+            preferredSubjectId: number;
+            label: string;
+          } => option !== null,
+        ),
+    [schedulesQuery.data],
+  );
+
+  useEffect(() => {
+    if (!form.preferredSubjectId && scheduleOptions[0]) {
+      setForm((current) => ({
+        ...current,
+        preferredSubjectId: String(scheduleOptions[0].preferredSubjectId),
+      }));
+    }
+  }, [form.preferredSubjectId, scheduleOptions]);
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateTeacherApplicationRequestDto) => createTeacherApplication(payload),
+    onSuccess: async () => {
+      setSubmitError("");
+      setSubmitSuccess("지원서가 제출되었습니다.");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.my() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.adminList() }),
+      ]);
+      router.replace("/apply/status");
+    },
+    onError: (error) => {
+      const message =
+        error && typeof error === "object" && "message" in error && typeof error.message === "string"
+          ? error.message
+          : "지원서를 제출하지 못했습니다.";
+      setSubmitSuccess("");
+      setSubmitError(message);
+    },
+  });
+
+  if (!isAuthenticated) {
+    return (
+      <ApplyLayout activeItem="apply">
+        <LoadingSection>
+          <LoadingSpinner label="교사 신청 페이지를 불러오는 중" />
+        </LoadingSection>
+      </ApplyLayout>
+    );
+  }
+
+  const existingApplication = applicationQuery.data?.application;
+  const hasBlockingApplication =
+    existingApplication?.status === "PENDING" || existingApplication?.status === "APPROVED";
+  const isSubmitting = createMutation.isPending;
+
+  function handleInputChange<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setSubmitError("");
+    setSubmitSuccess("");
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    window.alert("지원서가 제출되었습니다.");
-  };
+
+    if (hasBlockingApplication || isSubmitting) {
+      return;
+    }
+
+    const preferredSubjectId = Number(form.preferredSubjectId);
+    if (!Number.isFinite(preferredSubjectId)) {
+      setSubmitSuccess("");
+      setSubmitError("지원 희망 과목을 선택해 주세요.");
+      return;
+    }
+
+    createMutation.mutate({
+      birthDate: form.birthDate,
+      phoneNumber: form.phoneNumber.trim(),
+      email: form.email.trim(),
+      address: form.address.trim(),
+      educationAndMajor: form.educationAndMajor.trim(),
+      preferredSubjectId,
+      motivation: form.motivation.trim(),
+      desiredTeacherImage: form.desiredTeacherImage.trim(),
+      meaningOfSharing: form.meaningOfSharing.trim(),
+    });
+  }
 
   return (
-    <ApplyLayout>
+    <ApplyLayout activeItem="apply">
       <PageSection>
         <HeaderRow>
           <Title>교사 지원서 작성하기</Title>
-          <ApplyActionButton type="submit" form="teacher-apply-form">
+          <ApplyActionButton
+            type="submit"
+            form="teacher-apply-form"
+            disabled={
+              isSubmitting ||
+              hasBlockingApplication ||
+              applicationQuery.isLoading ||
+              schedulesQuery.isLoading
+            }
+          >
             제출
           </ApplyActionButton>
         </HeaderRow>
 
-        <Form id="teacher-apply-form" onSubmit={handleSubmit}>
-          {fields.map((field) => (
-            <FieldGroup key={field.id}>
-              <FieldLabel htmlFor={field.id}>{field.label}</FieldLabel>
-              <TextInput
-                id={field.id}
-                name={field.id}
-                type={field.type}
-                placeholder={field.placeholder}
-                onChange={
-                  field.id === "phone"
-                    ? (event) => {
-                        event.target.value = formatPhoneNumber(event.target.value);
-                      }
-                    : undefined
-                }
-              />
-            </FieldGroup>
-          ))}
+        {hasBlockingApplication ? (
+          <StatusNotice role="status">
+            이미 대기 또는 승인 상태의 교사 신청이 있습니다.{" "}
+            <StatusLink href="/apply/status">지원 현황</StatusLink>에서 내용을 확인해 주세요.
+          </StatusNotice>
+        ) : null}
+        {submitError ? <ErrorMessage role="alert">{submitError}</ErrorMessage> : null}
+        {submitSuccess ? <SuccessMessage role="status">{submitSuccess}</SuccessMessage> : null}
 
+        <Form id="teacher-apply-form" onSubmit={handleSubmit}>
           <FieldGroup>
-            <FieldLabel>지원 희망하는 과목과 요일</FieldLabel>
-            <OptionPanel>
-              {subjectOptions.map((option, index) => (
-                <OptionLabel key={option}>
-                  <RadioInput
-                    type="radio"
-                    name="subject"
-                    value={option}
-                    defaultChecked={index === 0}
-                  />
-                  <span>{option}</span>
-                </OptionLabel>
-              ))}
-            </OptionPanel>
+            <FieldLabel htmlFor="birthDate">생년 월일</FieldLabel>
+            <TextInput
+              id="birthDate"
+              name="birthDate"
+              type="date"
+              value={form.birthDate}
+              readOnly
+              required
+            />
           </FieldGroup>
 
-          {questions.map((question, index) => (
-            <FieldGroup key={question}>
-              <FieldLabel htmlFor={`question-${index + 1}`}>{question}</FieldLabel>
-              <TextInput
-                id={`question-${index + 1}`}
-                name={`question${index + 1}`}
-                type="text"
+          <FieldGroup>
+            <FieldLabel htmlFor="applicantName">이름</FieldLabel>
+            <TextInput id="applicantName" name="applicantName" value={user?.name ?? ""} readOnly />
+          </FieldGroup>
+
+          <FieldGroup>
+            <FieldLabel htmlFor="phoneNumber">연락처</FieldLabel>
+            <TextInput
+              id="phoneNumber"
+              name="phoneNumber"
+              type="tel"
+              placeholder="000-0000-0000"
+              value={form.phoneNumber}
+              readOnly
+              required
+            />
+          </FieldGroup>
+
+          <FieldGroup>
+            <FieldLabel htmlFor="email">이메일</FieldLabel>
+            <TextInput
+              id="email"
+              name="email"
+              type="email"
+              placeholder="이메일"
+              value={form.email}
+              readOnly
+              required
+            />
+          </FieldGroup>
+
+          <FieldGroup>
+            <FieldLabel htmlFor="address">주소</FieldLabel>
+            <TextInput
+              id="address"
+              name="address"
+              type="text"
+              placeholder="주소"
+              value={form.address}
+              onChange={(event) => handleInputChange("address", event.target.value)}
+              required
+            />
+          </FieldGroup>
+
+          <FieldGroup>
+            <FieldLabel htmlFor="educationAndMajor">최종 학력 및 전공</FieldLabel>
+            <TextInput
+              id="educationAndMajor"
+              name="educationAndMajor"
+              type="text"
+              placeholder="학력, 전공 순으로 작성해주세요"
+              value={form.educationAndMajor}
+              onChange={(event) => handleInputChange("educationAndMajor", event.target.value)}
+              required
+            />
+          </FieldGroup>
+
+          <FieldGroup>
+            <FieldLabel htmlFor="preferredSubjectId">지원 희망하는 과목과 요일</FieldLabel>
+            {schedulesQuery.isLoading ? (
+              <InlineStateBox>
+                <LoadingSpinner label="신청 가능 시간표를 불러오는 중" />
+              </InlineStateBox>
+            ) : schedulesQuery.isError ? (
+              <InlineStateBox role="alert">신청 가능 시간표를 불러오지 못했습니다.</InlineStateBox>
+            ) : scheduleOptions.length === 0 ? (
+              <InlineStateBox>현재 신청 가능한 시간표가 없습니다.</InlineStateBox>
+            ) : (
+              <SelectInput
+                id="preferredSubjectId"
+                name="preferredSubjectId"
+                value={form.preferredSubjectId}
+                onChange={(event) => handleInputChange("preferredSubjectId", event.target.value)}
+                required
+              >
+                {scheduleOptions.map((option) => (
+                  <option key={option.key} value={option.preferredSubjectId}>
+                    {option.label}
+                  </option>
+                ))}
+              </SelectInput>
+            )}
+          </FieldGroup>
+
+          {questions.map((question) => (
+            <FieldGroup key={question.id}>
+              <FieldLabel htmlFor={question.id}>{question.label}</FieldLabel>
+              <TextArea
+                id={question.id}
+                name={question.id}
+                value={form[question.id]}
+                onChange={(event) => handleInputChange(question.id, event.target.value)}
                 placeholder="답변을 작성해주세요"
+                required
               />
             </FieldGroup>
           ))}
@@ -178,7 +411,7 @@ const FieldLabel = styled.label`
   }
 `;
 
-const TextInput = styled.input`
+const inputBaseStyle = `
   width: 100%;
   min-height: 2.6875rem;
   padding: 0.8125rem ${spacing.space12};
@@ -198,6 +431,10 @@ const TextInput = styled.input`
     border-color: ${colors.point};
   }
 
+  &:read-only {
+    background-color: #f8f8f8;
+  }
+
   @media (min-width: 120rem) {
     min-height: 4rem;
     padding: ${spacing.space20};
@@ -205,42 +442,88 @@ const TextInput = styled.input`
   }
 `;
 
-const OptionPanel = styled.div`
-  display: grid;
-  gap: 0.625rem;
-  padding: 0.8125rem ${spacing.space12};
-  border: 1px solid ${colors.muted};
-  background-color: ${colors.white};
+const TextInput = styled.input`
+  ${inputBaseStyle}
+`;
 
-  @media (min-width: 120rem) {
-    gap: 0.9375rem;
-    padding: ${spacing.space20};
+const TextArea = styled.textarea`
+  ${inputBaseStyle}
+  min-height: 8rem;
+  resize: vertical;
+`;
+
+const SelectInput = styled.select`
+  ${inputBaseStyle}
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 2.75rem;
+  border-color: ${colors.muted};
+  background-color: #ffffff !important;
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%2364706C' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 0.875rem center;
+  background-repeat: no-repeat;
+  background-size: 1rem;
+
+  option {
+    background-color: ${colors.white} !important;
+    color: #000000;
   }
 `;
 
-const OptionLabel = styled.label`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.625rem;
-  color: #0d0d0d;
+const BaseMessage = styled.p`
+  margin: 0 0 1rem;
+  padding: ${spacing.space12} ${spacing.space16};
+  border-radius: 0.5rem;
   font-size: ${typography.fontSize14};
-  font-weight: 500;
-  line-height: ${typography.lineHeight130};
-  cursor: pointer;
+  line-height: ${typography.lineHeight150};
+`;
+
+const StatusNotice = styled(BaseMessage)`
+  background-color: ${colors.pointSoft};
+  color: ${colors.text};
+`;
+
+const ErrorMessage = styled(BaseMessage)`
+  background-color: #fff1f0;
+  color: ${colors.notice};
+`;
+
+const SuccessMessage = styled(BaseMessage)`
+  background-color: #f3faed;
+  color: ${colors.point};
+`;
+
+const InlineStateBox = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid ${colors.muted};
+  background-color: ${colors.white};
+  margin: 0;
+  color: #606060;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
 
   @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
     font-size: ${typography.fontSize20};
   }
 `;
 
-const RadioInput = styled.input`
-  width: 1.25rem;
-  height: 1.25rem;
-  margin: 0;
-  accent-color: ${colors.point};
+const StatusLink = styled(Link)`
+  color: ${colors.point};
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+`;
 
-  @media (min-width: 120rem) {
-    width: 1.875rem;
-    height: 1.875rem;
-  }
+const LoadingSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: ${spacing.space40} ${spacing.space20};
 `;

--- a/components/apply/TeacherApplyIntroPage.tsx
+++ b/components/apply/TeacherApplyIntroPage.tsx
@@ -1,6 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import ApplyLayout from "@/components/apply/ApplyLayout";
 import { ApplyActionLink } from "@/components/apply/ApplyAction";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 
 const notices = [
@@ -13,8 +19,27 @@ const notices = [
 ];
 
 export default function TeacherApplyIntroPage() {
+  const router = useRouter();
+  const { status } = useAuthSession();
+
+  useEffect(() => {
+    if (status === "unauthenticated" || status === "error") {
+      router.replace("/login");
+    }
+  }, [router, status]);
+
+  if (status !== "authenticated") {
+    return (
+      <ApplyLayout activeItem="apply">
+        <LoadingSection>
+          <LoadingSpinner label="교사 신청 페이지를 불러오는 중" />
+        </LoadingSection>
+      </ApplyLayout>
+    );
+  }
+
   return (
-    <ApplyLayout>
+    <ApplyLayout activeItem="apply">
       <PageSection>
         <Title>교사 신청</Title>
         <NoticeBox>
@@ -117,4 +142,12 @@ const ActionRow = styled.div`
   @media (min-width: 120rem) {
     margin-top: 3.25rem;
   }
+`;
+
+const LoadingSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: ${spacing.space40} ${spacing.space20};
 `;

--- a/components/apply/TeacherApplyStatusPage.tsx
+++ b/components/apply/TeacherApplyStatusPage.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import styled from "styled-components";
+import type { TeacherApplicationResponseDto } from "@/api/teacherApplication/teacherApplication.dto";
+import { cancelTeacherApplication, getMyTeacherApplication } from "@/api/teacherApplication/teacherApplication.api";
+import ApplyLayout from "@/components/apply/ApplyLayout";
+import {
+  formatTeacherApplicationPreference,
+  formatTeacherApplicationStatus,
+  getTeacherApplicationStatusColor,
+  getTeacherApplicationFields,
+} from "@/components/apply/teacherApplicationUtils";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+import { useAuthSession } from "@/hooks/useAuthSession";
+import { queryKeys } from "@/lib/queryKeys";
+import { colors, layout, spacing, typography } from "@/styles/tokens";
+import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
+
+export default function TeacherApplyStatusPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { status } = useAuthSession();
+  const isAuthenticated = status === "authenticated";
+  const [selectedApplicationId, setSelectedApplicationId] = useState<number | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+
+  useEffect(() => {
+    if (status === "unauthenticated" || status === "error") {
+      router.replace("/login");
+    }
+  }, [router, status]);
+
+  const applicationQuery = useQuery({
+    queryKey: queryKeys.teacherApplications.my(),
+    queryFn: getMyTeacherApplication,
+    enabled: isAuthenticated,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (applicationId: number) => cancelTeacherApplication({ applicationId }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.my() }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.teacherApplications.adminList() }),
+      ]);
+      setSelectedApplicationId(null);
+      setIsDetailOpen(false);
+    },
+  });
+
+  const applications = useMemo(() => {
+    const application = applicationQuery.data?.application;
+    return applicationQuery.data?.exists && application ? [application] : [];
+  }, [applicationQuery.data?.application, applicationQuery.data?.exists]);
+
+  useEffect(() => {
+    if (!applications.length) {
+      setSelectedApplicationId(null);
+      setIsDetailOpen(false);
+      return;
+    }
+
+    setSelectedApplicationId((current) =>
+      current && applications.some((application) => application.id === current)
+        ? current
+        : applications[0]?.id ?? null,
+    );
+  }, [applications]);
+
+  if (!isAuthenticated) {
+    return (
+      <ApplyLayout activeItem="status">
+        <LoadingSection>
+          <LoadingSpinner label="지원 현황을 불러오는 중" />
+        </LoadingSection>
+      </ApplyLayout>
+    );
+  }
+
+  const selectedApplication =
+    applications.find((application) => application.id === selectedApplicationId) ?? null;
+  const fields = getTeacherApplicationFields(selectedApplication);
+
+  function handleCancel() {
+    if (!selectedApplication?.id || cancelMutation.isPending) {
+      return;
+    }
+
+    cancelMutation.mutate(selectedApplication.id);
+  }
+
+  return (
+    <ApplyLayout activeItem="status">
+      <PageSection>
+        <Title>지원 현황</Title>
+
+        {applicationQuery.isLoading ? (
+          <LoadingSection>
+            <LoadingSpinner label="지원 현황을 불러오는 중" />
+          </LoadingSection>
+        ) : applicationQuery.isError ? (
+          <StateMessage role="alert">지원 현황을 불러오지 못했습니다.</StateMessage>
+        ) : applications.length === 0 ? (
+          <StateMessage>지원 현황이 없습니다.</StateMessage>
+        ) : !isDetailOpen ? (
+          <ApplicationListSection>
+            <SectionTitle>지원 목록</SectionTitle>
+            <ApplicationList>
+              {applications.map((application) => (
+                <ApplicationItem key={application.id ?? application.createdAt ?? "application"}>
+                  <ApplicationButton
+                    type="button"
+                    $active={false}
+                    onClick={() => {
+                      setSelectedApplicationId(application.id ?? null);
+                      setIsDetailOpen(true);
+                    }}
+                  >
+                    <ApplicationPrimary>
+                      <ApplicationName>{formatTeacherApplicationPreference(application)}</ApplicationName>
+                      <ApplicationStatus $active $status={application.status}>
+                        {formatTeacherApplicationStatus(application.status)}
+                      </ApplicationStatus>
+                    </ApplicationPrimary>
+                    <ApplicationMeta>
+                      신청일 {formatUtcToKstShortDate(application.createdAt) || "-"}
+                    </ApplicationMeta>
+                  </ApplicationButton>
+                </ApplicationItem>
+              ))}
+            </ApplicationList>
+          </ApplicationListSection>
+        ) : selectedApplication ? (
+          <DetailSection>
+            <BackButton
+              type="button"
+              onClick={() => {
+                setIsDetailOpen(false);
+              }}
+            >
+              지원 목록
+            </BackButton>
+            <SummaryList>
+              <SummaryItem>
+                <span>상태</span>
+                <StatusValue $status={selectedApplication.status}>
+                  {formatTeacherApplicationStatus(selectedApplication.status)}
+                </StatusValue>
+              </SummaryItem>
+              <SummaryItem>
+                <span>신청일</span>
+                <span>{formatUtcToKstShortDate(selectedApplication.createdAt) || "-"}</span>
+              </SummaryItem>
+              <SummaryItem>
+                <span>검토자</span>
+                <span>{selectedApplication.reviewedByName ?? "-"}</span>
+              </SummaryItem>
+              <SummaryItem>
+                <span>검토 메모</span>
+                <span>{selectedApplication.reviewNote?.trim() || "-"}</span>
+              </SummaryItem>
+            </SummaryList>
+
+            <FieldList>
+              {fields.map((field) => (
+                <FieldCard key={field.label}>
+                  <FieldLabel>{field.label}</FieldLabel>
+                  <FieldValue>{field.value}</FieldValue>
+                </FieldCard>
+              ))}
+            </FieldList>
+
+            {selectedApplication.status === "PENDING" ? (
+              <ActionRow>
+                <CancelButton
+                  type="button"
+                  disabled={cancelMutation.isPending}
+                  onClick={handleCancel}
+                >
+                  교원 신청 취소
+                </CancelButton>
+              </ActionRow>
+            ) : null}
+          </DetailSection>
+        ) : null}
+      </PageSection>
+    </ApplyLayout>
+  );
+}
+
+const PageSection = styled.section`
+  min-height: calc(100vh - ${layout.headerHeight});
+  padding: 2.1875rem 3.125rem 4rem;
+  background-color: ${colors.white};
+
+  @media (min-width: 120rem) {
+    min-height: calc(100vh - 7.1875rem);
+    padding: 3.5rem 4.6875rem 6rem;
+  }
+
+  @media (max-width: ${layout.breakpointTablet}) {
+    padding: ${spacing.space32} ${spacing.space20} ${spacing.space40};
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0 0 1.5rem;
+  color: #000000;
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    margin-bottom: 2.25rem;
+    font-size: 2.5rem;
+  }
+`;
+
+const ApplicationListSection = styled.section`
+  display: grid;
+  gap: ${spacing.space12};
+  width: 100%;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ApplicationList = styled.ul`
+  display: grid;
+  gap: ${spacing.space8};
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+const ApplicationItem = styled.li`
+  display: block;
+`;
+
+const ApplicationButton = styled.button<{ $active: boolean }>`
+  position: relative;
+  display: grid;
+  gap: ${spacing.space8};
+  width: 100%;
+  min-height: 4.75rem;
+  border: 1px solid ${({ $active }) => ($active ? colors.point : colors.border)};
+  border-radius: 0.5rem;
+  padding: ${spacing.space12} ${spacing.space16};
+  background-color: ${({ $active }) => ($active ? colors.pointSoft : colors.white)};
+  color: #1f2b28;
+  text-align: left;
+  cursor: pointer;
+  transform: translateX(${({ $active }) => ($active ? "0.25rem" : "0")});
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
+
+  &:hover {
+    background-color: ${({ $active }) => ($active ? colors.pointSoft : "#f1f5f2")};
+    border-color: ${({ $active }) => ($active ? colors.point : "#d5ddd8")};
+    transform: translateX(0.25rem);
+  }
+
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 0.375rem;
+    width: 0.1875rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    background-color: ${colors.point};
+    content: "";
+    opacity: ${({ $active }) => ($active ? 1 : 0)};
+    transform: translateY(-50%);
+    transition: opacity 0.18s ease;
+  }
+`;
+
+const ApplicationPrimary = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+`;
+
+const ApplicationName = styled.strong`
+  color: #050505;
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight150};
+`;
+
+const ApplicationStatus = styled.span<{
+  $active: boolean;
+  $status?: TeacherApplicationResponseDto["status"];
+}>`
+  flex-shrink: 0;
+  color: ${({ $active, $status }) =>
+    $active ? getTeacherApplicationStatusColor($status) : "#64706c"};
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ApplicationMeta = styled.span`
+  color: #64706c;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
+`;
+
+const DetailSection = styled.section`
+  display: grid;
+  gap: 1.5rem;
+`;
+
+const BackButton = styled.button`
+  justify-self: start;
+  border: 0;
+  padding: 0;
+  background-color: transparent;
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.125rem;
+  }
+`;
+
+const SummaryList = styled.ul`
+  display: grid;
+  gap: ${spacing.space12};
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+const SummaryItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  gap: ${spacing.space12};
+  padding: ${spacing.space12} ${spacing.space16};
+  border: 1px solid ${colors.muted};
+  border-radius: 0.5rem;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+
+  > span:first-child {
+    font-weight: 700;
+  }
+
+  > span:last-child {
+    text-align: right;
+  }
+`;
+
+const StatusValue = styled.span<{ $status?: TeacherApplicationResponseDto["status"] }>`
+  color: ${({ $status }) => getTeacherApplicationStatusColor($status)};
+  font-weight: 700;
+  text-align: right;
+`;
+
+const FieldList = styled.div`
+  display: grid;
+  gap: 1rem;
+`;
+
+const FieldCard = styled.section`
+  display: grid;
+  gap: 0.75rem;
+`;
+
+const FieldLabel = styled.h2`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const FieldValue = styled.div`
+  min-height: 2.6875rem;
+  padding: 0.8125rem ${spacing.space12};
+  border: 1px solid ${colors.muted};
+  background-color: #fafafa;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 500;
+  line-height: ${typography.lineHeight150};
+  white-space: pre-wrap;
+
+  @media (min-width: 120rem) {
+    min-height: 4rem;
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const CancelButton = styled.button`
+  min-height: 2.75rem;
+  border: 1px solid #da3a30;
+  border-radius: 0.5rem;
+  padding: 0 ${spacing.space20};
+  background-color: ${colors.white};
+  color: #da3a30;
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+
+  &:not(:disabled):hover {
+    border-color: #c53229;
+    background-color: #fff1f0;
+    color: #c53229;
+  }
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+`;
+
+const StateMessage = styled.p`
+  margin: 0;
+  padding: ${spacing.space20};
+  border: 1px solid ${colors.muted};
+  border-radius: 0.5rem;
+  color: #606060;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+`;
+
+const LoadingSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 16rem;
+`;

--- a/components/apply/teacherApplicationUtils.test.ts
+++ b/components/apply/teacherApplicationUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTeacherApplicationPreference,
+  formatTeacherApplicationStatus,
+  toTeacherScheduleOption,
+} from "./teacherApplicationUtils";
+
+describe("teacherApplicationUtils", () => {
+  it("formats teacher schedule options for the dropdown", () => {
+    const option = toTeacherScheduleOption(
+      {
+        scheduleKey: "1-TUESDAY",
+        classroomName: "개나리반",
+        dayOfWeek: "TUESDAY",
+        startTime: "19:00:00",
+        endTime: "21:00:00",
+        subjectIds: [3, 4],
+        subjects: [
+          { subjectId: 3, subjectName: "한글" },
+          { subjectId: 4, subjectName: "영어" },
+        ],
+      },
+      0,
+    );
+
+    expect(option).toEqual({
+      key: "1-TUESDAY",
+      preferredSubjectId: 3,
+      label: "개나리반 한글/영어 수업 - 화요일 19:00 ~ 21:00",
+    });
+  });
+
+  it("formats the preferred lesson summary in application detail", () => {
+    expect(
+      formatTeacherApplicationPreference({
+        preferredClassroomName: "개나리반",
+        preferredSubjectName: "한글",
+        preferredDayOfWeek: "THURSDAY",
+        preferredStartTime: "18:00:00",
+        preferredEndTime: "20:00:00",
+      }),
+    ).toBe("개나리반 한글 수업 - 목요일 18:00 ~ 20:00");
+  });
+
+  it("maps statuses to Korean labels", () => {
+    expect(formatTeacherApplicationStatus("PENDING")).toBe("대기");
+    expect(formatTeacherApplicationStatus("APPROVED")).toBe("승인");
+    expect(formatTeacherApplicationStatus("REJECTED")).toBe("반려");
+    expect(formatTeacherApplicationStatus("CANCELLED")).toBe("취소");
+  });
+});

--- a/components/apply/teacherApplicationUtils.ts
+++ b/components/apply/teacherApplicationUtils.ts
@@ -1,0 +1,132 @@
+import type {
+  AvailableTeacherScheduleResponseDto,
+  TeacherApplicationResponseDto,
+} from "@/api/teacherApplication/teacherApplication.dto";
+import type { SubjectDayOfWeek } from "@/api/subject/subject.dto";
+
+const DAY_OF_WEEK_LABELS: Record<SubjectDayOfWeek, string> = {
+  MONDAY: "월",
+  TUESDAY: "화",
+  WEDNESDAY: "수",
+  THURSDAY: "목",
+  FRIDAY: "금",
+  SATURDAY: "토",
+  SUNDAY: "일",
+};
+
+function formatSubjectDayOfWeek(dayOfWeek?: SubjectDayOfWeek) {
+  return dayOfWeek ? DAY_OF_WEEK_LABELS[dayOfWeek] : "—";
+}
+
+function formatSubjectTimeRange(startTime?: string, endTime?: string) {
+  const start = startTime ? startTime.slice(0, 5) : "—";
+  const end = endTime ? endTime.slice(0, 5) : "—";
+  return `${start} ~ ${end}`;
+}
+
+export type TeacherApplicationField = {
+  label: string;
+  value: string;
+};
+
+export function getTeacherApplicationFields(
+  application?: TeacherApplicationResponseDto | null,
+): TeacherApplicationField[] {
+  return [
+    { label: "생년 월일", value: application?.birthDate ?? "-" },
+    { label: "이름", value: application?.applicantName ?? "-" },
+    { label: "연락처", value: application?.applicantPhoneNumber ?? "-" },
+    { label: "이메일", value: application?.applicantEmail ?? "-" },
+    { label: "주소", value: application?.address ?? "-" },
+    { label: "최종 학력 및 전공", value: application?.educationAndMajor ?? "-" },
+    {
+      label: "지원 희망하는 과목과 요일",
+      value: formatTeacherApplicationPreference(application),
+    },
+    { label: "금정열린배움터에 관심을 가지게 된 동기", value: application?.motivation ?? "-" },
+    {
+      label: "금정열린배움터에서 어떠한 선생님이 되시길 희망하십니까?",
+      value: application?.desiredTeacherImage ?? "-",
+    },
+    {
+      label: "지원자께서 생각하시는 '나눔' 의 의미를 간단하게 서술해 주십시오. (2~3문장 내외)",
+      value: application?.meaningOfSharing ?? "-",
+    },
+  ];
+}
+
+export function formatTeacherApplicationStatus(status?: TeacherApplicationResponseDto["status"]) {
+  const labels = {
+    PENDING: "대기",
+    APPROVED: "승인",
+    REJECTED: "반려",
+    CANCELLED: "취소",
+  } as const;
+
+  return status ? labels[status] : "-";
+}
+
+export function getTeacherApplicationStatusColor(
+  status?: TeacherApplicationResponseDto["status"],
+) {
+  const colors = {
+    PENDING: "#C58A00",
+    APPROVED: "#88CD5A",
+    REJECTED: "#DA3A30",
+    CANCELLED: "#7B8480",
+  } as const;
+
+  return status ? colors[status] : "#7B8480";
+}
+
+export function formatTeacherApplicationPreference(
+  application?: Pick<
+    TeacherApplicationResponseDto,
+    | "preferredClassroomName"
+    | "preferredSubjectName"
+    | "preferredDayOfWeek"
+    | "preferredStartTime"
+    | "preferredEndTime"
+  > | null,
+) {
+  const classroomName = application?.preferredClassroomName?.trim();
+  const subjectName = application?.preferredSubjectName?.trim();
+  const dayOfWeek = formatSubjectDayOfWeek(application?.preferredDayOfWeek);
+  const time = formatSubjectTimeRange(application?.preferredStartTime, application?.preferredEndTime);
+
+  if (!classroomName && !subjectName && dayOfWeek === "—" && time === "— ~ —") {
+    return "-";
+  }
+
+  const classPart = classroomName ? `${classroomName} ` : "";
+  const subjectPart = subjectName ? `${subjectName} 수업` : "수업";
+  return `${classPart}${subjectPart} - ${dayOfWeek}요일 ${time}`;
+}
+
+export function toTeacherScheduleOption(
+  schedule: AvailableTeacherScheduleResponseDto,
+  index: number,
+) {
+  const subjectIds = schedule.subjectIds ?? [];
+  const subjects = schedule.subjects ?? [];
+  const preferredSubjectId =
+    subjects.find((subject) => typeof subject.subjectId === "number")?.subjectId ?? subjectIds[0];
+
+  if (typeof preferredSubjectId !== "number") {
+    return null;
+  }
+
+  const subjectNames = subjects
+    .map((subject) => subject.subjectName?.trim())
+    .filter((name): name is string => Boolean(name));
+  const joinedSubjectNames = subjectNames.length > 0 ? subjectNames.join("/") : "미정";
+  const classPart = schedule.classroomName?.trim() ? `${schedule.classroomName} ` : "";
+  const dayLabel = formatSubjectDayOfWeek(schedule.dayOfWeek);
+  const timeLabel = formatSubjectTimeRange(schedule.startTime, schedule.endTime);
+
+  return {
+    key: schedule.scheduleKey ?? `${preferredSubjectId}-${index}`,
+    preferredSubjectId,
+    label: `${classPart}${joinedSubjectNames} 수업 - ${dayLabel}요일 ${timeLabel}`,
+  };
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -45,6 +45,7 @@ export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { status, signOut } = useAuthSession();
   const isAuthenticated = status === "authenticated";
+  const newRegistrationHref = isAuthenticated ? "/apply" : "/login";
 
   if (pathname.startsWith("/admin")) {
     return null;
@@ -69,7 +70,7 @@ export default function Header() {
                 {headerMenus.map((menu) => (
                   <NavItem key={menu.label}>
                     <NavLink
-                      href={menu.href}
+                      href={menu.label === "신규 등록" ? newRegistrationHref : menu.href}
                       $isOpen={isMenuOpen}
                       onFocus={() => setIsMenuOpen(true)}
                       onMouseEnter={() => setIsMenuOpen(true)}
@@ -107,7 +108,15 @@ export default function Header() {
                   <SubMenuList>
                     {menu.items.map((item) => (
                       <SubMenuItem key={item.label}>
-                        <SubMenuLink href={item.href}>{item.label}</SubMenuLink>
+                        <SubMenuLink
+                          href={
+                            menu.label === "신규 등록" && item.label === "교사 신청"
+                              ? newRegistrationHref
+                              : item.href
+                          }
+                        >
+                          {item.label}
+                        </SubMenuLink>
                       </SubMenuItem>
                     ))}
                   </SubMenuList>

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -44,6 +44,14 @@ export const queryKeys = {
   teachers: {
     contactList: () => ["teachers", "contact-list"] as const,
   },
+  teacherApplications: {
+    my: () => ["teacher-applications", "me"] as const,
+    availableSchedules: () => ["teacher-applications", "available-schedules"] as const,
+    adminList: (params?: { keyword?: string; status?: string; page?: number; size?: number }) =>
+      ["admin", "teacher-applications", "list", params ?? {}] as const,
+    adminDetail: (applicationId: number) =>
+      ["admin", "teacher-applications", "detail", applicationId] as const,
+  },
   meetingRecords: {
     list: (params: { page: number; size: number; keyword?: string; mineOnly?: boolean }) =>
       ["meeting-records", "list", params] as const,


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 교사 신청 사용자 플로우 추가
   \- 메인 페이지 `신규 등록` 클릭 시 비로그인 사용자는 `/login`, 로그인 사용자는 `/apply`로 이동합니다.

   [교사 신청서 작성]

   \- 교사 신청서 작성 시 기본 사용자 정보는 자동으로 불러오며, 현재 교사가 배정되지 않은 수업 정보를 조회하여 지원자가 확인 후 선택할 수 있습니다.

   <img width="1898" height="863" alt="스크린샷 2026-06-21 134116" src="https://github.com/user-attachments/assets/871bb213-079a-427a-bca5-6a2cbf98446d" />

   <img width="1898" height="865" alt="스크린샷 2026-06-21 134138" src="https://github.com/user-attachments/assets/05e76e6b-7d17-4a74-a9cb-535a3eb01e34" />

   [지원 현황]

   \- 교사 신청서 제출 후 “지원 현황” 섹션에서 지원 상태 및 처리 현황을 확인할 수 있습니다.

   <img width="1918" height="863" alt="스크린샷 2026-06-21 134150" src="https://github.com/user-attachments/assets/fe893a67-384e-41af-a06b-48a2ee5f829a" />

   <img width="1898" height="867" alt="스크린샷 2026-06-21 134200" src="https://github.com/user-attachments/assets/1ec45287-b8ba-4d92-a9ec-ba4e4d48db8e" />

   \- 이미 지원하여 대기 중인 신청 건이 있는 경우에는 재지원할 수 없도록 중복 지원을 제한하였습니다.

   <img width="1900" height="862" alt="스크린샷 2026-06-21 134642" src="https://github.com/user-attachments/assets/17314c2d-6448-4b9d-91e5-5137a70af8ff" />

2. 관리자 교사 신청 관리 기능 추가
   \- 교사 신청 현황은 관리자 페이지의 `교사 신청 관리` 메뉴에서 확인할 수 있습니다.

   <img width="1918" height="862" alt="스크린샷 2026-06-21 134257" src="https://github.com/user-attachments/assets/5305aced-14a8-408a-a8d8-54bca9f0fd7d" />

   \- 관리자 승인 시, 신청자 권한을 `VOLUNTEER`로 자동 승격되도록 연동하였습니다.

   <img width="1918" height="862" alt="스크린샷 2026-06-21 134520" src="https://github.com/user-attachments/assets/59570350-5872-4f91-af23-32a981af9dd0" />

   <img width="1918" height="862" alt="스크린샷 2026-06-21 134552" src="https://github.com/user-attachments/assets/78a47970-5173-4494-9e95-a364f0d3776f" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #149 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
