### PR TITLE
[FEAT] 서비스 사용성 개선 (2)

### DIFF
--- a/api/client/authClient.test.ts
+++ b/api/client/authClient.test.ts
@@ -20,7 +20,13 @@ import {
 import { server } from "../../mocks/server";
 
 import authClient from "./authClient";
-import { getAccessToken, getRefreshToken, setAccessToken, setTokens } from "./tokenStorage";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  setAccessToken,
+  setTokens,
+} from "./tokenStorage";
 
 describe("authClient", () => {
   it("injects the Bearer token when an access token is stored", async () => {
@@ -171,6 +177,40 @@ describe("authClient", () => {
     await expect(request).rejects.toMatchObject({ response: { status: 401 } });
     expect(getAccessToken()).toBe(REFRESHED_ACCESS_TOKEN);
     expect(getRefreshToken()).toBe(REFRESHED_REFRESH_TOKEN);
+  });
+
+  it("does not restore tokens when logout clears storage during an in-flight refresh", async () => {
+    let releaseRefresh: () => void = () => undefined;
+    const refreshStarted = new Promise<void>((resolve) => {
+      server.use(
+        http.get(`${API_BASE_URL}/api/v1/protected/profile`, () => {
+          return HttpResponse.json({ message: "Access token expired" }, { status: 401 });
+        }),
+        http.post(`${API_BASE_URL}/api/v1/auth/refresh`, async () => {
+          resolve();
+          await new Promise<void>((release) => {
+            releaseRefresh = release;
+          });
+          return HttpResponse.json({
+            accessToken: REFRESHED_ACCESS_TOKEN,
+            refreshToken: REFRESHED_REFRESH_TOKEN,
+            tokenType: "Bearer",
+          });
+        }),
+      );
+    });
+
+    setTokens(EXPIRED_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
+
+    const request = authClient.get("/api/v1/protected/profile");
+    await refreshStarted;
+
+    clearTokens();
+    releaseRefresh();
+
+    await expect(request).rejects.toThrow("Auth state changed while refreshing token.");
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
   });
 
   it("stops after a single retry to prevent infinite refresh loops", async () => {

--- a/api/client/authClient.ts
+++ b/api/client/authClient.ts
@@ -7,7 +7,13 @@ import type {
 
 import type { TokenResponseDto } from "../auth/auth.dto";
 import { baseClientConfig, publicClient } from "./publicClient";
-import { clearTokens, getAccessToken, getRefreshToken, setTokens } from "./tokenStorage";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  getTokenStateVersion,
+  setTokens,
+} from "./tokenStorage";
 
 const authClient = axios.create(baseClientConfig);
 
@@ -24,6 +30,7 @@ function setAuthorizationHeader(headers: AxiosRequestHeaders, accessToken: strin
 
 async function refreshAccessToken() {
   const refreshToken = getRefreshToken();
+  const tokenStateAtRequestStart = getTokenStateVersion();
 
   if (!refreshToken) {
     clearTokens();
@@ -42,10 +49,20 @@ async function refreshAccessToken() {
         );
         const tokens = response.data;
 
+        if (
+          getTokenStateVersion() !== tokenStateAtRequestStart ||
+          getRefreshToken() !== refreshToken
+        ) {
+          throw new Error("Auth state changed while refreshing token.");
+        }
+
         setTokens(tokens.accessToken, tokens.refreshToken);
         return tokens;
       } catch (error) {
-        if (getRefreshToken() === refreshToken) {
+        if (
+          getTokenStateVersion() === tokenStateAtRequestStart &&
+          getRefreshToken() === refreshToken
+        ) {
           clearTokens();
         }
         throw error;

--- a/api/client/tokenStorage.ts
+++ b/api/client/tokenStorage.ts
@@ -2,6 +2,8 @@ export const ACCESS_TOKEN_STORAGE_KEY = "geumjeongyahak.accessToken";
 export const REFRESH_TOKEN_STORAGE_KEY = "geumjeongyahak.refreshToken";
 export const AUTH_TOKEN_CHANGE_EVENT = "geumjeongyahak:auth-token-change";
 
+let tokenStateVersion = 0;
+
 function getStorage() {
   if (typeof window === "undefined") {
     return null;
@@ -18,6 +20,10 @@ function notifyTokenChange() {
   window.dispatchEvent(new Event(AUTH_TOKEN_CHANGE_EVENT));
 }
 
+function bumpTokenStateVersion() {
+  tokenStateVersion += 1;
+}
+
 export function getAccessToken() {
   return getStorage()?.getItem(ACCESS_TOKEN_STORAGE_KEY) ?? null;
 }
@@ -26,23 +32,31 @@ export function getRefreshToken() {
   return getStorage()?.getItem(REFRESH_TOKEN_STORAGE_KEY) ?? null;
 }
 
+export function getTokenStateVersion() {
+  return tokenStateVersion;
+}
+
 export function setAccessToken(accessToken: string) {
   getStorage()?.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }
 
 export function setRefreshToken(refreshToken: string) {
   getStorage()?.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }
 
 export function removeAccessToken() {
   getStorage()?.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }
 
 export function removeRefreshToken() {
   getStorage()?.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }
 
@@ -51,6 +65,7 @@ export function setTokens(accessToken: string, refreshToken: string) {
 
   storage?.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
   storage?.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }
 
@@ -59,5 +74,6 @@ export function clearTokens() {
 
   storage?.removeItem(ACCESS_TOKEN_STORAGE_KEY);
   storage?.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+  bumpTokenStateVersion();
   notifyTokenChange();
 }

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -30,7 +30,7 @@ import {
 } from "./request.api";
 
 describe("request.api", () => {
-  it("returns absence requests with auth header and status query", async () => {
+  it("returns absence requests with auth header and supports mine filtering", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     let observedAuthorizationHeader: string | null = null;
@@ -50,7 +50,7 @@ describe("request.api", () => {
       }),
     );
 
-    const response = await getAbsenceRequests({ status: "PENDING" });
+    const response = await getAbsenceRequests({ status: "PENDING", mine: true });
 
     expect(response).toEqual({
       content: [ABSENCE_REQUEST_RESPONSE],
@@ -61,6 +61,7 @@ describe("request.api", () => {
     });
     expect(observedAuthorizationHeader).toBe(`Bearer ${VALID_ACCESS_TOKEN}`);
     expect(observedQueryString).toContain("status=PENDING");
+    expect(observedQueryString).toContain("mine=true");
   });
 
   it("creates a lesson exchange request with the expected body", async () => {

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -155,7 +155,7 @@ describe("request.api", () => {
     expect(observedBody).toEqual({ note: "승인합니다." });
   });
 
-  it("creates a purchase request with payment type and without expected price", async () => {
+  it("creates a purchase request with department affiliation and payment type", async () => {
     setAccessToken(VALID_ACCESS_TOKEN);
 
     let observedBody: unknown;
@@ -170,7 +170,7 @@ describe("request.api", () => {
     await createPurchaseRequest({
       title: "교재 결제 신청",
       content: "신청자: 홍길동",
-      classroomId: 1,
+      departmentId: 7,
       items: [
         {
           name: "국어 교재",
@@ -184,7 +184,7 @@ describe("request.api", () => {
     expect(observedBody).toEqual({
       title: "교재 결제 신청",
       content: "신청자: 홍길동",
-      classroomId: 1,
+      departmentId: 7,
       items: [
         {
           name: "국어 교재",

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -104,7 +104,8 @@ export async function createPurchaseRequest(body: CreatePurchaseRequestDto) {
   const requestBody: CreatePurchaseRequestDto = {
     title: body.title,
     content: body.content,
-    classroomId: body.classroomId,
+    ...(typeof body.classroomId === "number" ? { classroomId: body.classroomId } : {}),
+    ...(typeof body.departmentId === "number" ? { departmentId: body.departmentId } : {}),
     items: body.items.map((item) => ({
       name: item.name,
       quantity: item.quantity,

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -81,7 +81,8 @@ export type AbsenceRequestListItemDto = AbsenceRequestResponseDto;
 export interface CreatePurchaseRequestDto {
   title: string;
   content: string;
-  classroomId: number;
+  classroomId?: number;
+  departmentId?: number;
   items: PurchaseRequestItemDto[];
 }
 
@@ -114,6 +115,8 @@ export interface ReviewPurchaseRequestDto {
 export interface UpdateAdminPurchaseRequestDto {
   title: string;
   content: string;
+  classroomId?: number;
+  departmentId?: number;
   items: PurchaseRequestItemDto[];
 }
 
@@ -141,7 +144,10 @@ export interface PurchaseTransactionResponseDto {
 
 export interface PurchaseRequestSummaryResponseDto {
   id?: number;
+  classroomId?: number;
   classroomName?: string;
+  departmentId?: number;
+  departmentName?: string;
   requestedByName?: string;
   title?: string;
   totalPrice?: number;
@@ -150,7 +156,6 @@ export interface PurchaseRequestSummaryResponseDto {
 }
 
 export interface PurchaseRequestResponseDto extends PurchaseRequestSummaryResponseDto {
-  classroomId?: number;
   requestedById?: number;
   content?: string;
   vendorName?: string;

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -17,6 +17,7 @@ export type PaymentType = "PREPAID" | "ACTUAL";
 
 export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
+  mine?: boolean;
   keyword?: string;
   page?: number;
   size?: number;

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -131,6 +131,19 @@ function isAdminMenu(value: string | null): value is AdminMenu {
   return Boolean(value && navigationItems.some((item) => item.key === value));
 }
 
+function isReloadNavigation() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const navigationEntries = window.performance.getEntriesByType("navigation");
+  const navigationEntry = navigationEntries[0];
+
+  return navigationEntry instanceof PerformanceNavigationTiming
+    ? navigationEntry.type === "reload"
+    : false;
+}
+
 const fallbackPermissions: PermissionDefinitionDto[] = [
   {
     permissionCode: "user:manage:*",
@@ -408,11 +421,11 @@ export default function AdminDashboardPage() {
   const { status, user, signOut } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
   const [activeMenu, setActiveMenu] = useState<AdminMenu>(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === "undefined" || !isReloadNavigation()) {
       return "dashboard";
     }
 
-    const storedMenu = window.localStorage.getItem(ADMIN_ACTIVE_MENU_STORAGE_KEY);
+    const storedMenu = window.sessionStorage.getItem(ADMIN_ACTIVE_MENU_STORAGE_KEY);
     return isAdminMenu(storedMenu) ? storedMenu : "dashboard";
   });
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
@@ -487,7 +500,10 @@ export default function AdminDashboardPage() {
   function handleActiveMenuChange(menu: AdminMenu) {
     resetTransientPanels();
     setActiveMenu(menu);
-    window.localStorage.setItem(ADMIN_ACTIVE_MENU_STORAGE_KEY, menu);
+
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(ADMIN_ACTIVE_MENU_STORAGE_KEY, menu);
+    }
   }
 
   useEffect(() => {

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -420,14 +420,7 @@ export default function AdminDashboardPage() {
   const queryClient = useQueryClient();
   const { status, user, signOut } = useAuthSession();
   const isAdmin = status === "authenticated" && user?.role === "ADMIN";
-  const [activeMenu, setActiveMenu] = useState<AdminMenu>(() => {
-    if (typeof window === "undefined" || !isReloadNavigation()) {
-      return "dashboard";
-    }
-
-    const storedMenu = window.sessionStorage.getItem(ADMIN_ACTIVE_MENU_STORAGE_KEY);
-    return isAdminMenu(storedMenu) ? storedMenu : "dashboard";
-  });
+  const [activeMenu, setActiveMenu] = useState<AdminMenu>("dashboard");
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [selectedChannelId, setSelectedChannelId] = useState<number | null>(null);
   const [selectedPost, setSelectedPost] = useState<{ channelId: number; postId: number } | null>(
@@ -511,6 +504,18 @@ export default function AdminDashboardPage() {
       router.replace("/admin/login");
     }
   }, [router, status, user?.role]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !isReloadNavigation()) {
+      return;
+    }
+
+    const storedMenu = window.sessionStorage.getItem(ADMIN_ACTIVE_MENU_STORAGE_KEY);
+
+    if (isAdminMenu(storedMenu)) {
+      setActiveMenu(storedMenu);
+    }
+  }, []);
 
   const usersQuery = useQuery({
     queryKey: [

--- a/components/admin/classes/AdminClassroomsSection.tsx
+++ b/components/admin/classes/AdminClassroomsSection.tsx
@@ -33,6 +33,7 @@ import {
   TextInput,
 } from "@/components/admin/AdminDashboardSectionParts";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
+import { formatPhoneNumber } from "@/utils/phoneNumber";
 
 const CLASSROOMS_PER_PAGE = 11;
 
@@ -764,7 +765,7 @@ function StudentCreateFields({ form, disabled, setStudentCreateForm }: StudentCr
           onChange={(event) =>
             setStudentCreateForm((current) => ({
               ...current,
-              phoneNumber: event.target.value,
+              phoneNumber: formatPhoneNumber(event.target.value),
             }))
           }
         />

--- a/components/staff/archive/phone-book/PhoneBookPage.styles.ts
+++ b/components/staff/archive/phone-book/PhoneBookPage.styles.ts
@@ -132,9 +132,9 @@ export const ContactCard = styled.div`
 export const Divider = styled.span`
   display: block;
   flex: 0 0 auto;
-  width: 1px;
+  width: 0;
   height: 0.875rem;
-  background-color: #000000;
+  border-left: 1px solid #000000;
 
   @media (min-width: 120rem) {
     height: 1.3125rem;

--- a/components/staff/archive/phone-book/TeacherContactSection.tsx
+++ b/components/staff/archive/phone-book/TeacherContactSection.tsx
@@ -38,13 +38,24 @@ export default function TeacherContactSection() {
 }
 
 function TeacherContactCard({ contact }: { contact: TeacherContact }) {
+  const className = contact.className.trim();
+  const phone = contact.phone.trim();
+
   return (
     <S.ContactCard>
       <strong>{contact.name}</strong>
-      <S.Divider aria-hidden="true" />
-      <S.ContactValue>{contact.className}</S.ContactValue>
-      <S.Divider aria-hidden="true" />
-      <S.ContactValue>{contact.phone}</S.ContactValue>
+      {className ? (
+        <>
+          <S.Divider aria-hidden="true" />
+          <S.ContactValue>{className}</S.ContactValue>
+        </>
+      ) : null}
+      {phone ? (
+        <>
+          <S.Divider aria-hidden="true" />
+          <S.ContactValue>{phone}</S.ContactValue>
+        </>
+      ) : null}
     </S.ContactCard>
   );
 }

--- a/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
+++ b/components/staff/class-management/absence-request/AbsenceListPageClient.tsx
@@ -32,7 +32,7 @@ export default function AbsenceListPageClient() {
 
   const isAuthenticated = authStatus === "authenticated";
   const rawPage = searchParams.get("page");
-  const mineOnly = false;
+  const mineOnly = searchParams.get("mineOnly") === "1";
   const parsedPage = rawPage ? Number(rawPage) : 1;
   const requestedPage = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
 
@@ -50,6 +50,7 @@ export default function AbsenceListPageClient() {
     ],
     queryFn: () =>
       getAbsenceRequests({
+        mine: mineOnly,
         keyword: searchKeyword.trim() || undefined,
         page: requestedPage - 1,
         size: ITEMS_PER_PAGE,
@@ -105,7 +106,6 @@ export default function AbsenceListPageClient() {
       totalPages={totalPages}
       stableTableRows={STABLE_TABLE_ROWS}
       mineOnly={mineOnly}
-      showMineOnlyToggle={false}
       emptyMessage={emptyMessage}
       headerTone="journal"
       lineTone="muted"

--- a/components/staff/finance-management/FinanceRequestCreatePage.tsx
+++ b/components/staff/finance-management/FinanceRequestCreatePage.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { getClassrooms } from "@/api/classroom/classroom.api";
+import { getDepartments } from "@/api/department/department.api";
 import { createPurchaseRequest } from "@/api/request/request.api";
 import type { CreatePurchaseRequestDto } from "@/api/request/request.dto";
 import { getVendors } from "@/api/vendor/vendor.api";
@@ -27,6 +28,7 @@ type AffiliationOption = {
   id: number;
   label: string;
   value: string;
+  type: "classroom" | "department";
 };
 
 const initialItem: FinanceItemForm = {
@@ -50,6 +52,11 @@ export default function FinanceRequestCreatePage() {
     queryFn: () => getClassrooms({ page: 0, size: 100 }),
     retry: false,
   });
+  const { data: departmentData } = useQuery({
+    queryKey: ["departments", "finance-request-create"],
+    queryFn: () => getDepartments(),
+    retry: false,
+  });
   const { data: vendorData } = useQuery({
     queryKey: queryKeys.vendors.list(),
     queryFn: () => getVendors(),
@@ -57,16 +64,27 @@ export default function FinanceRequestCreatePage() {
   });
 
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
+  const departments = useMemo(() => departmentData?.departments ?? [], [departmentData]);
   const affiliationOptions = useMemo<AffiliationOption[]>(
-    () =>
-      classrooms
+    () => [
+      ...classrooms
         .filter((classroom) => typeof classroom.id === "number")
         .map((classroom) => ({
           id: classroom.id as number,
           label: classroom.name ?? `반 ${classroom.id}`,
           value: `classroom:${classroom.id}`,
+          type: "classroom" as const,
         })),
-    [classrooms],
+      ...departments
+        .filter((department) => typeof department.id === "number")
+        .map((department) => ({
+          id: department.id as number,
+          label: department.name ?? `부서 ${department.id}`,
+          value: `department:${department.id}`,
+          type: "department" as const,
+        })),
+    ],
+    [classrooms, departments],
   );
   const selectedAffiliation = affiliationOptions.find((option) => option.value === affiliationValue);
   const vendorBalances = useMemo(
@@ -165,7 +183,9 @@ export default function FinanceRequestCreatePage() {
     mutation.mutate({
       title: title.trim(),
       content: `소속: ${selectedOption.label}\n신청자: ${applicantName}\n\n${itemContent}`,
-      classroomId: selectedOption.id,
+      ...(selectedOption.type === "classroom"
+        ? { classroomId: selectedOption.id }
+        : { departmentId: selectedOption.id }),
       items: normalizedItems.map((item) => ({
         name: item.name,
         quantity: item.quantity ?? 1,

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { getClassrooms } from "@/api/classroom/classroom.api";
+import { getDepartments } from "@/api/department/department.api";
 import { uploadPurchaseItemImage } from "@/api/file/file.api";
 import {
   deletePurchaseRequest,
@@ -43,6 +44,7 @@ type AffiliationOption = {
   id: number;
   label: string;
   value: string;
+  type: "classroom" | "department";
 };
 
 type ExtendedPurchaseItem = PurchaseRequestItemResponseDto;
@@ -50,6 +52,10 @@ type ExtendedPurchaseItem = PurchaseRequestItemResponseDto;
 type ExtendedPurchaseRequest = PurchaseRequestResponseDto;
 
 const fallbackVendorNames = ["예소디자인", "목민서관", "지성문구", "마트"] as const;
+
+function getAffiliationLabel(request?: PurchaseRequestResponseDto) {
+  return request?.departmentName ?? request?.classroomName ?? "-";
+}
 
 type EditableItem = {
   id: number;
@@ -222,6 +228,11 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     queryFn: () => getClassrooms({ page: 0, size: 100 }),
     retry: false,
   });
+  const { data: departmentData } = useQuery({
+    queryKey: ["departments", "finance-request-detail"],
+    queryFn: () => getDepartments(),
+    retry: false,
+  });
 
   const deleteMutation = useMutation({
     mutationFn: () => deletePurchaseRequest({ requestId }),
@@ -240,25 +251,40 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const initialReportItems = useMemo(() => mapPurchaseItemsToReportItems(purchase), [purchase]);
   const activeReportItems = reportItems.length ? reportItems : initialReportItems;
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
+  const departments = useMemo(() => departmentData?.departments ?? [], [departmentData]);
   const affiliationOptions = useMemo<AffiliationOption[]>(
-    () =>
-      classrooms
+    () => [
+      ...classrooms
         .filter((classroom) => typeof classroom.id === "number")
         .map((classroom) => ({
           id: classroom.id as number,
           label: classroom.name ?? `반 ${classroom.id}`,
           value: `classroom:${classroom.id}`,
+          type: "classroom" as const,
         })),
-    [classrooms],
+      ...departments
+        .filter((department) => typeof department.id === "number")
+        .map((department) => ({
+          id: department.id as number,
+          label: department.name ?? `부서 ${department.id}`,
+          value: `department:${department.id}`,
+          type: "department" as const,
+        })),
+    ],
+    [classrooms, departments],
   );
   const selectedAffiliation = affiliationOptions.find(
     (option) => option.value === editAffiliationValue,
   );
   const requestAffiliationValue = useMemo(() => {
     const currentAffiliation = affiliationOptions.find((option) =>
-      typeof request?.classroomId === "number"
-        ? option.id === request.classroomId
-        : option.label === request?.classroomName,
+      option.type === "department"
+        ? (typeof request?.departmentId === "number"
+            ? option.id === request.departmentId
+            : option.label === request?.departmentName)
+        : typeof request?.classroomId === "number"
+          ? option.id === request.classroomId
+          : option.label === request?.classroomName,
     );
 
     return currentAffiliation?.value ?? "";
@@ -471,8 +497,22 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     const nextRequest = {
       ...request,
       title: editTitle.trim() || request.title,
-      classroomId: selectedAffiliation?.id ?? request.classroomId,
-      classroomName: selectedAffiliation?.label ?? request.classroomName,
+      classroomId:
+        selectedAffiliation?.type === "classroom"
+          ? selectedAffiliation.id
+          : request.classroomId,
+      classroomName:
+        selectedAffiliation?.type === "classroom"
+          ? selectedAffiliation.label
+          : request.classroomName,
+      departmentId:
+        selectedAffiliation?.type === "department"
+          ? selectedAffiliation.id
+          : request.departmentId,
+      departmentName:
+        selectedAffiliation?.type === "department"
+          ? selectedAffiliation.label
+          : request.departmentName,
       items: (editItems.length ? editItems : initialEditItems).map((item) => ({
         id: item.id,
         name: item.name.trim(),
@@ -594,7 +634,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       ))}
                     </EditSelect>
                   ) : (
-                    <InlineField>{request.classroomName ?? "-"}</InlineField>
+                    <InlineField>{getAffiliationLabel(request)}</InlineField>
                   )}
                   <InlineLabel>신청자</InlineLabel>
                   <InlineField>{request.requestedByName ?? "-"}</InlineField>

--- a/components/staff/finance-management/FinanceRequestListPage.tsx
+++ b/components/staff/finance-management/FinanceRequestListPage.tsx
@@ -39,6 +39,10 @@ function getRequestTime(createdAt?: string) {
   return Number.isNaN(time) ? 0 : time;
 }
 
+function getAffiliationLabel(request: { departmentName?: string; classroomName?: string }) {
+  return request.departmentName ?? request.classroomName ?? "-";
+}
+
 export default function FinanceRequestListPage({ currentPage }: FinanceRequestListPageProps) {
   const router = useRouter();
   const { user, status: authStatus } = useAuthSession();
@@ -78,7 +82,7 @@ export default function FinanceRequestListPage({ currentPage }: FinanceRequestLi
         normalizedKeyword.length === 0 ||
         [
           request.title,
-          request.classroomName,
+          getAffiliationLabel(request),
           request.requestedByName,
           statusLabel,
           formatUtcToKstShortDate(request.createdAt),
@@ -100,7 +104,7 @@ export default function FinanceRequestListPage({ currentPage }: FinanceRequestLi
   const rows: ListPanelRow[] = visibleRequests.map((request, index) => ({
     id: request.id ?? index,
     no: String(Math.max(1, requests.length - (startIndex + index))).padStart(2, "0"),
-    className: request.classroomName ?? "-",
+    className: getAffiliationLabel(request),
     title: request.title ?? "제목 없음",
     author: request.requestedByName ?? "-",
     date: formatUtcToKstShortDate(request.createdAt),

--- a/pwa/pages/mobile-home/hooks/useMobileHomeScreen.ts
+++ b/pwa/pages/mobile-home/hooks/useMobileHomeScreen.ts
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import {
+  checkOutTeacherAttendance,
   getDailyScheduleDetailIfExists,
   updateTeacherAttendance,
 } from "@/api/dailySchedule/dailySchedule.api";
@@ -18,6 +19,7 @@ import { useAttendanceSuccessPopup } from "@/pwa/pages/mobile-home/hooks/useAtte
 import type { MobileHomeDayValue, MobileScheduleMode } from "@/pwa/pages/mobile-home/types";
 import {
   getCurrentDayValue,
+  hasWrittenClassJournal,
   toAllScheduleItems,
   toMyLessonCardItems,
 } from "@/pwa/pages/mobile-home/utils";
@@ -67,6 +69,7 @@ export function useMobileHomeScreen() {
   const [selectedDay, setSelectedDay] = useState<MobileHomeDayValue>(getCurrentDayValue);
   const [scheduleMode, setScheduleMode] = useState<MobileScheduleMode>("all");
   const [isAttendanceResolving, setIsAttendanceResolving] = useState(false);
+  const [isCheckoutResolving, setIsCheckoutResolving] = useState(false);
 
   const weekFrom = dayjs().startOf("isoWeek").format("YYYY-MM-DD");
   const weekTo = dayjs().endOf("isoWeek").format("YYYY-MM-DD");
@@ -153,6 +156,7 @@ export function useMobileHomeScreen() {
   const hasCheckedOut =
     attendanceQuery.data?.teacherAttendance?.isCheckedOut === true ||
     attendanceQuery.data?.isTeacherCheckedOut === true;
+  const hasWrittenJournal = hasWrittenClassJournal(attendanceQuery.data);
   const hasLessonStarted = hasLessonStartedToday(todayLesson?.startTime);
 
   const attendanceMutation = useMutation({
@@ -188,6 +192,21 @@ export function useMobileHomeScreen() {
     hasLessonStarted &&
     hasCompletedAttendance &&
     !hasCheckedOut;
+
+  const checkoutMutation = useMutation({
+    mutationFn: (dailyScheduleId: number) => checkOutTeacherAttendance({ dailyScheduleId }),
+    onSuccess: () => {
+      setIsCheckoutResolving(false);
+      popup.show("checkout");
+      toast.success("퇴근이 완료되었습니다.");
+      attendanceQuery.refetch().catch(() => undefined);
+    },
+    onError: () => {
+      setIsCheckoutResolving(false);
+      toast.error("퇴근 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    },
+  });
+
   const sliderMode: "attendance" | "checkout" | "completed" = hasCheckedOut
     ? "completed"
     : isCheckoutReady
@@ -207,7 +226,9 @@ export function useMobileHomeScreen() {
           : hasCheckedOut
             ? "오늘 수업의 출석과 퇴근을 모두 완료했습니다."
             : hasCompletedAttendance
-              ? "퇴근을 완료하려면 수업 일지를 작성해야 합니다."
+              ? hasWrittenJournal
+                ? "수업 일지가 확인되었습니다. 밀어서 바로 퇴근할 수 있습니다."
+                : "퇴근을 완료하려면 수업 일지를 작성해야 합니다."
             : `${ATTENDANCE_TARGET_LABEL} 반경 ${ATTENDANCE_TARGET_RADIUS_METERS}m 안에서 출석할 수 있습니다.`;
 
   useEffect(() => {
@@ -267,6 +288,53 @@ export function useMobileHomeScreen() {
     );
   }
 
+  async function completeCheckout({
+    reset,
+    onRequireJournal,
+  }: {
+    reset: () => void;
+    onRequireJournal: () => void;
+  }) {
+    if (!isCheckoutReady || checkoutMutation.isPending || isCheckoutResolving) {
+      reset();
+      return;
+    }
+
+    setIsCheckoutResolving(true);
+
+    try {
+      const latestSchedule = (await attendanceQuery.refetch()).data;
+      const dailyScheduleId = latestSchedule?.dailyScheduleId;
+
+      if (typeof dailyScheduleId !== "number") {
+        setIsCheckoutResolving(false);
+        reset();
+        toast.error("오늘 수업 일정을 다시 확인해 주세요.");
+        return;
+      }
+
+      if (latestSchedule?.teacherAttendance?.isCheckedOut || latestSchedule?.isTeacherCheckedOut) {
+        setIsCheckoutResolving(false);
+        popup.show("checkout");
+        reset();
+        return;
+      }
+
+      if (!hasWrittenClassJournal(latestSchedule)) {
+        setIsCheckoutResolving(false);
+        reset();
+        onRequireJournal();
+        return;
+      }
+
+      checkoutMutation.mutate(dailyScheduleId);
+    } catch {
+      setIsCheckoutResolving(false);
+      reset();
+      toast.error("수업 일지 확인에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    }
+  }
+
   function openCheckoutJournal() {
     navigateWhenAuthenticated("/journal/write");
   }
@@ -291,9 +359,10 @@ export function useMobileHomeScreen() {
     isAttendanceReady,
     isCheckoutReady,
     isAttendancePending: isAttendanceResolving || attendanceMutation.isPending,
-    isCheckoutPending: false,
+    isCheckoutPending: isCheckoutResolving || checkoutMutation.isPending,
     hasCompletedAttendance,
     hasCheckedOut,
+    hasWrittenJournal,
     attendanceGuide,
     scheduleEmptyMessage:
       !isAuthenticated && scheduleMode === "mine"
@@ -309,6 +378,7 @@ export function useMobileHomeScreen() {
       (isAuthenticated &&
         (myLessonsQuery.isLoading || todayLessonsQuery.isLoading)),
     completeAttendance,
+    completeCheckout,
     openCheckoutJournal,
   };
 }

--- a/pwa/pages/mobile-home/index.tsx
+++ b/pwa/pages/mobile-home/index.tsx
@@ -35,6 +35,9 @@ function readNotificationPermission(isAuthenticated: boolean) {
 export default function MobileHomeScreen() {
   const router = useRouter();
   const shellRef = useRef<HTMLDivElement | null>(null);
+  const previousSliderModeRef = useRef<ReturnType<typeof useMobileHomeScreen>["sliderMode"] | null>(
+    null,
+  );
   const [notificationPermission, setNotificationPermission] =
     useState<NotificationPermission | null>(null);
   const [isCheckoutModalOpen, setIsCheckoutModalOpen] = useState(false);
@@ -48,8 +51,10 @@ export default function MobileHomeScreen() {
       isCheckoutModalOpen,
     onConfirm: ({ reset }) => {
       if (screen.sliderMode === "checkout") {
-        reset();
-        setIsCheckoutModalOpen(true);
+        screen.completeCheckout({
+          reset,
+          onRequireJournal: () => setIsCheckoutModalOpen(true),
+        });
         return;
       }
 
@@ -66,6 +71,17 @@ export default function MobileHomeScreen() {
     shellRef.current?.scrollTo({ top: 0, behavior: "auto" });
     window.scrollTo({ top: 0, behavior: "auto" });
   }, [screen.isAuthenticated]);
+
+  useEffect(() => {
+    if (
+      previousSliderModeRef.current === "attendance" &&
+      screen.sliderMode === "checkout"
+    ) {
+      slider.reset();
+    }
+
+    previousSliderModeRef.current = screen.sliderMode;
+  }, [screen.sliderMode, slider.reset]);
 
   async function handlePushOptInClick() {
     await syncPushSubscription({ requestPermission: true }).catch(() => undefined);

--- a/pwa/pages/mobile-home/utils.test.ts
+++ b/pwa/pages/mobile-home/utils.test.ts
@@ -12,9 +12,10 @@ vi.mock("@/api/event/eventDisplay", () => ({
 }));
 
 let toAllScheduleItems: typeof import("./utils").toAllScheduleItems;
+let hasWrittenClassJournal: typeof import("./utils").hasWrittenClassJournal;
 
 beforeEach(async () => {
-  ({ toAllScheduleItems } = await import("./utils"));
+  ({ toAllScheduleItems, hasWrittenClassJournal } = await import("./utils"));
 });
 
 describe("mobile-home utils", () => {
@@ -85,5 +86,44 @@ describe("mobile-home utils", () => {
       kind: "lesson",
       title: "벚꽃반",
     });
+  });
+
+  it("treats a daily schedule with a non-empty lesson note as a written journal", () => {
+    expect(
+      hasWrittenClassJournal({
+        dailyScheduleId: 1,
+        lessonDate: "2026-06-30",
+        classroomId: 1,
+        classroomName: "벚꽃반",
+        teacherId: 1,
+        teacherName: "홍길동",
+        activityStartTime: "19:20:00",
+        activityEndTime: "21:40:00",
+        status: "SCHEDULED",
+        lessonCount: 1,
+        lessons: [{ lessonId: 1, period: 1, note: "받아쓰기 복습 진행" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a daily schedule without lesson notes as an unwritten journal", () => {
+    expect(
+      hasWrittenClassJournal({
+        dailyScheduleId: 1,
+        lessonDate: "2026-06-30",
+        classroomId: 1,
+        classroomName: "벚꽃반",
+        teacherId: 1,
+        teacherName: "홍길동",
+        activityStartTime: "19:20:00",
+        activityEndTime: "21:40:00",
+        status: "SCHEDULED",
+        lessonCount: 2,
+        lessons: [
+          { lessonId: 1, period: 1, note: "   " },
+          { lessonId: 2, period: 2, note: null },
+        ],
+      }),
+    ).toBe(false);
   });
 });

--- a/pwa/pages/mobile-home/utils.ts
+++ b/pwa/pages/mobile-home/utils.ts
@@ -5,6 +5,7 @@ import {
   getEventDisplayTitle,
 } from "@/api/event/eventDisplay";
 import type { EventResponseDto } from "@/api/event/event.dto";
+import type { DailyScheduleDetailResponseDto } from "@/api/dailySchedule/dailySchedule.dto";
 import type { LessonSummaryResponseDto } from "@/api/lesson/lesson.dto";
 import type {
   MobileHomeDayValue,
@@ -71,6 +72,10 @@ export function getClassTone(classroomName?: string) {
       accent: "#88CD5A",
     }
   );
+}
+
+export function hasWrittenClassJournal(schedule?: DailyScheduleDetailResponseDto | null) {
+  return Boolean(schedule?.lessons?.some((lesson) => Boolean(lesson.note?.trim())));
 }
 
 function getEventEmoji(title?: string) {


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 로그아웃 후 stale refresh 응답으로 세션이 복구되는 문제 수정
2. 관리자 페이지 hydration mismatch와 섹션 복원 타이밍 수정
3. 관리자 메뉴 진입 초기화 및 학생 전화번호 자동 포맷 적용
4. 결제 신청 소속 선택에 부서 옵션 추가
5. 연락망 구분선 두께를 동일하게 정리
6. 결강 신청 목록에 내가 작성한 신청서만 보기 토글 추가
7. PWA 퇴근 처리 전 수업 일지 존재 여부를 확인하도록 개선

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #179 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
