### PR TITLE
[FEAT] 교학 회의록 첨부파일 전용 API 연동

### DIFF
--- a/api/meetingRecord/meetingRecord.api.test.ts
+++ b/api/meetingRecord/meetingRecord.api.test.ts
@@ -8,8 +8,10 @@ import { server } from "../../mocks/server";
 import { setAccessToken } from "../client/tokenStorage";
 
 import {
+  attachMeetingRecordFile,
   createAbsenceReport,
   createMeetingRecord,
+  deleteMeetingRecordAttachment,
   getMeetingRecords,
   updateMeetingRecord,
 } from "./meetingRecord.api";
@@ -62,6 +64,56 @@ describe("meetingRecord.api", () => {
 
     expect(observedCreateBody).toEqual({ title: "회의", agenda: "안건" });
     expect(observedUpdateBody).toEqual({ discussion: "논의" });
+  });
+
+  it("uploads a file to a meeting record via multipart", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedUrl = "";
+    let observedContentType = "";
+
+    server.use(
+      http.post(
+        `${API_BASE_URL}/api/v1/meeting-records/1/attachments`,
+        ({ request }) => {
+          observedUrl = request.url;
+          observedContentType = request.headers.get("content-type") ?? "";
+          return HttpResponse.json({
+            fileId: "mock-uuid",
+            originalName: "test.pdf",
+            isGoogleDrive: false,
+          });
+        },
+      ),
+    );
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    const response = await attachMeetingRecordFile({ recordId: 1 }, file, "test.pdf");
+
+    expect(response.fileId).toBe("mock-uuid");
+    expect(response.originalName).toBe("test.pdf");
+    expect(observedUrl).toContain("/meeting-records/1/attachments");
+    expect(observedContentType).toContain("multipart/form-data");
+  });
+
+  it("deletes a meeting record attachment", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedUrl = "";
+
+    server.use(
+      http.delete(
+        `${API_BASE_URL}/api/v1/meeting-records/1/attachments/file-abc`,
+        ({ request }) => {
+          observedUrl = request.url;
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await deleteMeetingRecordAttachment({ recordId: 1, fileId: "file-abc" });
+
+    expect(observedUrl).toContain("/meeting-records/1/attachments/file-abc");
   });
 
   it("creates an absence report for a meeting record", async () => {

--- a/api/meetingRecord/meetingRecord.api.ts
+++ b/api/meetingRecord/meetingRecord.api.ts
@@ -1,8 +1,11 @@
 import authClient from "../client/authClient";
 import type {
   CreateMeetingRecordRequestDto,
+  LinkMeetingRecordAttachmentRequestDto,
   MeetingAbsenceReportPathParamsDto,
   MeetingAbsenceReportResponseDto,
+  MeetingRecordAttachmentDto,
+  MeetingRecordAttachmentPathParamsDto,
   MeetingRecordDetailResponseDto,
   MeetingRecordListQueryParamsDto,
   MeetingRecordListResponseDto,
@@ -82,5 +85,42 @@ export async function updateAbsenceReport(
 export async function deleteAbsenceReport(pathParams: MeetingAbsenceReportPathParamsDto) {
   await authClient.delete(
     `/api/v1/meeting-records/${pathParams.recordId}/absence-reports/${pathParams.absenceReportId}`,
+  );
+}
+
+// 교학 회의록에 파일을 직접 업로드하는 요청 (multipart/form-data)
+export async function attachMeetingRecordFile(
+  pathParams: MeetingRecordPathParamsDto,
+  file: Blob,
+  filename?: string,
+) {
+  const formData = new FormData();
+  formData.append("file", filename ? new File([file], filename) : file);
+  const response = await authClient.post<MeetingRecordAttachmentDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}/attachments`,
+    formData,
+    { headers: { "Content-Type": "multipart/form-data" } },
+  );
+  return response.data;
+}
+
+// 이미 등록된 파일을 교학 회의록에 연결하는 요청
+export async function linkMeetingRecordAttachment(
+  pathParams: MeetingRecordPathParamsDto,
+  body: LinkMeetingRecordAttachmentRequestDto,
+) {
+  const response = await authClient.post<MeetingRecordAttachmentDto>(
+    `/api/v1/meeting-records/${pathParams.recordId}/attachments`,
+    body,
+  );
+  return response.data;
+}
+
+// 교학 회의록 첨부파일을 삭제하는 요청
+export async function deleteMeetingRecordAttachment(
+  pathParams: MeetingRecordAttachmentPathParamsDto,
+) {
+  await authClient.delete(
+    `/api/v1/meeting-records/${pathParams.recordId}/attachments/${pathParams.fileId}`,
   );
 }

--- a/api/meetingRecord/meetingRecord.dto.ts
+++ b/api/meetingRecord/meetingRecord.dto.ts
@@ -40,6 +40,21 @@ export interface MeetingRecordAttachmentDto {
   originalName?: string;
   downloadUrl?: string;
   viewUrl?: string;
+  contentType?: string;
+  fileSize?: number;
+  ext?: string;
+  isGoogleDrive?: boolean;
+  sortOrder?: number;
+}
+
+export interface MeetingRecordAttachmentPathParamsDto {
+  recordId: number;
+  fileId: string;
+}
+
+export interface LinkMeetingRecordAttachmentRequestDto {
+  fileId: string;
+  sortOrder?: number;
 }
 
 export interface MeetingRecordDetailResponseDto extends MeetingRecordSummaryResponseDto {

--- a/components/staff/archive/meeting-records/MeetingRecordFormPage.tsx
+++ b/components/staff/archive/meeting-records/MeetingRecordFormPage.tsx
@@ -4,9 +4,10 @@ import { useRef, useState, type FormEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
-import { deleteAttachment } from "@/api/file/file.api";
 import {
+  attachMeetingRecordFile,
   createMeetingRecord,
+  deleteMeetingRecordAttachment,
   updateMeetingRecord,
 } from "@/api/meetingRecord/meetingRecord.api";
 import type {
@@ -18,7 +19,6 @@ import MeetingRecordFormFields, {
 } from "@/components/staff/archive/meeting-records/MeetingRecordFormFields";
 import { FileUploadProgressNotice } from "@/components/common/FileUploadProgress";
 import {
-  embedMeetingRecordAttachments,
   extractMeetingRecordAttachments,
   type MeetingRecordAttachment,
 } from "@/components/staff/archive/meeting-records/meetingRecordAttachments";
@@ -30,7 +30,6 @@ import {
   ToolbarRight,
 } from "@/components/staff/archive/meeting-records/MeetingRecordDocument.styles";
 import { useAuthSession } from "@/hooks/useAuthSession";
-import { uploadMeetingRecordDocumentWithMetadata } from "@/lib/googleDrive";
 import { queryKeys } from "@/lib/queryKeys";
 
 type MeetingRecordFormPageProps = {
@@ -57,8 +56,20 @@ function createInitialValues(record?: MeetingRecordDetailResponseDto): MeetingRe
 }
 
 function createInitialAttachments(record?: MeetingRecordDetailResponseDto): MeetingRecordAttachment[] {
-  const parsedAgenda = extractMeetingRecordAttachments(record?.agenda);
-  return record?.attachments?.length ? (record.attachments as MeetingRecordAttachment[]) : parsedAgenda.attachments;
+  if (record?.attachments?.length) {
+    return record.attachments
+      .filter(
+        (att): att is typeof att & { fileId: string; originalName: string } =>
+          typeof att.fileId === "string" && typeof att.originalName === "string",
+      )
+      .map((att) => ({
+        fileId: att.fileId,
+        originalName: att.originalName,
+        downloadUrl: att.downloadUrl ?? "",
+        viewUrl: att.viewUrl,
+      }));
+  }
+  return extractMeetingRecordAttachments(record?.agenda).attachments;
 }
 
 function addRecordToFirstPageCache(
@@ -106,6 +117,7 @@ export default function MeetingRecordFormPage({
   const [attachments, setAttachments] = useState(() => createInitialAttachments(initialRecord));
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const shouldShowUploadToastRef = useRef(false);
+  const uploadErrorsRef = useRef(0);
   const isBeforeMeetingDisabled = mode === "edit" && initialRecord?.status === "AFTER_MEETING";
   const authorName =
     authStatus === "authenticated"
@@ -116,81 +128,80 @@ export default function MeetingRecordFormPage({
 
   const saveMutation = useMutation({
     mutationFn: async () => {
-      const hasFileUpload = selectedFiles.length > 0;
-      shouldShowUploadToastRef.current = hasFileUpload;
-      const uploadedAttachments =
-        hasFileUpload
-          ? await Promise.all(selectedFiles.map((file) => uploadMeetingRecordDocumentWithMetadata(file)))
-          : [];
-      const nextAttachments = [
-        ...attachments,
-        ...uploadedAttachments.map((file) => ({
-          fileId: file.fileId,
-          originalName: file.originalName,
-          downloadUrl: file.downloadUrl,
-          viewUrl: file.viewUrl,
-        })),
-      ];
-      const agendaWithAttachments = embedMeetingRecordAttachments(values.agenda.trim(), nextAttachments);
+      // Phase 1: 레코드 저장 (agenda에 첨부파일 임베딩 없음)
+      let savedRecord: MeetingRecordDetailResponseDto;
 
       if (mode === "edit" && initialRecord?.id) {
-        return updateMeetingRecord(
+        savedRecord = await updateMeetingRecord(
           { recordId: initialRecord.id },
           {
             title: values.title.trim(),
-            agenda: agendaWithAttachments,
+            agenda: values.agenda.trim(),
             discussion: values.discussion.trim(),
             suggestion: values.suggestion.trim(),
             status: values.status,
           },
         );
+      } else {
+        const created = await createMeetingRecord({
+          title: values.title.trim(),
+          agenda: values.agenda.trim(),
+        });
+
+        if (values.status === "AFTER_MEETING" && created.id) {
+          savedRecord = await updateMeetingRecord(
+            { recordId: created.id },
+            {
+              discussion: values.discussion.trim(),
+              suggestion: values.suggestion.trim(),
+              status: "AFTER_MEETING",
+            },
+          );
+        } else {
+          savedRecord = created;
+        }
       }
 
-      const created = await createMeetingRecord({
-        title: values.title.trim(),
-        agenda: agendaWithAttachments,
-      });
-
-      if (values.status === "AFTER_MEETING" && created.id) {
-        return updateMeetingRecord(
-          { recordId: created.id },
-          {
-            discussion: values.discussion.trim(),
-            suggestion: values.suggestion.trim(),
-            status: "AFTER_MEETING",
-          },
+      // Phase 2: 새 파일 업로드 (레코드 저장 후 recordId 확보된 상태)
+      if (selectedFiles.length > 0 && savedRecord.id) {
+        shouldShowUploadToastRef.current = true;
+        const recordId = savedRecord.id;
+        const results = await Promise.allSettled(
+          selectedFiles.map((file) => attachMeetingRecordFile({ recordId }, file, file.name)),
         );
+        uploadErrorsRef.current = results.filter((r) => r.status === "rejected").length;
       }
 
-      return created;
+      return savedRecord;
     },
     onSuccess: async (savedRecord) => {
+      const failedCount = uploadErrorsRef.current;
+      uploadErrorsRef.current = 0;
+
       if (shouldShowUploadToastRef.current) {
-        toast.success("파일 업로드가 완료되었습니다.");
+        if (failedCount > 0) {
+          toast.error(`파일 ${failedCount}개 업로드에 실패했습니다. 레코드는 저장되었습니다.`);
+        } else {
+          toast.success("파일 업로드가 완료되었습니다.");
+        }
       }
+      shouldShowUploadToastRef.current = false;
 
       const savedRecordId = savedRecord.id ?? initialRecord?.id;
-      const parsedAgenda = extractMeetingRecordAttachments(savedRecord.agenda);
-      const normalizedRecord = {
-        ...savedRecord,
-        agenda: parsedAgenda.content,
-        attachments: parsedAgenda.attachments,
-      };
 
-      setAttachments(parsedAgenda.attachments);
       setSelectedFiles([]);
 
       if (mode === "create") {
         queryClient.setQueriesData<MeetingRecordListResponseDto>(
           { queryKey: ["meeting-records", "list"] },
-          (current) => addRecordToFirstPageCache(current, normalizedRecord),
+          (current) => addRecordToFirstPageCache(current, savedRecord),
         );
       }
 
       if (mode === "edit" && savedRecordId) {
         queryClient.setQueryData<MeetingRecordDetailResponseDto>(
           queryKeys.meetingRecords.detail(savedRecordId),
-          (current) => ({ ...current, ...normalizedRecord }),
+          (current) => ({ ...current, ...savedRecord }),
         );
         await queryClient.invalidateQueries({ queryKey: ["meeting-records"] });
         onSaved?.(savedRecordId);
@@ -214,6 +225,7 @@ export default function MeetingRecordFormPage({
     },
     onError: () => {
       shouldShowUploadToastRef.current = false;
+      uploadErrorsRef.current = 0;
     },
   });
 
@@ -224,7 +236,9 @@ export default function MeetingRecordFormPage({
     !saveMutation.isPending;
 
   async function handleRemoveExistingAttachment(fileId: string) {
-    await deleteAttachment({ fileId });
+    const recordId = initialRecord?.id;
+    if (!recordId) return;
+    await deleteMeetingRecordAttachment({ recordId, fileId });
     setAttachments((current) => current.filter((file) => file.fileId !== fileId));
   }
 

--- a/components/staff/archive/meeting-records/meetingRecordAttachments.ts
+++ b/components/staff/archive/meeting-records/meetingRecordAttachments.ts
@@ -46,16 +46,3 @@ export function extractMeetingRecordAttachments(html?: string) {
   return { content, attachments };
 }
 
-export function embedMeetingRecordAttachments(
-  html: string,
-  attachments: MeetingRecordAttachment[],
-) {
-  const content = html.replace(ATTACHMENTS_MARKER_REGEX, "").trim();
-
-  if (attachments.length === 0) {
-    return content;
-  }
-
-  const encoded = encodeURIComponent(JSON.stringify(attachments));
-  return `${content}<div data-meeting-attachments="${encoded}" style="display:none"></div>`;
-}

--- a/mocks/handlers/meetingRecord.handlers.ts
+++ b/mocks/handlers/meetingRecord.handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http, type RequestHandler } from "msw";
 import type {
   MeetingAbsenceReportResponseDto,
+  MeetingRecordAttachmentDto,
   MeetingRecordDetailResponseDto,
 } from "@/api/meetingRecord/meetingRecord.dto";
 
@@ -8,10 +9,12 @@ import { API_BASE_URL, REFRESHED_ACCESS_TOKEN, VALID_ACCESS_TOKEN } from "./auth
 
 let nextMeetingRecordId = 3;
 let nextAbsenceReportId = 10;
+let nextAttachmentIndex = 1;
 
 type MockMeetingRecord = MeetingRecordDetailResponseDto & {
   id: number;
   absenceReports: MeetingAbsenceReportResponseDto[];
+  attachments: MeetingRecordAttachmentDto[];
 };
 
 const MEETING_RECORDS: MockMeetingRecord[] = [
@@ -27,6 +30,7 @@ const MEETING_RECORDS: MockMeetingRecord[] = [
     discussion: "",
     suggestion: "",
     absenceReports: [],
+    attachments: [],
   },
   {
     id: 2,
@@ -40,6 +44,7 @@ const MEETING_RECORDS: MockMeetingRecord[] = [
     discussion: "행사 일정을 논의했습니다.",
     suggestion: "부서별 준비 항목을 확정했습니다.",
     absenceReports: [{ id: 1, authorId: 1, author: "Teacher One", reason: "수업", opinion: "" }],
+    attachments: [],
   },
 ];
 
@@ -99,6 +104,7 @@ export const meetingRecordHandlers: RequestHandler[] = [
       discussion: "",
       suggestion: "",
       absenceReports: [],
+      attachments: [],
       viewCount: 0,
     };
 
@@ -150,6 +156,66 @@ export const meetingRecordHandlers: RequestHandler[] = [
 
     return new HttpResponse(null, { status: 204 });
   }),
+  http.post(
+    `${API_BASE_URL}/api/v1/meeting-records/:recordId/attachments`,
+    async ({ request, params }) => {
+      const unauthorizedResponse = unauthorizedWhenNeeded(request);
+      if (unauthorizedResponse) return unauthorizedResponse;
+
+      const record = MEETING_RECORDS.find((item) => item.id === Number(params.recordId));
+      if (!record) {
+        return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+      }
+
+      const contentType = request.headers.get("content-type") ?? "";
+      let attachment: MeetingRecordAttachmentDto;
+
+      if (contentType.includes("multipart/form-data")) {
+        const formData = await request.formData();
+        const file = formData.get("file");
+        const filename = file instanceof File ? file.name : `attachment-${nextAttachmentIndex}`;
+        attachment = {
+          fileId: `mock-file-${nextAttachmentIndex}`,
+          originalName: filename,
+          contentType: file instanceof File ? file.type : "application/octet-stream",
+          fileSize: file instanceof File ? file.size : 0,
+          isGoogleDrive: false,
+          downloadUrl: `https://example.com/files/mock-file-${nextAttachmentIndex}`,
+          sortOrder: record.attachments.length,
+        };
+      } else {
+        const body = (await request.json()) as { fileId?: string; sortOrder?: number };
+        attachment = {
+          fileId: body.fileId ?? `mock-file-${nextAttachmentIndex}`,
+          originalName: `file-${nextAttachmentIndex}.pdf`,
+          isGoogleDrive: true,
+          downloadUrl: `https://drive.google.com/mock/${nextAttachmentIndex}`,
+          sortOrder: body.sortOrder ?? record.attachments.length,
+        };
+      }
+
+      nextAttachmentIndex += 1;
+      record.attachments.push(attachment);
+
+      return HttpResponse.json(attachment);
+    },
+  ),
+  http.delete(
+    `${API_BASE_URL}/api/v1/meeting-records/:recordId/attachments/:fileId`,
+    ({ request, params }) => {
+      const unauthorizedResponse = unauthorizedWhenNeeded(request);
+      if (unauthorizedResponse) return unauthorizedResponse;
+
+      const record = MEETING_RECORDS.find((item) => item.id === Number(params.recordId));
+      if (!record) {
+        return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+      }
+
+      record.attachments = record.attachments.filter((att) => att.fileId !== params.fileId);
+
+      return new HttpResponse(null, { status: 204 });
+    },
+  ),
   http.post(
     `${API_BASE_URL}/api/v1/meeting-records/:recordId/absence-reports`,
     async ({ request, params }) => {


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

BE PR #162에서 추가된 교학 회의록 첨부파일 전용 API를 Frontend에 연동합니다.
기존에 `agenda` HTML에 첨부파일 메타데이터를 숨겨진 `<div>`로 임베딩하던 방식을
전용 엔드포인트를 통한 독립적인 첨부파일 관리 방식으로 전환합니다.

### 업로드 플로우 변경

**Before**

```mermaid
sequenceDiagram
  actor User
  participant Form as MeetingRecordFormPage
  participant Drive as Google Drive<br/>(Apps Script)
  participant Backend

  User->>Form: 파일 선택 + 저장 클릭
  Form->>Drive: 파일 업로드 (base64 인코딩)
  Drive-->>Form: driveUrl, fileName, mimeType
  Form->>Backend: POST /api/v1/files/drive<br/>(fileId 등록)
  Backend-->>Form: fileId
  Form->>Form: embedMeetingRecordAttachments()<br/>agenda HTML에 fileId 임베딩
  Form->>Backend: POST/PATCH /api/v1/meeting-records<br/>(agenda에 첨부파일 포함)
  Backend-->>Form: 저장 완료
```

**After**

```mermaid
sequenceDiagram
  actor User
  participant Form as MeetingRecordFormPage
  participant Backend

  User->>Form: 파일 선택 + 저장 클릭

  Note over Form,Backend: Phase 1 — 레코드 저장 (agenda plain text)
  Form->>Backend: POST/PATCH /api/v1/meeting-records<br/>(agenda, 임베딩 없음)
  Backend-->>Form: savedRecord (with recordId)

  Note over Form,Backend: Phase 2 — 첨부파일 업로드 (Promise.allSettled)
  loop 선택된 파일 각각
    Form->>Backend: POST /api/v1/meeting-records/{recordId}/attachments<br/>(multipart/form-data)
    Backend-->>Form: MeetingRecordAttachmentDto
  end

  Form->>User: 저장 완료 토스트<br/>(부분 실패 시 실패 개수 안내)
```

### 첨부파일 삭제 흐름

```mermaid
sequenceDiagram
  actor User
  participant Form as MeetingRecordFormPage
  participant Backend

  User->>Form: 기존 첨부파일 X 클릭
  Form->>Backend: DELETE /api/v1/meeting-records/{recordId}/attachments/{fileId}
  Backend-->>Form: 204 No Content
  Form->>Form: setAttachments() 로컬 상태 업데이트
```

### 구 레코드 backward compat

```mermaid
flowchart TD
  A[GET /api/v1/meeting-records/recordId] --> B{response.attachments<br/>길이 > 0?}
  B -- Yes --> C[response.attachments 사용<br/>새 API 응답]
  B -- No --> D[extractMeetingRecordAttachments<br/>agenda HTML 파싱]
  D --> E[구 레코드 임베딩 데이터 표시]
```

### 변경 파일 요약

1. **`api/meetingRecord/meetingRecord.dto.ts`**
   - `MeetingRecordAttachmentDto`: `contentType`, `fileSize`, `ext`, `isGoogleDrive`, `sortOrder` 추가
   - `MeetingRecordAttachmentPathParamsDto`, `LinkMeetingRecordAttachmentRequestDto` 신규 추가

2. **`api/meetingRecord/meetingRecord.api.ts`**
   - `attachMeetingRecordFile()`: multipart POST
   - `linkMeetingRecordAttachment()`: JSON POST (기존 fileId 연결용)
   - `deleteMeetingRecordAttachment()`: DELETE

3. **`components/staff/archive/meeting-records/MeetingRecordFormPage.tsx`**
   - Google Drive 업로드(`uploadMeetingRecordDocumentWithMetadata`) 제거
   - `mutationFn`을 2-phase (레코드 저장 → 파일 업로드)로 재작성
   - `handleRemoveExistingAttachment`를 `deleteMeetingRecordAttachment`로 교체
   - `Promise.allSettled`로 부분 업로드 실패 처리

4. **`components/staff/archive/meeting-records/meetingRecordAttachments.ts`**
   - `embedMeetingRecordAttachments` 삭제
   - `extractMeetingRecordAttachments` 유지 (구 레코드 fallback)

5. **`mocks/handlers/meetingRecord.handlers.ts`**
   - `MockMeetingRecord`에 `attachments` 필드 추가
   - 첨부파일 POST / DELETE 핸들러 추가

6. **`api/meetingRecord/meetingRecord.api.test.ts`**
   - `attachMeetingRecordFile`, `deleteMeetingRecordAttachment` 테스트 추가

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #164 

## 💬 기타 사항

- `MeetingRecordDetailPage.tsx`는 이미 `response.attachments` fallback 로직이 구현되어 있어 변경 없음
- `lib/googleDrive/`의 함수는 다른 기능(board, events 등)에서 사용 중이므로 삭제하지 않음
- BE PR #162의 `403 MR-003`(권한 없음) 에러는 `authClient` 인터셉터의 기존 401→refresh 흐름과 별개로 처리됨 (UI 레벨 에러 토스트)

## 📂 참고 자료

> Handoff: `Handoff/backend-to-frontend/2026-06-28/001-meeting-record-attachments.md`
> 관련 BE PR: Geumjeongyahak/Backend#162