### PR TITLE
[FEAT] 링크 기반 인증 및 비밀번호 변경 플로우 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# local design review artifacts
+.superpowers/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/api/auth/auth.api.test.ts
+++ b/api/auth/auth.api.test.ts
@@ -22,12 +22,14 @@ import { getAccessToken, getRefreshToken, setTokens } from "../client/tokenStora
 import {
   adminLogin,
   connectLocalAccount,
+  confirmPasswordReset,
   googleLogin,
   googleSignup,
   login,
   logout,
   logoutAllDevices,
   refreshToken,
+  requestPasswordReset,
   signup,
 } from "./auth.api";
 
@@ -123,6 +125,46 @@ describe("auth.api", () => {
 
     await expect(signup(DEFAULT_SIGNUP_REQUEST)).rejects.toMatchObject({
       response: { status: 409 },
+    });
+  });
+
+  it("requests a password reset mail with the expected body", async () => {
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth/password-reset/request`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ message: "비밀번호 재설정 안내 메일이 발송되었습니다." });
+      }),
+    );
+
+    const response = await requestPasswordReset({ email: "reset@example.com" });
+
+    expect(response).toEqual({ message: "비밀번호 재설정 안내 메일이 발송되었습니다." });
+    expect(observedBody).toEqual({ email: "reset@example.com" });
+  });
+
+  it("confirms password reset with email, reset code, and new password", async () => {
+    let observedBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth/password-reset/confirm`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ message: "비밀번호가 재설정되었습니다." });
+      }),
+    );
+
+    const response = await confirmPasswordReset({
+      email: "reset@example.com",
+      resetCode: "123456",
+      newPassword: "new-password123!",
+    });
+
+    expect(response).toEqual({ message: "비밀번호가 재설정되었습니다." });
+    expect(observedBody).toEqual({
+      email: "reset@example.com",
+      resetCode: "123456",
+      newPassword: "new-password123!",
     });
   });
 

