### PR TITLE
[BUG] 반에 등록된 학생이 없을 때 출석부가 수정되지 않는 버그 수정

### DIFF
--- a/pwa/components/MobileStudentAttendanceList.tsx
+++ b/pwa/components/MobileStudentAttendanceList.tsx
@@ -36,7 +36,23 @@ export default function MobileStudentAttendanceList({
   onAdd,
 }: MobileStudentAttendanceListProps) {
   if (!entries.length) {
-    return <EmptyState>출석을 기록할 학생이 없습니다.</EmptyState>;
+    return (
+      <>
+        <EmptyState>출석을 기록할 학생이 없습니다.</EmptyState>
+        {isEditing ? (
+          <AddRow>
+            <AddButton
+              type="button"
+              disabled={disabled}
+              aria-label="학생 항목 추가"
+              onClick={onAdd}
+            >
+              <IconPlus size={16} stroke={2.4} aria-hidden="true" />
+            </AddButton>
+          </AddRow>
+        ) : null}
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

수업 일지 작성 시, 반에 등록된 학생이 없을 때 출석부가 수정되지 않는 버그를 수정하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #172 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
