### PR TITLE
[FIX] 회원가입 인증 에러 처리 보강

### DIFF
--- a/app/(public)/auth/email-verification/page.tsx
+++ b/app/(public)/auth/email-verification/page.tsx
@@ -1,17 +1,18 @@
 import EmailVerificationForm from "@/components/auth/EmailVerificationForm";
 
 type PageProps = {
-  searchParams?: Promise<{ email?: string; code?: string; status?: string }>;
+  searchParams?: Promise<{ email?: string; code?: string; status?: string; errorCode?: string }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
-  const { email = "", code = "", status = "" } = (await searchParams) ?? {};
+  const { email = "", code = "", status = "", errorCode = "" } = (await searchParams) ?? {};
 
   return (
     <EmailVerificationForm
       email={decodeURIComponent(email)}
       verificationCode={decodeURIComponent(code)}
       resultStatus={status}
+      errorCode={errorCode}
     />
   );
 }

--- a/components/auth/EmailVerificationForm.tsx
+++ b/components/auth/EmailVerificationForm.tsx
@@ -4,12 +4,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { IconAlertTriangle, IconCircleCheck, IconMailCheck } from "@tabler/icons-react";
 import { confirmEmailVerification, resendEmailVerification } from "@/api/auth/auth.api";
+import { getVerificationStatusMessage } from "@/components/auth/authErrorMessages";
 import AuthActionCard, {
   ActionButton,
   ActionForm,
   InlineActionButton,
   type ActionTone,
 } from "@/components/auth/AuthActionCard";