--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -10,6 +10,8 @@ import type {
   GoogleSignupRequestDto,
   LoginRequestDto,
   LogoutRequestDto,
+  PasswordResetConfirmRequestDto,
+  PasswordResetRequestDto,
   RefreshTokenRequestDto,
   SignupRequestDto,
   TokenResponseDto,
@@ -34,6 +36,22 @@ export async function confirmEmailVerification(body: EmailVerificationConfirmReq
 export async function resendEmailVerification(body: EmailVerificationResendRequestDto) {
   const response = await publicClient.post<AuthMessageResponseDto>(
     "/api/v1/auth/email-verification/resend",
+    body,
+  );
+  return response.data;
+}
+
+export async function requestPasswordReset(body: PasswordResetRequestDto) {
+  const response = await publicClient.post<AuthMessageResponseDto>(
+    "/api/v1/auth/password-reset/request",
+    body,
+  );
+  return response.data;
+}
+
+export async function confirmPasswordReset(body: PasswordResetConfirmRequestDto) {
+  const response = await publicClient.post<AuthMessageResponseDto>(
+    "/api/v1/auth/password-reset/confirm",
     body,
   );
   return response.data;

--- a/api/auth/auth.dto.ts
+++ b/api/auth/auth.dto.ts
@@ -62,4 +62,14 @@ export interface EmailVerificationResendRequestDto {
   email: string;
 }
 
+export interface PasswordResetRequestDto {
+  email: string;
+}
+
+export interface PasswordResetConfirmRequestDto {
+  email: string;
+  resetCode: string;
+  newPassword: string;
+}
+
 export type AdminLoginRequestDto = LoginRequestDto;

--- a/app/(public)/auth/password-reset/page.tsx
+++ b/app/(public)/auth/password-reset/page.tsx
@@ -1,0 +1,11 @@
+import PasswordResetRequestForm from "@/components/auth/PasswordResetRequestForm";
+
+type PageProps = {
+  searchParams?: Promise<{ email?: string }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const { email = "" } = (await searchParams) ?? {};
+
+  return <PasswordResetRequestForm initialEmail={decodeURIComponent(email)} />;
+}

--- a/app/(public)/auth/reset-password/page.tsx
+++ b/app/(public)/auth/reset-password/page.tsx
@@ -1,4 +1,4 @@
-import EmailVerificationForm from "@/components/auth/EmailVerificationForm";
+import PasswordResetForm from "@/components/auth/PasswordResetForm";
 
 type PageProps = {
   searchParams?: Promise<{ email?: string; code?: string }>;
@@ -8,9 +8,9 @@ export default async function Page({ searchParams }: PageProps) {
   const { email = "", code = "" } = (await searchParams) ?? {};
 
   return (
-    <EmailVerificationForm
+    <PasswordResetForm
       email={decodeURIComponent(email)}
-      verificationCode={decodeURIComponent(code)}
+      resetCode={decodeURIComponent(code)}
     />
   );
 }

--- a/components/auth/AuthActionCard.tsx
+++ b/components/auth/AuthActionCard.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import type { ReactNode } from "react";
+import styled, { keyframes } from "styled-components";
+import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+
+export type ActionTone = "default" | "success" | "error";
+
+type AuthActionCardProps = {
+  icon: ReactNode;
+  eyebrow?: string;
+  title: string;
+  description: ReactNode;
+  status?: ReactNode;
+  statusTone?: ActionTone;
+  showProgress?: boolean;
+  children?: ReactNode;
+  footer?: ReactNode;
+};
+
+export default function AuthActionCard({
+  icon,
+  eyebrow = "금정열린배움터",
+  title,
+  description,
+  status,
+  statusTone = "default",
+  showProgress = false,
+  children,
+  footer,
+}: AuthActionCardProps) {
+  return (
+    <Main>
+      <Card>
+        <IconFrame $tone={statusTone}>{icon}</IconFrame>
+        <Eyebrow>{eyebrow}</Eyebrow>
+        <Title>{title}</Title>
+        <Description>{description}</Description>
+
+        {showProgress ? (
+          <ProgressTrack aria-hidden="true">
+            <ProgressBar />
+          </ProgressTrack>
+        ) : null}
+
+        {status ? <StatusMessage $tone={statusTone}>{status}</StatusMessage> : null}
+        {children}
+        {footer ? <Footer>{footer}</Footer> : null}
+      </Card>
+    </Main>
+  );
+}
+
+export const ActionForm = styled.form`
+  display: grid;
+  gap: ${spacing.space16};
+  margin-top: ${spacing.space20};
+`;
+
+export const ActionButton = styled.button`
+  width: 100%;
+  min-height: 2.875rem;
+  border: 0;
+  border-radius: 0.625rem;
+  background-color: #4f9d34;
+  color: ${colors.white};
+  font-family: inherit;
+  font-size: ${typography.fontSize14};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+  transition: filter 0.18s ease, transform 0.18s ease;
+
+  &:not(:disabled):hover {
+    filter: brightness(0.97);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid ${colors.pointSoft};
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.56;
+    transform: none;
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 3.75rem;
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+export const InlineActionButton = styled.button`
+  border: 0;
+  background: none;
+  color: #4f9d34;
+  font-family: inherit;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+
+  &:focus-visible {
+    border-radius: 0.25rem;
+    outline: 2px solid ${colors.pointSoft};
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    color: ${colors.muted};
+    cursor: not-allowed;
+    text-decoration: none;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+export const AccountPill = styled.div`
+  width: 100%;
+  min-height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 ${spacing.space12};
+  border: 1px solid #dfe8dc;
+  border-radius: 999px;
+  background: #f8fbf6;
+  color: #52604c;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  word-break: break-all;
+
+  @media (min-width: 120rem) {
+    min-height: 3.25rem;
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const Main = styled.main`
+  min-height: calc(100vh - ${layout.headerHeight});
+  display: grid;
+  place-items: center;
+  padding: ${spacing.space32} ${spacing.space20};
+  background:
+    linear-gradient(180deg, #f4f8f1 0%, ${colors.background} 46%),
+    ${colors.background};
+`;
+
+const Card = styled.section`
+  width: min(100%, 27rem);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding: ${spacing.space32} ${spacing.space24};
+  border: 1px solid #e6ece5;
+  border-radius: ${radii.radius12};
+  background: ${colors.white};
+  box-shadow: 0 1.5rem 3.75rem rgba(34, 34, 34, 0.08);
+
+  > * {
+    width: 100%;
+  }
+
+  @media (min-width: 120rem) {
+    width: 39rem;
+    padding: ${spacing.space46} ${spacing.space40};
+  }
+`;
+
+const IconFrame = styled.div<{ $tone: ActionTone }>`
+  width: 3.75rem;
+  height: 3.75rem;
+  display: grid;
+  place-items: center;
+  margin-bottom: ${spacing.space20};
+  border-radius: ${radii.radius12};
+  background: ${({ $tone }) => ($tone === "error" ? colors.noticeSoft : colors.pointSoft)};
+  color: ${({ $tone }) => ($tone === "error" ? colors.notice : "#4f9d34")};
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+    stroke-width: 1.9;
+  }
+
+  @media (min-width: 120rem) {
+    width: 5rem;
+    height: 5rem;
+    border-radius: ${radii.radius20};
+
+    svg {
+      width: 2.625rem;
+      height: 2.625rem;
+    }
+  }
+`;
+
+const Eyebrow = styled.p`
+  margin: 0 0 ${spacing.space8};
+  color: #4f9d34;
+  font-size: ${typography.fontSize13};
+  font-weight: 800;
+  line-height: ${typography.lineHeight130};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  color: #151a18;
+  font-size: 1.625rem;
+  font-weight: 800;
+  line-height: 1.22;
+  letter-spacing: 0;
+  word-break: keep-all;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize32};
+  }
+`;
+
+const Description = styled.p`
+  margin: ${spacing.space12} 0 0;
+  color: #52604c;
+  font-size: ${typography.fontSize14};
+  line-height: 1.65;
+  word-break: keep-all;
+
+  strong {
+    color: #151a18;
+    font-weight: 800;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const loading = keyframes`
+  0% {
+    transform: translateX(-70%);
+  }
+  100% {
+    transform: translateX(170%);
+  }
+`;
+
+const ProgressTrack = styled.div`
+  height: 0.625rem;
+  margin-top: ${spacing.space24};
+  overflow: hidden;
+  border-radius: 999px;
+  background: ${colors.pointSoft};
+`;
+
+const ProgressBar = styled.div`
+  width: 44%;
+  height: 100%;
+  border-radius: inherit;
+  background: #89ca6b;
+  animation: ${loading} 1.2s ease-in-out infinite;
+`;
+
+const StatusMessage = styled.p<{ $tone: ActionTone }>`
+  min-height: 1.25rem;
+  margin: ${spacing.space16} 0 0;
+  color: ${({ $tone }) =>
+    $tone === "error" ? colors.notice : $tone === "success" ? "#4f9d34" : "#52604c"};
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+  word-break: keep-all;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;
+
+const Footer = styled.div`
+  margin-top: ${spacing.space24};
+  padding-top: ${spacing.space20};
+  border-top: 1px solid #e6ece5;
+  color: #7a857f;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight150};
+  text-align: center;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;

--- a/components/auth/EmailVerificationForm.tsx
+++ b/components/auth/EmailVerificationForm.tsx
@@ -1,35 +1,39 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import styled from "styled-components";
+import { IconAlertTriangle, IconCircleCheck, IconMailCheck } from "@tabler/icons-react";
 import { confirmEmailVerification, resendEmailVerification } from "@/api/auth/auth.api";
-import {
-  Field,
-  FieldGroup,
-  Form,
-  Input,
-  Label,
-  Status,
-  SubmitButton,
-} from "@/components/auth/AuthFormParts";
-import AuthShell from "@/components/auth/AuthShell";
-import { colors, spacing, typography } from "@/styles/tokens";
+import AuthActionCard, {
+  ActionButton,
+  ActionForm,
+  InlineActionButton,
+  type ActionTone,
+} from "@/components/auth/AuthActionCard";
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
 type EmailVerificationFormProps = {
   email: string;
+  verificationCode: string;
 };
 
-export default function EmailVerificationForm({ email }: EmailVerificationFormProps) {
+export default function EmailVerificationForm({
+  email,
+  verificationCode,
+}: EmailVerificationFormProps) {
   const router = useRouter();
-  const [code, setCode] = useState("");
-  const [statusMessage, setStatusMessage] = useState("");
-  const [statusTone, setStatusTone] = useState<"default" | "error">("default");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasVerificationLink = Boolean(email && verificationCode);
+  const [statusMessage, setStatusMessage] = useState(
+    hasVerificationLink
+      ? "이메일 인증을 확인하고 있습니다."
+      : "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.",
+  );
+  const [statusTone, setStatusTone] = useState<ActionTone>("default");
+  const [isSubmitting, setIsSubmitting] = useState(hasVerificationLink);
   const [cooldown, setCooldown] = useState(0);
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const autoSubmittedRef = useRef(false);
 
   const startCooldown = useCallback(() => {
     setCooldown(RESEND_COOLDOWN_SECONDS);
@@ -50,34 +54,33 @@ export default function EmailVerificationForm({ email }: EmailVerificationFormPr
     };
   }, []);
 
-  const canSubmit = code.length === 6 && !isSubmitting;
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!canSubmit) return;
-
-    setIsSubmitting(true);
-    setStatusMessage("");
-
-    try {
-      await confirmEmailVerification({ email, verificationCode: code });
-      setStatusTone("default");
-      setStatusMessage("이메일 인증이 완료되었습니다. 로그인해 주세요.");
-      router.replace("/login");
-    } catch {
-      setStatusTone("error");
-      setStatusMessage("인증 코드가 올바르지 않습니다. 다시 확인해 주세요.");
-    } finally {
-      setIsSubmitting(false);
+  useEffect(() => {
+    if (!email || !verificationCode || autoSubmittedRef.current) {
+      return;
     }
-  }
+
+    autoSubmittedRef.current = true;
+    confirmEmailVerification({ email, verificationCode })
+      .then(() => {
+        setStatusTone("success");
+        setStatusMessage("이메일 인증이 완료되었습니다. 로그인 화면으로 이동합니다.");
+        setTimeout(() => router.replace("/login"), 900);
+      })
+      .catch(() => {
+        setStatusTone("error");
+        setStatusMessage("인증 링크가 만료되었거나 올바르지 않습니다. 인증 메일을 다시 받아 주세요.");
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  }, [email, router, verificationCode]);
 
   async function handleResend() {
-    if (cooldown > 0) return;
+    if (!email || cooldown > 0) return;
 
     try {
       await resendEmailVerification({ email });
-      setStatusTone("default");
+      setStatusTone("success");
       setStatusMessage("인증 메일을 다시 발송했습니다.");
       startCooldown();
     } catch {
@@ -86,103 +89,54 @@ export default function EmailVerificationForm({ email }: EmailVerificationFormPr
     }
   }
 
+  const isError = statusTone === "error";
+  const isComplete = statusTone === "success" && hasVerificationLink && !isSubmitting;
+  const icon = isError ? (
+    <IconAlertTriangle aria-hidden="true" />
+  ) : isComplete ? (
+    <IconCircleCheck aria-hidden="true" />
+  ) : (
+    <IconMailCheck aria-hidden="true" />
+  );
+  const title = isError
+    ? "인증 링크를 다시 받아 주세요"
+    : isSubmitting
+      ? "이메일 인증을 확인하고 있어요"
+      : hasVerificationLink
+        ? "이메일 인증이 완료되었습니다"
+        : "메일함을 확인해 주세요";
+  const description = email ? (
+    <>
+      <strong>{email}</strong>으로 발송된 인증 링크로 회원가입을 완료합니다.
+    </>
+  ) : (
+    "인증할 이메일 정보가 없습니다. 회원가입 후 받은 메일의 버튼을 다시 열어 주세요."
+  );
+
   return (
-    <AuthShell switchText="다른 계정으로 가입하시겠어요?" switchLabel="회원가입" switchHref="/register">
-      <Form onSubmit={handleSubmit} aria-label="이메일 인증 폼">
-        <Description>
-          <strong>{email}</strong>으로 발송된 6자리 인증번호를 입력해 주세요.
-        </Description>
-
-        <FieldGroup>
-          <Field>
-            <Label htmlFor="email-verification-code">인증번호</Label>
-            <Input
-              id="email-verification-code"
-              name="verificationCode"
-              type="text"
-              inputMode="numeric"
-              autoComplete="one-time-code"
-              placeholder="6자리 숫자 입력"
-              maxLength={6}
-              value={code}
-              onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
-              required
-            />
-          </Field>
-        </FieldGroup>
-
-        <Status
-          role="status"
-          aria-live="polite"
-          $tone={statusTone}
-          $visible={Boolean(statusMessage)}
-        >
-          {statusMessage || " "}
-        </Status>
-
-        <SubmitButton type="submit" disabled={!canSubmit}>
-          {isSubmitting ? "확인 중" : "인증 완료"}
-        </SubmitButton>
-
-        <ResendRow>
-          <ResendText>메일을 받지 못하셨나요?</ResendText>
-          <ResendButton type="button" onClick={handleResend} disabled={cooldown > 0}>
-            {cooldown > 0 ? `재발송 (${cooldown}초)` : "인증 메일 재발송"}
-          </ResendButton>
-        </ResendRow>
-      </Form>
-    </AuthShell>
+    <AuthActionCard
+      icon={icon}
+      title={title}
+      description={description}
+      status={statusMessage}
+      statusTone={statusTone}
+      showProgress={isSubmitting}
+      footer={
+        <>
+          메일을 받지 못하셨나요?{" "}
+          <InlineActionButton type="button" onClick={handleResend} disabled={!email || cooldown > 0}>
+            {cooldown > 0 ? `재발송 ${cooldown}초` : "인증 메일 재발송"}
+          </InlineActionButton>
+        </>
+      }
+    >
+      {hasVerificationLink ? (
+        <ActionForm as="div">
+          <ActionButton type="button" onClick={() => router.replace("/login")} disabled={isSubmitting}>
+            {isSubmitting ? "인증 확인 중" : "로그인으로 이동"}
+          </ActionButton>
+        </ActionForm>
+      ) : null}
+    </AuthActionCard>
   );
 }
-
-const Description = styled.p`
-  margin: 0;
-  color: ${colors.text};
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight150};
-  word-break: keep-all;
-
-  strong {
-    color: ${colors.point};
-    font-weight: 700;
-  }
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize20};
-  }
-`;
-
-const ResendRow = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: ${spacing.space8};
-`;
-
-const ResendText = styled.span`
-  color: ${colors.muted};
-  font-size: ${typography.fontSize13};
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize16};
-  }
-`;
-
-const ResendButton = styled.button`
-  border: 0;
-  background: none;
-  color: ${colors.point};
-  font-family: inherit;
-  font-size: ${typography.fontSize13};
-  font-weight: 700;
-  cursor: pointer;
-
-  &:disabled {
-    color: ${colors.muted};
-    cursor: not-allowed;
-  }
-
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize16};
-  }
-`;

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import styled from "styled-components";
 import { login } from "@/api/auth/auth.api";
 import { setGoogleOAuthIntent } from "@/api/auth/googleOAuthState";
 import { baseURL } from "@/api/client/publicClient";
@@ -16,6 +18,7 @@ import {
 } from "@/components/auth/AuthFormParts";
 import GoogleLoginButton from "@/components/auth/GoogleLoginButton";
 import AuthShell from "@/components/auth/AuthShell";
+import { colors, spacing, typography } from "@/styles/tokens";
 
 type LoginFormState = {
   email: string;
@@ -34,6 +37,9 @@ export default function LoginForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
+  const passwordResetHref = form.email.trim()
+    ? `/auth/password-reset?email=${encodeURIComponent(form.email.trim())}`
+    : "/auth/password-reset";
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -101,6 +107,10 @@ export default function LoginForm() {
           </Field>
         </FieldGroup>
 
+        <PasswordHelpRow>
+          <PasswordHelpLink href={passwordResetHref}>비밀번호를 잊으셨나요?</PasswordHelpLink>
+        </PasswordHelpRow>
+
         <Status
           role="status"
           aria-live="polite"
@@ -119,3 +129,33 @@ export default function LoginForm() {
     </AuthShell>
   );
 }
+
+const PasswordHelpRow = styled.div`
+  margin-top: -${spacing.space8};
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const PasswordHelpLink = styled(Link)`
+  color: #5b6a55;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+  text-decoration: none;
+
+  &:hover {
+    color: ${colors.point};
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+
+  &:focus-visible {
+    border-radius: 0.25rem;
+    outline: 2px solid ${colors.pointSoft};
+    outline-offset: 2px;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize16};
+  }
+`;

--- a/components/auth/PasswordResetForm.tsx
+++ b/components/auth/PasswordResetForm.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IconAlertTriangle, IconLockCheck } from "@tabler/icons-react";
+import styled from "styled-components";
+import { confirmPasswordReset } from "@/api/auth/auth.api";
+import {
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+  Status,
+} from "@/components/auth/AuthFormParts";
+import AuthActionCard, {
+  AccountPill,
+  ActionButton,
+  ActionForm,
+  InlineActionButton,
+  type ActionTone,
+} from "@/components/auth/AuthActionCard";
+import { colors } from "@/styles/tokens";
+
+type PasswordResetFormProps = {
+  email: string;
+  resetCode: string;
+};
+
+type PasswordResetFormState = {
+  password: string;
+  confirmPassword: string;
+};
+
+const initialState: PasswordResetFormState = {
+  password: "",
+  confirmPassword: "",
+};
+
+export default function PasswordResetForm({ email, resetCode }: PasswordResetFormProps) {
+  const router = useRouter();
+  const [form, setForm] = useState(initialState);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [statusTone, setStatusTone] = useState<ActionTone>("default");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const passwordMatchState =
+    form.confirmPassword.length === 0
+      ? "idle"
+      : form.password === form.confirmPassword
+        ? "matched"
+        : "mismatched";
+  const isPasswordConfirmed =
+    form.confirmPassword.length > 0 && form.password === form.confirmPassword;
+  const hasValidLink = Boolean(email && resetCode);
+  const canSubmit = hasValidLink && form.password.length >= 8 && isPasswordConfirmed;
+  const visibleStatus =
+    statusMessage ||
+    (!hasValidLink
+      ? "메일의 비밀번호 변경 링크를 다시 확인해 주세요."
+      : form.confirmPassword.length > 0 && !isPasswordConfirmed
+        ? "비밀번호와 비밀번호 확인이 일치하지 않습니다."
+        : " ");
+  const effectiveTone = passwordMatchState === "mismatched" ? "error" : statusTone;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) {
+      if (form.confirmPassword.length > 0 && !isPasswordConfirmed) {
+        setStatusTone("error");
+        setStatusMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+      }
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatusTone("default");
+    setStatusMessage("");
+
+    try {
+      await confirmPasswordReset({
+        email,
+        resetCode,
+        newPassword: form.password,
+      });
+      setStatusTone("success");
+      setStatusMessage("비밀번호가 변경되었습니다. 로그인 화면으로 이동합니다.");
+      setTimeout(() => router.replace("/login"), 900);
+    } catch {
+      setStatusTone("error");
+      setStatusMessage("비밀번호 변경 링크가 만료되었거나 올바르지 않습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthActionCard
+      icon={
+        effectiveTone === "error" ? (
+          <IconAlertTriangle aria-hidden="true" />
+        ) : (
+          <IconLockCheck aria-hidden="true" />
+        )
+      }
+      eyebrow="비밀번호 변경"
+      title={hasValidLink ? "새 비밀번호를 설정해 주세요" : "변경 링크를 다시 확인해 주세요"}
+      description={
+        hasValidLink
+          ? "메일 링크에서 계정을 확인했습니다. 새 비밀번호만 입력하면 됩니다."
+          : "비밀번호 변경 링크가 올바르지 않습니다. 메일의 비밀번호 변경하기 버튼을 다시 열어 주세요."
+      }
+      status={visibleStatus}
+      statusTone={effectiveTone}
+      showProgress={isSubmitting}
+      footer={
+        <>
+          비밀번호가 기억나셨나요?{" "}
+          <InlineActionButton type="button" onClick={() => router.replace("/login")}>
+            로그인
+          </InlineActionButton>
+        </>
+      }
+    >
+      <ActionForm onSubmit={handleSubmit} aria-label="비밀번호 변경 폼">
+        {hasValidLink ? <AccountPill>{email}</AccountPill> : null}
+
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="reset-password">새 비밀번호</Label>
+            <PasswordInput
+              id="reset-password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              placeholder="8자 이상 입력"
+              value={form.password}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, password: event.target.value }))
+              }
+              required
+              minLength={8}
+              disabled={!hasValidLink || isSubmitting}
+              $matchState={passwordMatchState}
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="reset-confirm-password">새 비밀번호 확인</Label>
+            <PasswordInput
+              id="reset-confirm-password"
+              name="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              placeholder="비밀번호를 한 번 더 입력"
+              value={form.confirmPassword}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, confirmPassword: event.target.value }))
+              }
+              required
+              minLength={8}
+              disabled={!hasValidLink || isSubmitting}
+              $matchState={passwordMatchState}
+            />
+          </Field>
+        </FieldGroup>
+
+        <ResetStatus
+          role="status"
+          aria-live="polite"
+          $tone={effectiveTone === "error" ? "error" : "default"}
+          $matchState={passwordMatchState}
+          $visible={Boolean(statusMessage) || !hasValidLink || form.confirmPassword.length > 0}
+        >
+          {visibleStatus}
+        </ResetStatus>
+
+        <ActionButton type="submit" disabled={!canSubmit || isSubmitting}>
+          {isSubmitting ? "변경 중" : "비밀번호 변경"}
+        </ActionButton>
+      </ActionForm>
+    </AuthActionCard>
+  );
+}
+
+const PasswordInput = styled(Input)<{ $matchState: "idle" | "matched" | "mismatched" }>`
+  border-color: ${({ $matchState }) =>
+    $matchState === "matched"
+      ? colors.point
+      : $matchState === "mismatched"
+        ? "#e5a19b"
+        : colors.border};
+  background-color: ${({ $matchState }) =>
+    $matchState === "matched"
+      ? "#f4faef"
+      : $matchState === "mismatched"
+        ? "#fff6f5"
+        : colors.white};
+
+  &:focus {
+    border-color: ${({ $matchState }) =>
+      $matchState === "matched"
+        ? colors.point
+        : $matchState === "mismatched"
+          ? "#de8c85"
+          : colors.point};
+    outline: 2px solid
+      ${({ $matchState }) =>
+        $matchState === "matched"
+          ? colors.pointSoft
+          : $matchState === "mismatched"
+            ? "#f8d8d4"
+            : colors.pointSoft};
+  }
+`;
+
+const ResetStatus = styled(Status)<{
+  $matchState: "idle" | "matched" | "mismatched";
+}>`
+  margin: 0;
+  color: ${({ $tone, $matchState }) =>
+    $matchState === "mismatched"
+      ? "#d98882"
+      : $tone === "error"
+        ? colors.notice
+        : "#52604c"};
+`;

