### PR TITLE
[FIX] 이메일 인증 token 링크 처리

### DIFF
--- a/app/(public)/auth/email-verification/page.tsx
+++ b/app/(public)/auth/email-verification/page.tsx
@@ -1,16 +1,23 @@
 import EmailVerificationForm from "@/components/auth/EmailVerificationForm";
 
 type PageProps = {
-  searchParams?: Promise<{ email?: string; code?: string; status?: string; errorCode?: string }>;
+  searchParams?: Promise<{
+    email?: string;
+    code?: string;
+    token?: string;
+    status?: string;
+    errorCode?: string;
+  }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
-  const { email = "", code = "", status = "", errorCode = "" } = (await searchParams) ?? {};
+  const { email = "", code = "", token = "", status = "", errorCode = "" } = (await searchParams) ?? {};
 
   return (
     <EmailVerificationForm
       email={decodeURIComponent(email)}
       verificationCode={decodeURIComponent(code)}
+      token={decodeURIComponent(token)}
       resultStatus={status}
       errorCode={errorCode}
     />

--- a/components/auth/EmailVerificationForm.test.ts
+++ b/components/auth/EmailVerificationForm.test.ts
@@ -1,0 +1,29 @@
+import "../../test/setup";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+vi.mock("./AuthActionCard", () => ({
+  default: () => null,
+  ActionButton: "button",
+  ActionForm: "div",
+  InlineActionButton: "button",
+}));
+
+import { buildEmailVerificationTokenConfirmUrl } from "./EmailVerificationForm";
+
+describe("EmailVerificationForm", () => {
+  it("builds the backend token confirmation URL from the public API base URL", () => {
+    expect(
+      buildEmailVerificationTokenConfirmUrl(
+        "https://dev.geumjeongschool.com",
+        "token+/=",
+      ),
+    ).toBe(
+      "https://dev.geumjeongschool.com/api/v1/auth/email-verification/confirm?token=token%2B%2F%3D",
+    );
+  });
+});

--- a/components/auth/EmailVerificationForm.tsx
+++ b/components/auth/EmailVerificationForm.tsx
@@ -3,31 +3,40 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { IconAlertTriangle, IconCircleCheck, IconMailCheck } from "@tabler/icons-react";
-import { confirmEmailVerification, resendEmailVerification } from "@/api/auth/auth.api";
-import { getVerificationStatusMessage } from "@/components/auth/authErrorMessages";
+import { confirmEmailVerification, resendEmailVerification } from "../../api/auth/auth.api";
+import { baseURL } from "../../api/client/publicClient";
+import { getVerificationStatusMessage } from "./authErrorMessages";
 import AuthActionCard, {
   ActionButton,
   ActionForm,
   InlineActionButton,
   type ActionTone,
-} from "@/components/auth/AuthActionCard";
+} from "./AuthActionCard";
 import {
   clearPendingEmailVerificationEmail,
   getPendingEmailVerificationEmail,
-} from "@/components/auth/emailVerificationSession";
+} from "./emailVerificationSession";
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
 type EmailVerificationFormProps = {
   email: string;
   verificationCode: string;
+  token?: string;
   resultStatus?: string;
   errorCode?: string;
 };
 
+export function buildEmailVerificationTokenConfirmUrl(apiBaseURL: string, token: string) {
+  const url = new URL("/api/v1/auth/email-verification/confirm", apiBaseURL);
+  url.searchParams.set("token", token);
+  return url.toString();
+}
+
 export default function EmailVerificationForm({
   email,
   verificationCode,
+  token = "",
   resultStatus = "",
   errorCode = "",
 }: EmailVerificationFormProps) {
@@ -35,20 +44,21 @@ export default function EmailVerificationForm({
   const isSuccessRedirect = resultStatus === "success";
   const isFailureRedirect = resultStatus === "invalid" || resultStatus === "expired";
   const hasVerificationLink = Boolean(email && verificationCode);
+  const hasTokenLink = Boolean(token);
   const [resendEmail] = useState(() => email || getPendingEmailVerificationEmail() || "");
   const [statusMessage, setStatusMessage] = useState(
     isSuccessRedirect
       ? getVerificationStatusMessage("success")
       : isFailureRedirect
         ? getVerificationStatusMessage(resultStatus, errorCode)
-        : hasVerificationLink
+        : hasVerificationLink || hasTokenLink
           ? "이메일 인증을 확인하고 있습니다."
           : "메일의 인증하기 버튼을 눌러 인증을 완료해 주세요.",
   );
   const [statusTone, setStatusTone] = useState<ActionTone>(
     isSuccessRedirect ? "success" : isFailureRedirect ? "error" : "default",
   );
-  const [isSubmitting, setIsSubmitting] = useState(hasVerificationLink && !resultStatus);
+  const [isSubmitting, setIsSubmitting] = useState((hasVerificationLink || hasTokenLink) && !resultStatus);
   const [cooldown, setCooldown] = useState(0);
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const autoSubmittedRef = useRef(false);
@@ -71,6 +81,15 @@ export default function EmailVerificationForm({
       if (cooldownRef.current) clearInterval(cooldownRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (resultStatus || !token || autoSubmittedRef.current) {
+      return;
+    }
+
+    autoSubmittedRef.current = true;
+    window.location.assign(buildEmailVerificationTokenConfirmUrl(baseURL, token));
+  }, [resultStatus, token]);
 
   useEffect(() => {
     if (resultStatus || !email || !verificationCode || autoSubmittedRef.current) {
@@ -112,7 +131,7 @@ export default function EmailVerificationForm({
   }
 
   const isError = statusTone === "error";
-  const showLoginAction = hasVerificationLink || isSuccessRedirect;
+  const showLoginAction = hasVerificationLink || hasTokenLink || isSuccessRedirect;
   const isComplete = statusTone === "success" && showLoginAction && !isSubmitting;
   const icon = isError ? (
     <IconAlertTriangle aria-hidden="true" />


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 이메일 인증 페이지에서 `token` search param을 읽어 `EmailVerificationForm`에 전달했습니다.
2. `token` 링크 진입 시 기존 public API base URL 기준으로 백엔드 `GET /api/v1/auth/email-verification/confirm?token=...` URL을 만들고 `window.location.assign(...)`으로 이동하도록 처리했습니다.
3. 기존 `email` + `code` POST 자동 인증 흐름과 `status=success|invalid|expired` 결과 화면은 유지했습니다.
4. token confirm URL 생성 로직의 인코딩 회귀 테스트를 추가했습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #185

## 💬 기타 사항

- `NEXT_PUBLIC_API_BASE_URL` 값이 dev 백엔드(`https://dev.geumjeongschool.com`)를 가리켜야 메일 링크 confirm 요청도 해당 백엔드로 이동합니다.

## 📂 참고 자료

> Backend issue: https://github.com/Geumjeongyahak/Backend/issues/180  
> Backend PR: https://github.com/Geumjeongyahak/Backend/pull/181
