### PR TITLE
[FEAT] 회원가입 이메일 인증 및 Google OAuth 콜백 개선

### DIFF
--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -4,6 +4,8 @@ import { clearTokens, setTokens } from "../client/tokenStorage";
 import type {
   AuthMessageResponseDto,
   AdminLoginRequestDto,
+  EmailVerificationConfirmRequestDto,
+  EmailVerificationResendRequestDto,
   GoogleLoginRequestDto,
   GoogleSignupRequestDto,
   LoginRequestDto,
@@ -13,10 +15,27 @@ import type {
   TokenResponseDto,
 } from "./auth.dto";
 
-// 회원가입 후 토큰을 발급받는 요청
+// 회원가입 — 이메일 인증 필요, 토큰 미발급
 export async function signup(body: SignupRequestDto) {
-  const response = await publicClient.post<TokenResponseDto>("/api/v1/auth/signup", body);
-  setTokens(response.data.accessToken, response.data.refreshToken);
+  const response = await publicClient.post<AuthMessageResponseDto>("/api/v1/auth/signup", body);
+  return response.data;
+}
+
+// 이메일 인증 코드 확인
+export async function confirmEmailVerification(body: EmailVerificationConfirmRequestDto) {
+  const response = await publicClient.post<AuthMessageResponseDto>(
+    "/api/v1/auth/email-verification/confirm",
+    body,
+  );
+  return response.data;
+}
+
+// 이메일 인증 코드 재발송
+export async function resendEmailVerification(body: EmailVerificationResendRequestDto) {
+  const response = await publicClient.post<AuthMessageResponseDto>(
+    "/api/v1/auth/email-verification/resend",
+    body,
+  );
   return response.data;
 }
 
@@ -71,6 +90,13 @@ export async function googleLogin(body: GoogleLoginRequestDto) {
 
 export async function connectLocalAccount(body: GoogleLoginRequestDto) {
   const response = await authClient.post<TokenResponseDto>("/api/v1/auth/google/connect", body);
+  setTokens(response.data.accessToken, response.data.refreshToken);
+  return response.data;
+}
+
+// 비로그인 상태에서 Google 계정과 기존 Local 계정 연결 (콜백 signupRequired+connectedToLocal 흐름)
+export async function connectGoogleToLocalAccount(body: GoogleLoginRequestDto) {
+  const response = await publicClient.post<TokenResponseDto>("/api/v1/auth/google/connect", body);
   setTokens(response.data.accessToken, response.data.refreshToken);
   return response.data;
 }

--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -45,7 +45,21 @@ export interface GoogleLoginRequestDto {
 export interface GoogleCallbackRedirectQueryParamsDto {
   tempToken?: string;
   signupRequired?: string;
+  connectedToLocal?: string;
+  email?: string;
+  name?: string;
+  profileImageUrl?: string;
+  error?: string;
   errorCode?: string;
+}
+
+export interface EmailVerificationConfirmRequestDto {
+  email: string;
+  verificationCode: string;
+}
+
+export interface EmailVerificationResendRequestDto {
+  email: string;
 }
 
 export type AdminLoginRequestDto = LoginRequestDto;

--- a/app/(public)/auth/email-verification/page.tsx
+++ b/app/(public)/auth/email-verification/page.tsx
@@ -1,0 +1,11 @@
+import EmailVerificationForm from "@/components/auth/EmailVerificationForm";
+
+type PageProps = {
+  searchParams?: Promise<{ email?: string }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const { email = "" } = (await searchParams) ?? {};
+
+  return <EmailVerificationForm email={decodeURIComponent(email)} />;
+}

--- a/components/auth/EmailVerificationForm.tsx
+++ b/components/auth/EmailVerificationForm.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import styled from "styled-components";
+import { confirmEmailVerification, resendEmailVerification } from "@/api/auth/auth.api";
+import {
+  Field,
+  FieldGroup,
+  Form,
+  Input,
+  Label,
+  Status,
+  SubmitButton,
+} from "@/components/auth/AuthFormParts";
+import AuthShell from "@/components/auth/AuthShell";
+import { colors, spacing, typography } from "@/styles/tokens";
+
+const RESEND_COOLDOWN_SECONDS = 60;
+
+type EmailVerificationFormProps = {
+  email: string;
+};
+
+export default function EmailVerificationForm({ email }: EmailVerificationFormProps) {
+  const router = useRouter();
+  const [code, setCode] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [statusTone, setStatusTone] = useState<"default" | "error">("default");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCooldown = useCallback(() => {
+    setCooldown(RESEND_COOLDOWN_SECONDS);
+    cooldownRef.current = setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(cooldownRef.current!);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownRef.current) clearInterval(cooldownRef.current);
+    };
+  }, []);
+
+  const canSubmit = code.length === 6 && !isSubmitting;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setIsSubmitting(true);
+    setStatusMessage("");
+
+    try {
+      await confirmEmailVerification({ email, verificationCode: code });
+      setStatusTone("default");
+      setStatusMessage("이메일 인증이 완료되었습니다. 로그인해 주세요.");
+      router.replace("/login");
+    } catch {
+      setStatusTone("error");
+      setStatusMessage("인증 코드가 올바르지 않습니다. 다시 확인해 주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleResend() {
+    if (cooldown > 0) return;
+
+    try {
+      await resendEmailVerification({ email });
+      setStatusTone("default");
+      setStatusMessage("인증 메일을 다시 발송했습니다.");
+      startCooldown();
+    } catch {
+      setStatusTone("error");
+      setStatusMessage("재발송에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+    }
+  }
+
+  return (
+    <AuthShell switchText="다른 계정으로 가입하시겠어요?" switchLabel="회원가입" switchHref="/register">
+      <Form onSubmit={handleSubmit} aria-label="이메일 인증 폼">
+        <Description>
+          <strong>{email}</strong>으로 발송된 6자리 인증번호를 입력해 주세요.
+        </Description>
+
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="email-verification-code">인증번호</Label>
+            <Input
+              id="email-verification-code"
+              name="verificationCode"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              placeholder="6자리 숫자 입력"
+              maxLength={6}
+              value={code}
+              onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+              required
+            />
+          </Field>
+        </FieldGroup>
+
+        <Status
+          role="status"
+          aria-live="polite"
+          $tone={statusTone}
+          $visible={Boolean(statusMessage)}
+        >
+          {statusMessage || " "}
+        </Status>
+
+        <SubmitButton type="submit" disabled={!canSubmit}>
+          {isSubmitting ? "확인 중" : "인증 완료"}
+        </SubmitButton>
+
+        <ResendRow>
+          <ResendText>메일을 받지 못하셨나요?</ResendText>
+          <ResendButton type="button" onClick={handleResend} disabled={cooldown > 0}>
+            {cooldown > 0 ? `재발송 (${cooldown}초)` : "인증 메일 재발송"}
+          </ResendButton>
+        </ResendRow>
+      </Form>
+    </AuthShell>
+  );
+}
+
+const Description = styled.p`
+  margin: 0;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  word-break: keep-all;
+
+  strong {
+    color: ${colors.point};
+    font-weight: 700;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ResendRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${spacing.space8};
+`;
+
+const ResendText = styled.span`
+  color: ${colors.muted};
+  font-size: ${typography.fontSize13};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const ResendButton = styled.button`
+  border: 0;
+  background: none;
+  color: ${colors.point};
+  font-family: inherit;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  cursor: pointer;
+
+  &:disabled {
+    color: ${colors.muted};
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;

--- a/components/auth/GoogleCallbackPage.tsx
+++ b/components/auth/GoogleCallbackPage.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import type { GoogleCallbackRedirectQueryParamsDto } from "@/api/auth/auth.dto";
-import { connectLocalAccount, googleLogin } from "@/api/auth/auth.api";
+import {
+  connectGoogleToLocalAccount,
+  connectLocalAccount,
+  googleLogin,
+} from "@/api/auth/auth.api";
 import {
   clearGoogleOAuthIntent,
   getGoogleOAuthIntent,
@@ -29,13 +33,16 @@ export default function GoogleCallbackPage({ searchParams }: GoogleCallbackPageP
   const router = useRouter();
   const [statusMessage, setStatusMessage] = useState("구글 로그인 정보를 확인하고 있습니다.");
   const [hasError, setHasError] = useState(false);
+  const [pendingConnect, setPendingConnect] = useState<{ tempToken: string } | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
 
   useEffect(() => {
-    const { tempToken, errorCode } = searchParams;
+    const { tempToken, error, errorCode } = searchParams;
     const signupRequired = searchParams.signupRequired === "true";
+    const connectedToLocal = searchParams.connectedToLocal === "true";
 
     async function handleCallback() {
-      if (errorCode) {
+      if (error === "oauth_failed" || errorCode) {
         setHasError(true);
         setStatusMessage("구글 로그인 중 오류가 발생했습니다. 다시 시도해 주세요.");
         clearGoogleOAuthIntent();
@@ -49,8 +56,20 @@ export default function GoogleCallbackPage({ searchParams }: GoogleCallbackPageP
         return;
       }
 
+      if (signupRequired && connectedToLocal) {
+        // 같은 이메일의 Local 계정 존재 → 계정 연결 확인 UI
+        setStatusMessage("이미 가입된 계정이 있습니다. 구글 계정을 연결하시겠어요?");
+        setPendingConnect({ tempToken });
+        return;
+      }
+
       if (signupRequired) {
-        router.replace(`/auth/google/signup?tempToken=${encodeURIComponent(tempToken)}`);
+        // 신규 Google 회원가입 — name/email/profileImageUrl prefill
+        const params = new URLSearchParams({ tempToken });
+        if (searchParams.name) params.set("name", searchParams.name);
+        if (searchParams.email) params.set("email", searchParams.email);
+        if (searchParams.profileImageUrl) params.set("profileImageUrl", searchParams.profileImageUrl);
+        router.replace(`/auth/google/signup?${params.toString()}`);
         return;
       }
 
@@ -79,11 +98,48 @@ export default function GoogleCallbackPage({ searchParams }: GoogleCallbackPageP
     void handleCallback();
   }, [router, searchParams]);
 
+  async function handleConfirmConnect() {
+    if (!pendingConnect || isConnecting) return;
+
+    setIsConnecting(true);
+    try {
+      await connectGoogleToLocalAccount({ tempToken: pendingConnect.tempToken });
+      clearGoogleOAuthIntent();
+      setStatusMessage("계정 연결이 완료되었습니다. 잠시 후 메인으로 이동합니다.");
+      setPendingConnect(null);
+      router.replace("/");
+    } catch {
+      setHasError(true);
+      setStatusMessage("계정 연결에 실패했습니다. 다시 시도해 주세요.");
+      setPendingConnect(null);
+      clearGoogleOAuthIntent();
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  function handleCancelConnect() {
+    clearGoogleOAuthIntent();
+    setPendingConnect(null);
+    router.replace("/login");
+  }
+
   return (
     <AuthShell switchText="일반 로그인으로 돌아가시겠어요?" switchLabel="로그인" switchHref="/login">
       <ContentSection aria-live="polite">
-        {hasError ? null : <LoadingSpinner label="구글 로그인 처리 중" />}
+        {!hasError && !pendingConnect && <LoadingSpinner label="구글 로그인 처리 중" />}
         <StatusText $tone={hasError ? "error" : "default"}>{statusMessage}</StatusText>
+
+        {pendingConnect && !hasError && (
+          <ButtonRow>
+            <ConnectButton onClick={handleConfirmConnect} disabled={isConnecting}>
+              {isConnecting ? "연결 중" : "연결하기"}
+            </ConnectButton>
+            <CancelButton onClick={handleCancelConnect} disabled={isConnecting}>
+              취소
+            </CancelButton>
+          </ButtonRow>
+        )}
       </ContentSection>
     </AuthShell>
   );
@@ -108,4 +164,39 @@ const StatusText = styled.p<{ $tone: "default" | "error" }>`
   @media (min-width: 120rem) {
     font-size: ${typography.fontSize20};
   }
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: ${spacing.space12};
+`;
+
+const ConnectButton = styled.button`
+  min-height: 2.5rem;
+  padding: 0 ${spacing.space20};
+  border: 0;
+  border-radius: 0.375rem;
+  background-color: ${colors.point};
+  color: ${colors.white};
+  font-family: inherit;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.75rem;
+    border-radius: 0.5rem;
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const CancelButton = styled(ConnectButton)`
+  background-color: transparent;
+  border: 1px solid ${colors.border};
+  color: ${colors.text};
 `;

--- a/components/auth/GoogleSignupForm.tsx
+++ b/components/auth/GoogleSignupForm.tsx
@@ -37,7 +37,10 @@ type GoogleSignupFormProps = {
 export default function GoogleSignupForm({ searchParams }: GoogleSignupFormProps) {
   const router = useRouter();
   const tempToken = searchParams.tempToken ?? "";
-  const [form, setForm] = useState(initialState);
+  const [form, setForm] = useState<GoogleSignupFormState>({
+    ...initialState,
+    name: searchParams.name ?? "",
+  });
   const [statusMessage, setStatusMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -78,8 +78,7 @@ export default function RegisterForm() {
         birthDate: form.birthDate,
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
-      setStatusMessage("회원가입이 완료되었습니다. 잠시 후 메인으로 이동합니다.");
-      router.replace("/");
+      router.replace(`/auth/email-verification?email=${encodeURIComponent(form.email.trim())}`);
     } catch {
       setStatusMessage("회원가입 정보를 확인해 주세요.");
     } finally {

--- a/pwa/components/MobileRegisterPage.tsx
+++ b/pwa/components/MobileRegisterPage.tsx
@@ -70,7 +70,7 @@ export default function MobileRegisterPage() {
         birthDate: form.birthDate,
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
-      router.replace("/", { scroll: true });
+      router.replace(`/auth/email-verification?email=${encodeURIComponent(form.email.trim())}`);
     } catch {
       setStatusMessage("회원가입 정보를 확인해 주세요.");
     } finally {


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

Handoff 문서(`Handoff/2026-06-27-signup-google-drive-frontend.md`)를 기반으로 회원가입 이메일 인증 흐름과 Google OAuth 콜백 처리를 개선하였습니다.

### Local 회원가입 — 이메일 인증 필수화

- 회원가입 성공 후 자동 로그인 제거
- `/auth/email-verification?email=...` 화면으로 이동하도록 변경 (데스크탑/모바일 공통)
- 이메일 인증 화면 신규 추가: 6자리 코드 입력, 재발송 버튼(60초 쿨다운), 인증 완료 후 로그인 화면으로 이동

### Google OAuth 콜백 개선

- `signupRequired=true && connectedToLocal=true`: 같은 이메일의 Local 계정이 있을 때 계정 연결 확인 UI 표시 → 확인 시 `/api/v1/auth/google/connect` 호출 후 로그인
- `signupRequired=true && connectedToLocal=false`: 신규 Google 가입 화면으로 이동, `name` / `email` / `profileImageUrl` 쿼리로 전달해 이름 자동 입력
- `error=oauth_failed` 파라미터 추가 처리

### API 변경

| 항목 | 변경 내용 |
|---|---|
| `POST /api/v1/auth/signup` | 반환 타입 `TokenResponse` → `{ message }`, 토큰 미발급 |
| `POST /api/v1/auth/email-verification/confirm` | 신규 |
| `POST /api/v1/auth/email-verification/resend` | 신규 |
| `POST /api/v1/auth/google/connect` | 비로그인 상태에서 publicClient로도 호출 가능하도록 추가 |

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

N/A

## 💬 기타 사항

운영 환경 `FRONTEND_REDIRECT_URI` 설정 오류는 Backend 이슈(#160)로 별도 트래킹합니다.

## 📂 참고 자료

> Handoff/2026-06-27-signup-google-drive-frontend.md