--- a/components/auth/PasswordResetRequestForm.tsx
+++ b/components/auth/PasswordResetRequestForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IconAlertTriangle, IconMailCheck } from "@tabler/icons-react";
+import { requestPasswordReset } from "@/api/auth/auth.api";
+import {
+  Field,
+  FieldGroup,
+  Input,
+  Label,
+} from "@/components/auth/AuthFormParts";
+import AuthActionCard, {
+  ActionButton,
+  ActionForm,
+  InlineActionButton,
+  type ActionTone,
+} from "@/components/auth/AuthActionCard";
+
+type PasswordResetRequestFormProps = {
+  initialEmail: string;
+};
+
+export default function PasswordResetRequestForm({
+  initialEmail,
+}: PasswordResetRequestFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState(initialEmail);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [statusTone, setStatusTone] = useState<ActionTone>("default");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const trimmedEmail = email.trim();
+  const canSubmit = trimmedEmail.length > 0 && !isSubmitting;
+  const isSuccess = statusTone === "success";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setIsSubmitting(true);
+    setStatusTone("default");
+    setStatusMessage("");
+
+    try {
+      await requestPasswordReset({ email: trimmedEmail });
+      setStatusTone("success");
+      setStatusMessage("비밀번호 변경 링크를 보냈습니다. 메일함에서 링크를 열어 주세요.");
+    } catch {
+      setStatusTone("error");
+      setStatusMessage("메일 발송에 실패했습니다. 이메일을 확인한 뒤 다시 시도해 주세요.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthActionCard
+      icon={
+        statusTone === "error" ? (
+          <IconAlertTriangle aria-hidden="true" />
+        ) : (
+          <IconMailCheck aria-hidden="true" />
+        )
+      }
+      eyebrow="비밀번호 변경"
+      title={isSuccess ? "메일을 보냈습니다" : "비밀번호 변경 링크 받기"}
+      description={
+        isSuccess
+          ? "메일의 비밀번호 변경하기 버튼을 누르면 새 비밀번호를 설정할 수 있습니다."
+          : "가입한 이메일 주소를 입력하면 비밀번호 변경 링크를 보내드립니다."
+      }
+      status={statusMessage}
+      statusTone={statusTone}
+      showProgress={isSubmitting}
+      footer={
+        <>
+          비밀번호가 기억나셨나요?{" "}
+          <InlineActionButton type="button" onClick={() => router.replace("/login")}>
+            로그인
+          </InlineActionButton>
+        </>
+      }
+    >
+      <ActionForm onSubmit={handleSubmit} aria-label="비밀번호 변경 링크 요청 폼">
+        <FieldGroup>
+          <Field>
+            <Label htmlFor="password-reset-email">이메일</Label>
+            <Input
+              id="password-reset-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              placeholder="이메일을 입력하세요"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              disabled={isSubmitting}
+            />
+          </Field>
+        </FieldGroup>
+
+        <ActionButton type="submit" disabled={!canSubmit}>
+          {isSubmitting ? "발송 중" : isSuccess ? "다시 보내기" : "변경 링크 보내기"}
+        </ActionButton>
+      </ActionForm>
+    </AuthActionCard>
+  );
+}

--- a/pwa/components/MobileLoginPage.tsx
+++ b/pwa/components/MobileLoginPage.tsx
@@ -27,6 +27,9 @@ export default function MobileLoginPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
+  const passwordResetHref = form.email.trim()
+    ? `/auth/password-reset?email=${encodeURIComponent(form.email.trim())}`
+    : "/auth/password-reset";
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -93,6 +96,8 @@ export default function MobileLoginPage() {
             />
           </Field>
 
+          <PasswordHelpLink href={passwordResetHref}>비밀번호를 잊으셨나요?</PasswordHelpLink>
+
           <Status role="status" aria-live="polite" $visible={Boolean(statusMessage)}>
             {statusMessage}
           </Status>
@@ -149,13 +154,6 @@ const Title = styled.h1`
   word-break: keep-all;
 `;
 
-const Description = styled.p`
-  color: #66725f;
-  font-size: ${typography.fontSize14};
-  line-height: ${typography.lineHeight150};
-  word-break: keep-all;
-`;
-
 const Panel = styled.section`
   padding: 1.5rem;
   border-radius: 1.5rem;
@@ -198,6 +196,27 @@ const Input = styled.input`
   &:focus {
     border-color: ${colors.point};
     box-shadow: 0 0 0 0.1875rem rgba(136, 205, 90, 0.16);
+  }
+`;
+
+const PasswordHelpLink = styled(Link)`
+  justify-self: flex-end;
+  margin-top: -${spacing.space8};
+  color: #5b6a55;
+  font-size: ${typography.fontSize13};
+  font-weight: 700;
+  text-decoration: none;
+
+  &:hover {
+    color: ${colors.point};
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+
+  &:focus-visible {
+    border-radius: 0.25rem;
+    outline: 2px solid rgba(136, 205, 90, 0.32);
+    outline-offset: 2px;
   }
 `;
 


### PR DESCRIPTION
## Summary
- 이메일 인증 화면을 6자리 입력 대신 링크 자동 확인 플로우로 바꿨습니다.
- 로그인 화면에 비밀번호 변경 진입점을 추가하고, 변경 링크 요청/새 비밀번호 설정 화면을 추가했습니다.
- 인증 링크 플로우에 맞춘 공통 상태 카드 UI를 추가했습니다.

## Test Plan
- `npm run test -- api/auth/auth.api.test.ts`
- `npx eslint components/auth/AuthActionCard.tsx components/auth/LoginForm.tsx components/auth/EmailVerificationForm.tsx components/auth/PasswordResetForm.tsx components/auth/PasswordResetRequestForm.tsx pwa/components/MobileLoginPage.tsx app/(public)/auth/password-reset/page.tsx app/(public)/auth/reset-password/page.tsx app/(public)/auth/email-verification/page.tsx`
- `npm run build`
