### PR TITLE
[FIX] Google OAuth token 리프레시 토큰 초기화 문제 해결

### DIFF
--- a/api/channel/channel.api.test.ts
+++ b/api/channel/channel.api.test.ts
@@ -11,7 +11,7 @@ import { setAccessToken } from "../client/tokenStorage";
 import { createChannel, getChannel, getChannels, updateChannel } from "./channel.api";
 
 describe("channel.api", () => {
-  it("returns channels with authorization header and query params", async () => {
+  it("returns channels without authorization header and with query params", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     let observedAuthorizationHeader: string | null = null;
@@ -28,7 +28,7 @@ describe("channel.api", () => {
     const response = await getChannels({ channelType: "NOTICE", isActive: true });
 
     expect(response).toEqual(CHANNEL_LIST_RESPONSE);
-    expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
+    expect(observedAuthorizationHeader).toBeNull();
     expect(observedQueryString).toContain("channelType=NOTICE");
     expect(observedQueryString).toContain("isActive=true");
   });

--- a/api/channel/channel.api.ts
+++ b/api/channel/channel.api.ts
@@ -1,4 +1,5 @@
 import authClient from "../client/authClient";
+import publicClient from "../client/publicClient";
 import type {
   ChannelListQueryParamsDto,
   ChannelResponseDto,
@@ -9,7 +10,7 @@ import type {
 
 // 채널 목록을 조회하는 요청
 export async function getChannels(query?: ChannelListQueryParamsDto) {
-  const response = await authClient.get<ChannelResponseDto[]>("/api/v1/channels", {
+  const response = await publicClient.get<ChannelResponseDto[]>("/api/v1/channels", {
     params: query,
   });
   return response.data;

--- a/api/client/authClient.test.ts
+++ b/api/client/authClient.test.ts
@@ -143,6 +143,36 @@ describe("authClient", () => {
     expect(getRefreshToken()).toBeNull();
   });
 
+  it("keeps newer tokens when an older refresh request fails", async () => {
+    let releaseRefresh: () => void = () => undefined;
+    const refreshStarted = new Promise<void>((resolve) => {
+      server.use(
+        http.get(`${API_BASE_URL}/api/v1/protected/profile`, () => {
+          return HttpResponse.json({ message: "Access token expired" }, { status: 401 });
+        }),
+        http.post(`${API_BASE_URL}/api/v1/auth/refresh`, async () => {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseRefresh = release;
+          });
+          return HttpResponse.json({ message: "Refresh expired" }, { status: 401 });
+        }),
+      );
+    });
+
+    setTokens(EXPIRED_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
+
+    const request = authClient.get("/api/v1/protected/profile");
+    await refreshStarted;
+
+    setTokens(REFRESHED_ACCESS_TOKEN, REFRESHED_REFRESH_TOKEN);
+    releaseRefresh();
+
+    await expect(request).rejects.toMatchObject({ response: { status: 401 } });
+    expect(getAccessToken()).toBe(REFRESHED_ACCESS_TOKEN);
+    expect(getRefreshToken()).toBe(REFRESHED_REFRESH_TOKEN);
+  });
+
   it("stops after a single retry to prevent infinite refresh loops", async () => {
     let protectedRequestCount = 0;
     let refreshRequestCount = 0;

--- a/api/client/authClient.ts
+++ b/api/client/authClient.ts
@@ -45,7 +45,9 @@ async function refreshAccessToken() {
         setTokens(tokens.accessToken, tokens.refreshToken);
         return tokens;
       } catch (error) {
-        clearTokens();
+        if (getRefreshToken() === refreshToken) {
+          clearTokens();
+        }
         throw error;
       } finally {
         refreshPromise = null;
@@ -96,7 +98,6 @@ authClient.interceptors.response.use(
 
       return authClient(originalRequest);
     } catch (refreshError) {
-      clearTokens();
       return Promise.reject(refreshError);
     }
   },


### PR DESCRIPTION
## 📝 PR 유형

아래에서 해당하는 항목의 [ ] 안에 x를 표시해 주세요.

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. refresh 요청 실패 시 현재 저장된 refresh token이 요청 시작 시점의 token과 같을 때만 토큰을 삭제하도록 수정했습니다.

2. 공개 채널 목록 조회가 인증 갱신 흐름을 타지 않도록 `publicClient`를 사용하게 변경했습니다.

3. 이전 refresh 요청 실패가 새로 저장된 OAuth 토큰을 지우지 않는 회귀 테스트와 공개 채널 목록 조회의 Authorization 헤더 미전송 테스트를 반영했습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #167

## 💬 기타 사항

- `npm test -- --run api/client/authClient.test.ts api/channel/channel.api.test.ts` 통과
- `npm exec eslint api/client/authClient.ts api/client/authClient.test.ts api/channel/channel.api.ts api/channel/channel.api.test.ts` 통과
- `npm run lint`는 이번 변경 범위 밖 기존 오류로 실패합니다. 예: `components/admin/lesson-management/AdminLessonDetailPanel.tsx:47`의 `react-hooks/set-state-in-effect`, `pwa/components/MobileLoginPage.tsx:63`의 `react/no-unescaped-entities`

## 📂 참고 자료

> N/A