### PR TITLE
[FIX] 이메일 인증 결과 흐름 수정

### DIFF
--- a/api/auth/auth.api.test.ts
+++ b/api/auth/auth.api.test.ts
@@ -11,6 +11,7 @@ import { server } from "../../mocks/server";
 import {
   API_BASE_URL,
   DEFAULT_LOGIN_REQUEST,
+  DEFAULT_SIGNUP_RESPONSE,
   DEFAULT_SIGNUP_REQUEST,
   REFRESHED_ACCESS_TOKEN,
   REFRESHED_REFRESH_TOKEN,
@@ -109,11 +110,10 @@ describe("auth.api", () => {
     expect(getRefreshToken()).toBe(VALID_REFRESH_TOKEN);
   });
 
-  it("returns tokens for a successful signup", async () => {
+  it("returns the signup message without issuing tokens", async () => {
     const response = await signup(DEFAULT_SIGNUP_REQUEST);
 
-    expect(response.accessToken).toBe(VALID_ACCESS_TOKEN);
-    expect(response.refreshToken).toBe(VALID_REFRESH_TOKEN);
+    expect(response).toEqual(DEFAULT_SIGNUP_RESPONSE);
   });
 
   it("throws an error when signup fails", async () => {

--- a/app/(public)/auth/email-verification/page.tsx
+++ b/app/(public)/auth/email-verification/page.tsx
@@ -1,16 +1,17 @@
 import EmailVerificationForm from "@/components/auth/EmailVerificationForm";
 
 type PageProps = {
-  searchParams?: Promise<{ email?: string; code?: string }>;
+  searchParams?: Promise<{ email?: string; code?: string; status?: string }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
-  const { email = "", code = "" } = (await searchParams) ?? {};
+  const { email = "", code = "", status = "" } = (await searchParams) ?? {};
 
   return (
     <EmailVerificationForm
       email={decodeURIComponent(email)}
       verificationCode={decodeURIComponent(code)}
+      resultStatus={status}
     />
   );
 }

--- a/components/auth/EmailVerificationForm.tsx
+++ b/components/auth/EmailVerificationForm.tsx
@@ -16,21 +16,31 @@ const RESEND_COOLDOWN_SECONDS = 60;
 type EmailVerificationFormProps = {
   email: string;
   verificationCode: string;
+  resultStatus?: string;
 };
 
 export default function EmailVerificationForm({
   email,
   verificationCode,
+  resultStatus = "",
 }: EmailVerificationFormProps) {
   const router = useRouter();
+  const isSuccessRedirect = resultStatus === "success";
+  const isFailureRedirect = resultStatus === "invalid" || resultStatus === "expired";
   const hasVerificationLink = Boolean(email && verificationCode);
   const [statusMessage, setStatusMessage] = useState(
-    hasVerificationLink
-      ? "이메일 인증을 확인하고 있습니다."
-      : "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.",
+    isSuccessRedirect
+      ? "이메일 인증이 완료되었습니다. 로그인해 주세요."
+      : isFailureRedirect
+        ? "인증 링크가 만료되었거나 올바르지 않습니다. 인증 메일을 다시 받아 주세요."
+        : hasVerificationLink
+          ? "이메일 인증을 확인하고 있습니다."
+          : "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.",
   );
-  const [statusTone, setStatusTone] = useState<ActionTone>("default");
-  const [isSubmitting, setIsSubmitting] = useState(hasVerificationLink);
+  const [statusTone, setStatusTone] = useState<ActionTone>(
+    isSuccessRedirect ? "success" : isFailureRedirect ? "error" : "default",
+  );
+  const [isSubmitting, setIsSubmitting] = useState(hasVerificationLink && !resultStatus);
   const [cooldown, setCooldown] = useState(0);
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const autoSubmittedRef = useRef(false);
@@ -55,7 +65,7 @@ export default function EmailVerificationForm({
   }, []);
 
   useEffect(() => {
-    if (!email || !verificationCode || autoSubmittedRef.current) {
+    if (resultStatus || !email || !verificationCode || autoSubmittedRef.current) {
       return;
     }
 
@@ -73,7 +83,7 @@ export default function EmailVerificationForm({
       .finally(() => {
         setIsSubmitting(false);
       });
-  }, [email, router, verificationCode]);
+  }, [email, resultStatus, router, verificationCode]);
 
   async function handleResend() {
     if (!email || cooldown > 0) return;
@@ -90,7 +100,8 @@ export default function EmailVerificationForm({
   }
 
   const isError = statusTone === "error";
-  const isComplete = statusTone === "success" && hasVerificationLink && !isSubmitting;
+  const showLoginAction = hasVerificationLink || isSuccessRedirect;
+  const isComplete = statusTone === "success" && showLoginAction && !isSubmitting;
   const icon = isError ? (
     <IconAlertTriangle aria-hidden="true" />
   ) : isComplete ? (
@@ -102,7 +113,7 @@ export default function EmailVerificationForm({
     ? "인증 링크를 다시 받아 주세요"
     : isSubmitting
       ? "이메일 인증을 확인하고 있어요"
-      : hasVerificationLink
+      : showLoginAction
         ? "이메일 인증이 완료되었습니다"
         : "메일함을 확인해 주세요";
   const description = email ? (
@@ -130,7 +141,7 @@ export default function EmailVerificationForm({
         </>
       }
     >
-      {hasVerificationLink ? (
+      {showLoginAction ? (
         <ActionForm as="div">
           <ActionButton type="button" onClick={() => router.replace("/login")} disabled={isSubmitting}>
             {isSubmitting ? "인증 확인 중" : "로그인으로 이동"}

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
+import { isAxiosError } from "axios";
 import styled from "styled-components";
 import { signup } from "@/api/auth/auth.api";
 import {
@@ -35,6 +36,16 @@ const initialState: RegisterFormState = {
   birthDate: "",
   phoneNumber: "",
 };
+
+function getSignupErrorMessage(error: unknown) {
+  if (isAxiosError(error)) {
+    const data = error.response?.data;
+    if (data && typeof data === "object" && "detail" in data && typeof data.detail === "string") {
+      return data.detail;
+    }
+  }
+  return "회원가입 정보를 확인해 주세요.";
+}
 
 export default function RegisterForm() {
   const router = useRouter();
@@ -79,8 +90,8 @@ export default function RegisterForm() {
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
       router.replace(`/auth/email-verification?email=${encodeURIComponent(form.email.trim())}`);
-    } catch {
-      setStatusMessage("회원가입 정보를 확인해 주세요.");
+    } catch (error) {
+      setStatusMessage(getSignupErrorMessage(error));
     } finally {
       setIsSubmitting(false);
     }

--- a/mocks/handlers/auth.handlers.ts
+++ b/mocks/handlers/auth.handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from "msw";
 
 import type {
+  AuthMessageResponseDto,
   LoginRequestDto,
   LogoutRequestDto,
   RefreshTokenRequestDto,
@@ -39,6 +40,10 @@ export const DEFAULT_TOKEN_RESPONSE: TokenResponseDto = {
   tokenType: "Bearer",
 };
 
+export const DEFAULT_SIGNUP_RESPONSE: AuthMessageResponseDto = {
+  message: "회원가입이 완료되었습니다. 이메일 인증을 완료해 주세요.",
+};
+
 function createUnauthorizedResponse(message: string) {
   return HttpResponse.json({ message }, { status: 401 });
 }
@@ -61,7 +66,7 @@ export const authHandlers = [
       return HttpResponse.json({ message: "Invalid signup payload" }, { status: 400 });
     }
 
-    return HttpResponse.json(DEFAULT_TOKEN_RESPONSE, { status: 201 });
+    return HttpResponse.json(DEFAULT_SIGNUP_RESPONSE, { status: 201 });
   }),
 
   http.post(`${API_BASE_URL}/api/v1/auth/refresh`, async ({ request }) => {


### PR DESCRIPTION
## 📝 PR 유형

아래에서 해당하는 항목의 [ ] 안에 x를 표시해 주세요.

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 이메일 인증 결과 페이지 상태 처리
   백엔드 리디렉션의 `status=success`, `status=invalid`, `status=expired` 쿼리를 받아 성공/실패 화면을 표시하도록 수정했습니다.

2. 회원가입 실패 메시지 표시
   signup 실패 시 백엔드 ProblemDetail의 `detail` 메시지를 사용자에게 표시하도록 수정했습니다.

3. signup 테스트 계약 정리
   signup API mock과 테스트를 토큰 반환이 아닌 이메일 인증 안내 메시지 반환 기준으로 맞췄습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #181

## 💬 기타 사항

- 전체 `npm run lint`는 기존 PWA hook lint 오류로 실패합니다. 이번 변경 파일 lint는 통과했습니다.
- Backend PR: https://github.com/Geumjeongyahak/Backend/pull/181

## 📂 참고 자료

> Backend issue: https://github.com/Geumjeongyahak/Backend/issues/180