+import {
+  clearPendingEmailVerificationEmail,
+  getPendingEmailVerificationEmail,
+} from "@/components/auth/emailVerificationSession";
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
@@ -17,22 +22,25 @@ type EmailVerificationFormProps = {
   email: string;
   verificationCode: string;
   resultStatus?: string;
+  errorCode?: string;
 };
 
 export default function EmailVerificationForm({
   email,
   verificationCode,
   resultStatus = "",
+  errorCode = "",
 }: EmailVerificationFormProps) {
   const router = useRouter();
   const isSuccessRedirect = resultStatus === "success";
   const isFailureRedirect = resultStatus === "invalid" || resultStatus === "expired";
   const hasVerificationLink = Boolean(email && verificationCode);
+  const [resendEmail] = useState(() => email || getPendingEmailVerificationEmail() || "");
   const [statusMessage, setStatusMessage] = useState(
     isSuccessRedirect
-      ? "이메일 인증이 완료되었습니다. 로그인해 주세요."
+      ? getVerificationStatusMessage("success")
       : isFailureRedirect
-        ? "인증 링크가 만료되었거나 올바르지 않습니다. 인증 메일을 다시 받아 주세요."
+        ? getVerificationStatusMessage(resultStatus, errorCode)
         : hasVerificationLink
           ? "이메일 인증을 확인하고 있습니다."
           : "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.",
@@ -72,24 +80,28 @@ export default function EmailVerificationForm({
     autoSubmittedRef.current = true;
     confirmEmailVerification({ email, verificationCode })
       .then(() => {
-        setStatusTone("success");
-        setStatusMessage("이메일 인증이 완료되었습니다. 로그인 화면으로 이동합니다.");
-        setTimeout(() => router.replace("/login"), 900);
+        clearPendingEmailVerificationEmail();
+        router.replace("/auth/email-verification?status=success");
       })
       .catch(() => {
-        setStatusTone("error");
-        setStatusMessage("인증 링크가 만료되었거나 올바르지 않습니다. 인증 메일을 다시 받아 주세요.");
+        router.replace("/auth/email-verification?status=invalid&errorCode=AUTH014");
       })
       .finally(() => {
         setIsSubmitting(false);
       });
   }, [email, resultStatus, router, verificationCode]);
 
+  useEffect(() => {
+    if (isSuccessRedirect) {
+      clearPendingEmailVerificationEmail();
+    }
+  }, [isSuccessRedirect]);
+
   async function handleResend() {
-    if (!email || cooldown > 0) return;
+    if (!resendEmail || cooldown > 0) return;
 
     try {
-      await resendEmailVerification({ email });
+      await resendEmailVerification({ email: resendEmail });
       setStatusTone("success");
       setStatusMessage("인증 메일을 다시 발송했습니다.");
       startCooldown();
@@ -117,11 +129,11 @@ export default function EmailVerificationForm({
         ? "이메일 인증이 완료되었습니다"
         : "메일함을 확인해 주세요";
   const description = email ? (
-    <>
-      <strong>{email}</strong>으로 발송된 인증 링크로 회원가입을 완료합니다.
-    </>
+    "인증 링크를 확인하고 있습니다."
+  ) : resendEmail ? (
+    "가입한 이메일로 발송된 인증 링크로 회원가입을 완료합니다."
   ) : (
-    "인증할 이메일 정보가 없습니다. 회원가입 후 받은 메일의 버튼을 다시 열어 주세요."
+    "회원가입 후 받은 메일의 인증하기 버튼을 열어 주세요."
   );
 
   return (
@@ -135,7 +147,7 @@ export default function EmailVerificationForm({
       footer={
         <>
           메일을 받지 못하셨나요?{" "}
-          <InlineActionButton type="button" onClick={handleResend} disabled={!email || cooldown > 0}>
+          <InlineActionButton type="button" onClick={handleResend} disabled={!resendEmail || cooldown > 0}>
             {cooldown > 0 ? `재발송 ${cooldown}초` : "인증 메일 재발송"}
           </InlineActionButton>
         </>

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -2,7 +2,6 @@
 
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
-import { isAxiosError } from "axios";
 import styled from "styled-components";
 import { signup } from "@/api/auth/auth.api";
 import {
@@ -15,6 +14,8 @@ import {
   SubmitButton,
 } from "@/components/auth/AuthFormParts";
 import AuthShell from "@/components/auth/AuthShell";
+import { getSignupErrorMessage } from "@/components/auth/authErrorMessages";
+import { setPendingEmailVerificationEmail } from "@/components/auth/emailVerificationSession";
 import { colors } from "@/styles/tokens";
 import { openDatePicker } from "@/utils/datePicker";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
@@ -36,16 +37,6 @@ const initialState: RegisterFormState = {
   birthDate: "",
   phoneNumber: "",
 };
-
-function getSignupErrorMessage(error: unknown) {
-  if (isAxiosError(error)) {
-    const data = error.response?.data;
-    if (data && typeof data === "object" && "detail" in data && typeof data.detail === "string") {
-      return data.detail;
-    }
-  }
-  return "회원가입 정보를 확인해 주세요.";
-}
 
 export default function RegisterForm() {
   const router = useRouter();
@@ -82,14 +73,16 @@ export default function RegisterForm() {
     setStatusMessage("");
 
     try {
+      const email = form.email.trim();
       await signup({
         password: form.password,
         name: form.name.trim(),
-        email: form.email.trim(),
+        email,
         birthDate: form.birthDate,
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
-      router.replace(`/auth/email-verification?email=${encodeURIComponent(form.email.trim())}`);
+      setPendingEmailVerificationEmail(email);
+      router.replace("/auth/email-verification");
     } catch (error) {
       setStatusMessage(getSignupErrorMessage(error));
     } finally {

--- a/components/auth/authErrorMessages.test.ts
+++ b/components/auth/authErrorMessages.test.ts
@@ -1,0 +1,40 @@
+import "../../test/setup";
+
+import { describe, expect, it } from "vitest";
+
+import { getSignupErrorMessage, getVerificationStatusMessage } from "./authErrorMessages";
+
+function axiosLikeError(code: string, detail = "server detail") {
+  return {
+    response: {
+      data: { code, detail },
+    },
+  };
+}
+
+describe("authErrorMessages", () => {
+  it("maps Google duplicate signup errors by backend code", () => {
+    expect(getSignupErrorMessage(axiosLikeError("AUTH007", "ignored"))).toBe(
+      "이미 Google 계정으로 가입된 이메일입니다. Google로 로그인해 주세요.",
+    );
+  });
+
+  it("maps duplicate local email signup errors by backend code", () => {
+    expect(getSignupErrorMessage(axiosLikeError("BIZ-01-002", "ignored"))).toBe(
+      "이미 사용 중인 이메일입니다.",
+    );
+  });
+
+  it("falls back to backend detail for unknown signup errors", () => {
+    expect(getSignupErrorMessage(axiosLikeError("UNKNOWN", "서버 메시지"))).toBe("서버 메시지");
+  });
+
+  it("maps verification result error codes", () => {
+    expect(getVerificationStatusMessage("expired", "AUTH015")).toBe(
+      "인증 링크가 만료되었습니다. 인증 메일을 다시 받아 주세요.",
+    );
+    expect(getVerificationStatusMessage("invalid", "VAL003")).toBe(
+      "인증 링크가 올바르지 않습니다. 회원가입 후 받은 메일의 버튼을 다시 열어 주세요.",
+    );
+  });
+});

--- a/components/auth/authErrorMessages.ts
+++ b/components/auth/authErrorMessages.ts
@@ -1,0 +1,59 @@
+type ProblemLike = {
+  response?: {
+    data?: unknown;
+  };
+};
+
+function getProblemData(error: unknown) {
+  if (!error || typeof error !== "object" || !("response" in error)) {
+    return null;
+  }
+
+  const data = (error as ProblemLike).response?.data;
+  return data && typeof data === "object" ? data : null;
+}
+
+function getStringField(data: object, field: string) {
+  return field in data && typeof data[field as keyof typeof data] === "string"
+    ? data[field as keyof typeof data]
+    : "";
+}
+
+export function getSignupErrorMessage(error: unknown) {
+  const data = getProblemData(error);
+  const code = data ? getStringField(data, "code") : "";
+  const detail = data ? getStringField(data, "detail") : "";
+
+  switch (code) {
+    case "AUTH007":
+      return "이미 Google 계정으로 가입된 이메일입니다. Google로 로그인해 주세요.";
+    case "BIZ-01-002":
+      return "이미 사용 중인 이메일입니다.";
+    case "VAL001":
+    case "VAL002":
+    case "VAL003":
+      return "입력한 회원가입 정보를 확인해 주세요.";
+    default:
+      return detail || "회원가입 정보를 확인해 주세요.";
+  }
+}
+
+export function getVerificationStatusMessage(status: string, errorCode = "") {
+  if (status === "success") {
+    return "이메일 인증이 완료되었습니다. 로그인해 주세요.";
+  }
+
+  if (status === "expired" || errorCode === "AUTH015") {
+    return "인증 링크가 만료되었습니다. 인증 메일을 다시 받아 주세요.";
+  }
+
+  if (errorCode === "VAL003") {
+    return "인증 링크가 올바르지 않습니다. 회원가입 후 받은 메일의 버튼을 다시 열어 주세요.";
+  }
+
+  if (status === "invalid" || errorCode === "AUTH014") {
+    return "인증 링크가 올바르지 않습니다. 인증 메일을 다시 받아 주세요.";
+  }
+
+  return "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.";
+}

--- a/components/auth/emailVerificationSession.test.ts
+++ b/components/auth/emailVerificationSession.test.ts
@@ -1,0 +1,25 @@
+import "../../test/setup";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  clearPendingEmailVerificationEmail,
+  getPendingEmailVerificationEmail,
+  setPendingEmailVerificationEmail,
+} from "./emailVerificationSession";
+
+describe("emailVerificationSession", () => {
+  it("stores pending email in sessionStorage instead of the URL", () => {
+    setPendingEmailVerificationEmail("user@example.com");
+
+    expect(getPendingEmailVerificationEmail()).toBe("user@example.com");
+  });
+
+  it("clears pending email after verification succeeds", () => {
+    setPendingEmailVerificationEmail("user@example.com");
+
+    clearPendingEmailVerificationEmail();
+
+    expect(getPendingEmailVerificationEmail()).toBeNull();
+  });
+});

--- a/components/auth/emailVerificationSession.ts
+++ b/components/auth/emailVerificationSession.ts
@@ -1,0 +1,21 @@
+const PENDING_EMAIL_VERIFICATION_EMAIL_KEY = "gjlearn.pendingEmailVerificationEmail";
+
+function getStorage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.sessionStorage;
+}
+
+export function getPendingEmailVerificationEmail() {
+  return getStorage()?.getItem(PENDING_EMAIL_VERIFICATION_EMAIL_KEY) ?? null;
+}
+
+export function setPendingEmailVerificationEmail(email: string) {
+  getStorage()?.setItem(PENDING_EMAIL_VERIFICATION_EMAIL_KEY, email);
+}
+
+export function clearPendingEmailVerificationEmail() {
+  getStorage()?.removeItem(PENDING_EMAIL_VERIFICATION_EMAIL_KEY);
+}

--- a/pwa/components/MobileRegisterPage.tsx
+++ b/pwa/components/MobileRegisterPage.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { signup } from "@/api/auth/auth.api";
+import { getSignupErrorMessage } from "@/components/auth/authErrorMessages";
+import { setPendingEmailVerificationEmail } from "@/components/auth/emailVerificationSession";
 import { colors, radii, spacing, typography } from "@/styles/tokens";
 import { openDatePicker } from "@/utils/datePicker";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
@@ -63,16 +65,18 @@ export default function MobileRegisterPage() {
     setStatusMessage("");
 
     try {
+      const email = form.email.trim();
       await signup({
         password: form.password,
         name: form.name.trim(),
-        email: form.email.trim(),
+        email,
         birthDate: form.birthDate,
         phoneNumber: form.phoneNumber.trim() || undefined,
       });
-      router.replace(`/auth/email-verification?email=${encodeURIComponent(form.email.trim())}`);
-    } catch {
-      setStatusMessage("회원가입 정보를 확인해 주세요.");
+      setPendingEmailVerificationEmail(email);
+      router.replace("/auth/email-verification");
+    } catch (error) {
+      setStatusMessage(getSignupErrorMessage(error));
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## 📝 PR 유형

아래에서 해당하는 항목의 [ ] 안에 x를 표시해 주세요.

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 이메일 인증 URL 개인정보 제거
   회원가입 성공 후 `/auth/email-verification`로만 이동하고 이메일은 `sessionStorage`에 보관해 재발송에만 사용합니다.

2. 인증 결과 에러 코드 처리
   `status`, `errorCode` query를 해석해 성공/만료/잘못된 링크/필수값 누락 메시지를 표시합니다.

3. 회원가입 에러 메시지 매핑
   `AUTH007`, `BIZ-01-002`, `VAL001~VAL003` 등 backend code를 사용자 메시지로 매핑하고 일반/모바일 가입 폼에서 같이 사용합니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Refs #181

## 💬 기타 사항

- 전체 `npm run lint`는 기존 PWA hook lint 오류가 있어 변경 파일 lint로 검증했습니다.
- Backend PR: https://github.com/Geumjeongyahak/Backend/pull/182

## 📂 참고 자료

> Follow-up to #182