### PR TITLE
[FIX] PWA Firebase config 프론트 환경변수 전환

### DIFF
--- a/pwa/lib/pushNotifications.test.ts
+++ b/pwa/lib/pushNotifications.test.ts
@@ -2,12 +2,13 @@ import "../../test/setup";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { subscribePush } from "../../api/push/push.api";
+import { getAdminPushConfig, subscribePush } from "../../api/push/push.api";
 
 import { PUSH_TOKEN_STORAGE_KEY, syncPushSubscription } from "./pushNotifications";
 
 vi.mock("../../api/push/push.api", () => ({
   getAdminPushConfig: vi.fn(async () => ({
+    enabled: true,
     apiKey: "api-key",
     authDomain: "auth.example.com",
     projectId: "project-id",
@@ -79,5 +80,21 @@ describe("syncPushSubscription", () => {
     expect(requestPermission).toHaveBeenCalledTimes(1);
     expect(subscribePush).toHaveBeenCalledWith({ token: "fcm-token", deviceType: "WEB" });
     expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBe("fcm-token");
+  });
+
+  it("does not subscribe when backend push config is disabled", async () => {
+    vi.mocked(getAdminPushConfig).mockResolvedValueOnce({
+      enabled: false,
+      apiKey: "api-key",
+      projectId: "project-id",
+      messagingSenderId: "sender-id",
+      appId: "app-id",
+      vapidKey: "vapid-key",
+    });
+    setNotification("granted");
+
+    await syncPushSubscription();
+
+    expect(subscribePush).not.toHaveBeenCalled();
   });
 });

--- a/pwa/lib/pushNotifications.ts
+++ b/pwa/lib/pushNotifications.ts
@@ -13,10 +13,9 @@ type SyncPushSubscriptionOptions = {
 
 function hasFirebaseConfig(config: AdminPushConfigResponseDto) {
   return Boolean(
-    config.apiKey &&
-      config.authDomain &&
+    config.enabled &&
+      config.apiKey &&
       config.projectId &&
-      config.storageBucket &&
       config.messagingSenderId &&
       config.appId &&
       config.vapidKey,

--- a/pwa/pages/mobile-home/utils.ts
+++ b/pwa/pages/mobile-home/utils.ts
@@ -3,7 +3,7 @@ import {
   getEventDisplayDate,
   getEventDisplayId,
   getEventDisplayTitle,
-} from "@/api/event/eventDisplay";
+} from "../../../api/event/eventDisplay";
 import type { EventResponseDto } from "@/api/event/event.dto";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
 import type {

--- a/utils/mapLessonsToWeeklySchedule.ts
+++ b/utils/mapLessonsToWeeklySchedule.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import isoWeek from "dayjs/plugin/isoWeek";
-import { getEventDisplayDate, getEventDisplayId, getEventDisplayTitle } from "@/api/event/eventDisplay";
+import { getEventDisplayDate, getEventDisplayId, getEventDisplayTitle } from "../api/event/eventDisplay";
 import type { EventResponseDto } from "@/api/event/event.dto";
 import type { SubjectDayOfWeek } from "@/api/subject/subject.dto";
 import type { UserTeacherAssignmentResponseDto } from "@/api/user/user.dto";


### PR DESCRIPTION
## 📝 PR 유형

아래에서 해당하는 항목의 [ ] 안에 x를 표시해 주세요.

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [x] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. PWA Push Firebase 설정 소스 변경
   PWA 푸시 구독 흐름에서 Backend `/admin/push/config` 의존성을 제거했습니다.
   Firebase web config와 VAPID public key는 `NEXT_PUBLIC_FIREBASE_*` 환경변수를 사용합니다.

2. GitHub Actions / Docker build 환경변수 연결
   production environment secret의 Firebase public config 값을 Docker build arg로 전달하도록 배포 workflow를 수정했습니다.
   Next.js client bundle에 필요한 build-time public env만 추가했습니다.

3. Push 구독 테스트 갱신
   테스트에서 Backend config mock을 제거하고 `vi.stubEnv`로 Firebase public env를 주입하도록 바꿨습니다.
   VAPID key가 없으면 FCM token 구독 등록을 진행하지 않는 케이스를 검증합니다.

4. 기존 관리자 Push API 유지
   `api/push`의 `/admin/push/config` 함수와 테스트는 관리자 화면/기존 API 레이어 용도로 유지했습니다.
   PWA 런타임 코드에서만 해당 의존을 끊었습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #176

## 🔐 GitHub Secret 설정

production environment에 아래 secret을 추가했습니다.

- `NEXT_PUBLIC_FIREBASE_API_KEY_PROD`
- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN_PROD`
- `NEXT_PUBLIC_FIREBASE_PROJECT_ID_PROD`
- `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET_PROD`
- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID_PROD`
- `NEXT_PUBLIC_FIREBASE_APP_ID_PROD`
- `NEXT_PUBLIC_FIREBASE_VAPID_KEY_PROD`

프론트 repo에는 Firebase service account JSON, private key, VAPID private key를 추가하지 않았습니다.

## ✅ 검증

- `npm run test -- pwa/lib/pushNotifications.test.ts api/push/push.api.test.ts`: 2개 파일 / 6개 테스트 통과
- `npm run build`: 통과
- `git diff --check`: 통과
- `npm run lint`: 통과 (기존 warning 9개 유지)

## 💬 기타 사항

- merge 후 `dev` push workflow가 Cloud Run 배포를 실행합니다.
- PWA 푸시가 실제 수신되려면 Backend Firebase Admin credential과 FCM 발송 설정이 유효해야 합니다.
- 노출된 Firebase service account key는 Backend/GCP 쪽에서 폐기 후 재발급이 필요합니다.