### PR TITLE
[FEAT] 결제 요청 플로우 개편

### DIFF
--- a/app/staff/class-management/absence-request/[postId]/page.tsx
+++ b/app/staff/class-management/absence-request/[postId]/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import {
   deleteAbsenceRequest,
@@ -14,6 +15,7 @@ import { Button } from "@/components/common/VariantButton";
 import { StatusBadge, type ExchangeStatus } from "@/components/staff/class-management/exchange-request/ExchangeRequestDetail";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatRequestStatus } from "@/utils/formatRequestStatus";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
@@ -41,8 +43,8 @@ export default function AbsencePostPage() {
       router.push("/staff/class-management/absence-request");
       router.refresh();
     },
-    onError: () => {
-      window.alert("결강 신청서 삭제에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결강 신청서 삭제에 실패했습니다."));
     },
   });
   const updateAbsenceMutation = useMutation({
@@ -54,8 +56,8 @@ export default function AbsencePostPage() {
       setIsEditing(false);
       window.alert("결강 신청서가 수정되었습니다.");
     },
-    onError: () => {
-      window.alert("결강 신청서 수정에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결강 신청서 수정에 실패했습니다."));
     },
   });
 

--- a/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
+++ b/app/staff/class-management/exchange-request/[postId]/useExchangePostPage.ts
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import type {
   LessonExchangeProposalDto,
   LessonExchangeProposalRequestDto,
@@ -20,6 +21,7 @@ import {
   withdrawLessonExchangeProposal,
 } from "@/api/lessonExchange/lessonExchange.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 import {
@@ -121,7 +123,7 @@ export function useExchangePostPage() {
       window.alert("교환 제안이 등록되었습니다.");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "교환 제안 등록에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "교환 제안 등록에 실패했습니다."));
     },
   });
 
@@ -140,7 +142,7 @@ export function useExchangePostPage() {
       window.alert("수업 교환 신청이 수정되었습니다.");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "수업 교환 신청 수정에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "수업 교환 신청 수정에 실패했습니다."));
     },
   });
 
@@ -161,7 +163,7 @@ export function useExchangePostPage() {
       });
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "교환 제안 수락에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "교환 제안 수락에 실패했습니다."));
     },
   });
 
@@ -186,7 +188,7 @@ export function useExchangePostPage() {
       window.alert("교환 제안이 수정되었습니다.");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "교환 제안 수정에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "교환 제안 수정에 실패했습니다."));
     },
   });
 
@@ -206,7 +208,7 @@ export function useExchangePostPage() {
       window.alert("교환 제안이 삭제되었습니다.");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "교환 제안 삭제에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "교환 제안 삭제에 실패했습니다."));
     },
   });
 
@@ -227,7 +229,7 @@ export function useExchangePostPage() {
       router.push("/staff/class-management/exchange-request");
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "수업 교환 신청 취소에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "수업 교환 신청 취소에 실패했습니다."));
     },
   });
 

--- a/app/staff/class-management/exchange-request/new/page.tsx
+++ b/app/staff/class-management/exchange-request/new/page.tsx
@@ -5,9 +5,11 @@ import { useRouter } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import { createLessonExchangeRequest } from "@/api/lessonExchange/lessonExchange.api";
 import { getCurrentUser } from "@/api/user/user.api";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import {
   koreanShortDateToLocalDateTime,
@@ -57,8 +59,8 @@ export default function Page() {
       router.push("/staff/class-management/exchange-request");
       router.refresh();
     },
-    onError: () => {
-      window.alert("수업 교환 신청서 생성에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "수업 교환 신청서 생성에 실패했습니다."));
     },
   });
 

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -1700,14 +1700,11 @@ export default function AdminDashboardPage() {
               purchaseStatus={purchaseStatus}
               purchaseSearch={purchaseSearch}
               purchasePage={purchasePage}
-              isPurchaseCreateModalOpen={isPurchaseCreateModalOpen}
-              purchaseCreate={purchaseCreate}
               reviewNote={reviewNote}
               purchasesQuery={purchasesQuery}
               purchaseDetailQuery={purchaseDetailQuery}
               vendorsQuery={vendorsQuery}
               createVendorMutation={createVendorMutation}
-              createPurchaseMutation={createPurchaseMutation}
               approvePurchaseMutation={approvePurchaseMutation}
               rejectPurchaseMutation={rejectPurchaseMutation}
               confirmPurchaseMutation={confirmPurchaseMutation}
@@ -1715,11 +1712,8 @@ export default function AdminDashboardPage() {
               setPurchaseStatus={setPurchaseStatus}
               setPurchaseSearch={setPurchaseSearch}
               setPurchasePage={setPurchasePage}
-              setIsPurchaseCreateModalOpen={setIsPurchaseCreateModalOpen}
-              setPurchaseCreate={setPurchaseCreate}
               setSelectedPurchaseId={setSelectedPurchaseId}
               setReviewNote={setReviewNote}
-              emptyPurchaseCreate={emptyPurchaseCreate}
             />
           ) : null}
           {activeMenu === "teacherApplications" ? <AdminTeacherApplicationsSection /> : null}

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -1,7 +1,6 @@
 ﻿"use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ToastContainer, toast } from "react-toastify";
@@ -516,6 +515,25 @@ export default function AdminDashboardPage() {
     }
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const adminUrl = window.location.href;
+    window.history.pushState({ __adminBackGuard: true }, "", adminUrl);
+
+    function handlePopState() {
+      window.history.pushState({ __adminBackGuard: true }, "", adminUrl);
+    }
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
   const usersQuery = useQuery({
     queryKey: [
       "admin",
@@ -804,8 +822,7 @@ export default function AdminDashboardPage() {
   const pendingAbsenceRequestCount = pendingAbsenceRequestsQuery.data?.totalElements ?? 0;
   const pendingLessonExchangeRequestCount =
     pendingLessonExchangeRequestsQuery.data?.totalElements ?? 0;
-  const pendingTeacherApplicationCount =
-    pendingTeacherApplicationsQuery.data?.totalElements ?? 0;
+  const pendingTeacherApplicationCount = pendingTeacherApplicationsQuery.data?.totalElements ?? 0;
   const requestSummaries = [
     {
       label: "대기 중인 수업 교환 요청",
@@ -1445,6 +1462,18 @@ export default function AdminDashboardPage() {
     router.replace("/admin/login");
   }
 
+  function handleGoHome() {
+    router.replace("/");
+  }
+
+  function handleReloadAdmin() {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.location.replace("/admin");
+  }
+
   if (!isAdmin) {
     return (
       <Main>
@@ -1484,7 +1513,7 @@ export default function AdminDashboardPage() {
     <ConsoleShell>
       <TopLine aria-hidden="true" />
       <Sidebar>
-        <Brand href="/" aria-label="홈으로 이동">
+        <Brand type="button" onClick={handleReloadAdmin} aria-label="관리자 페이지 새로고침">
           <BrandLogo src="/logo.svg" alt="" aria-hidden="true" />
           <BrandText>
             <BrandTitle>관리자 콘솔</BrandTitle>
@@ -1505,9 +1534,14 @@ export default function AdminDashboardPage() {
           ))}
         </SidebarNav>
 
-        <LogoutButton type="button" onClick={handleLogout}>
-          로그아웃
-        </LogoutButton>
+        <SidebarActionGroup>
+          <LogoutButton type="button" onClick={handleGoHome}>
+            홈으로
+          </LogoutButton>
+          <LogoutButton type="button" onClick={handleLogout}>
+            로그아웃
+          </LogoutButton>
+        </SidebarActionGroup>
       </Sidebar>
 
       <Main>
@@ -1764,13 +1798,17 @@ const Sidebar = styled.aside`
   }
 `;
 
-const Brand = styled(Link)`
+const Brand = styled.button`
   display: flex;
   align-items: center;
   gap: ${spacing.space8};
   margin-bottom: ${spacing.space24};
+  border: 0;
   border-radius: 0.375rem;
-  text-decoration: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
   transition:
     transform 0.18s ease,
     opacity 0.18s ease;
@@ -1790,12 +1828,23 @@ const Brand = styled(Link)`
   }
 `;
 
+const SidebarActionGroup = styled.div`
+  display: grid;
+  gap: ${spacing.space8};
+  margin-top: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space12};
+    margin-top: ${spacing.space32};
+  }
+`;
+
 const BrandLogo = styled.img`
-  width: 1.75rem;
+  width: 3rem;
   height: auto;
 
   @media (min-width: 120rem) {
-    width: 2.625rem;
+    width: 4rem;
   }
 `;
 
@@ -1876,16 +1925,14 @@ const SidebarItem = styled.button<{ $active: boolean }>`
   }
 
   @media (min-width: 120rem) {
-    min-height: 3.625rem;
     padding: 1rem;
     border-radius: 0.5rem;
-    font-size: ${typography.fontSize18};
+    font-size: ${typography.fontSize16};
   }
 `;
 
 const LogoutButton = styled.button`
   min-height: 2.375rem;
-  margin-top: ${spacing.space20};
   border: 1px solid ${colors.border};
   border-radius: 0.375rem;
   background-color: ${colors.white};
@@ -1895,12 +1942,24 @@ const LogoutButton = styled.button`
   font-weight: 800;
   line-height: ${typography.lineHeight130};
   cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    transform 0.18s ease,
+    opacity 0.18s ease;
+
+  &:hover {
+    background-color: #f1f5f2;
+    transform: translateX(0.125rem);
+  }
+
+  &:active {
+    transform: translateX(0.125rem) scale(0.98);
+  }
 
   @media (min-width: 120rem) {
-    min-height: 3.625rem;
-    margin-top: ${spacing.space32};
+    min-height: 3rem;
     border-radius: 0.5rem;
-    font-size: ${typography.fontSize18};
+    font-size: ${typography.fontSize16};
   }
 `;
 

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -23,6 +23,7 @@ import {
   ADMIN_USERS_PER_PAGE,
   AdminUsersSection,
 } from "@/components/admin/users/AdminUsersSection";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import type {
   AdminMenu,
   ChannelFormState,
@@ -287,13 +288,7 @@ function toNumber(value: string) {
 }
 
 function getErrorMessage(error: unknown, fallback: string) {
-  if (error && typeof error === "object" && "message" in error) {
-    const message = (error as { message?: unknown }).message;
-    if (typeof message === "string" && message.trim()) {
-      return message;
-    }
-  }
-  return fallback;
+  return extractApiErrorMessage(error, fallback);
 }
 
 function getTotalFromPage(contentLength: number, totalElements?: number) {

--- a/components/admin/AdminLoginPage.tsx
+++ b/components/admin/AdminLoginPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 import { login } from "@/api/auth/auth.api";
@@ -25,6 +25,26 @@ export default function AdminLoginPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canSubmit = form.email.trim().length > 0 && form.password.length > 0;
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const loginUrl = window.location.href;
+    window.history.pushState({ __adminLoginBackGuard: true }, "", loginUrl);
+
+    function handlePopState() {
+      window.history.pushState({ __adminLoginBackGuard: true }, "", loginUrl);
+      router.replace("/");
+    }
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [router]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/components/admin/lesson-management/AdminLessonScheduleTables.tsx
+++ b/components/admin/lesson-management/AdminLessonScheduleTables.tsx
@@ -33,6 +33,7 @@ import {
 import { normalizeLessonTimeForApi } from "@/components/admin/lesson-management/lessonCreateError";
 import { formatSubjectTeacherName } from "@/components/admin/subjects/shared/subjectDisplay";
 import { queryKeys } from "@/lib/queryKeys";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const WEEKDAY_COLUMNS: { value: SubjectDayOfWeek; label: string }[] = [
@@ -196,8 +197,7 @@ function buildCellFormState(selection: ScheduleCellSelection | null): ScheduleCe
 }
 
 function resolveScheduleMutationError(error: unknown) {
-  if (error instanceof Error && error.message.trim()) return error.message;
-  return "시간표 항목 저장에 실패했습니다.";
+  return extractApiErrorMessage(error, "시간표 항목 저장에 실패했습니다.");
 }
 
 type ScheduleTableProps = {
@@ -303,7 +303,7 @@ export function AdminLessonScheduleTables() {
     key: string;
     form: ScheduleCellFormState;
   }>(() => ({ key: "none", form: buildCellFormState(null) }));
-  const [formError, setFormError] = useState<string | null>(null);
+  const [, setFormError] = useState<string | null>(null);
   const [periodColors, setPeriodColors] = useState<PeriodColorMap>(() => readStoredPeriodColors());
   const [isColorSettingsOpen, setIsColorSettingsOpen] = useState(false);
 
@@ -343,7 +343,6 @@ export function AdminLessonScheduleTables() {
 
   const cellForm =
     cellFormState.key === selectedCellKey ? cellFormState.form : buildCellFormState(selectedCell);
-  const visibleFormError = cellFormState.key === selectedCellKey ? formError : null;
   const setCellForm = (updater: SetStateAction<ScheduleCellFormState>) => {
     setCellFormState((current) => {
       const baseForm =
@@ -391,7 +390,8 @@ export function AdminLessonScheduleTables() {
     },
     onError: async (error) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.admin.subjects() });
-      setFormError(resolveScheduleMutationError(error));
+      setFormError(null);
+      toast.error(resolveScheduleMutationError(error));
     },
   });
 
@@ -454,7 +454,8 @@ export function AdminLessonScheduleTables() {
     },
     onError: async (error) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.admin.subjects() });
-      setFormError(resolveScheduleMutationError(error));
+      setFormError(null);
+      toast.error(resolveScheduleMutationError(error));
     },
   });
 
@@ -665,7 +666,6 @@ export function AdminLessonScheduleTables() {
               </PeriodEditorList>
             </ModalBody>
 
-            {visibleFormError ? <InlineStatus role="alert">{visibleFormError}</InlineStatus> : null}
             {teachersQuery.isError ? (
               <InlineStatus role="alert">교사 목록을 불러오지 못했습니다.</InlineStatus>
             ) : null}

--- a/components/admin/lesson-management/lessonCreateError.ts
+++ b/components/admin/lesson-management/lessonCreateError.ts
@@ -1,4 +1,5 @@
 import { isAxiosError } from "axios";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 
 const LESSON_TIME_OVERLAP_MESSAGE = "시간대가 겹치는 수업이 존재합니다";
 
@@ -41,11 +42,7 @@ export function resolveLessonCreateErrorMessage(error: unknown) {
     return LESSON_TIME_OVERLAP_MESSAGE;
   }
 
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-
-  return "수업 생성에 실패했습니다.";
+  return extractApiErrorMessage(error, "수업 생성에 실패했습니다.");
 }
 
 export function formatLessonTimeRange(startTime?: string, endTime?: string) {
@@ -68,9 +65,5 @@ export function formatLessonStatusLabel(status?: string) {
 }
 
 export function resolveLessonDeleteErrorMessage(error: unknown) {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-
-  return "수업 삭제에 실패했습니다.";
+  return extractApiErrorMessage(error, "수업 삭제에 실패했습니다.");
 }

--- a/components/admin/lesson-management/useLessonCreateSubmit.ts
+++ b/components/admin/lesson-management/useLessonCreateSubmit.ts
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import { createLesson } from "@/api/lesson/lesson.api";
 import {
   normalizeLessonTimeForApi,
@@ -32,7 +33,8 @@ export function useLessonCreateSubmit({ teacherId, subjectId }: UseLessonCreateS
       await queryClient.invalidateQueries({ queryKey: ["admin", "lessons"] });
     },
     onError: (error) => {
-      setSubmitError(resolveLessonCreateErrorMessage(error));
+      setSubmitError(null);
+      toast.error(resolveLessonCreateErrorMessage(error));
     },
   });
 

--- a/components/admin/purchase-requests/AdminPurchasesSection.tsx
+++ b/components/admin/purchase-requests/AdminPurchasesSection.tsx
@@ -14,10 +14,6 @@ import type {
 } from "@/api/request/request.dto";
 import type { VendorResponseDto } from "@/api/vendor/vendor.dto";
 import type { CreateVendorRequestDto } from "@/api/vendor/vendor.dto";
-import type {
-  PurchaseCreateItemState,
-  PurchaseCreateState,
-} from "@/components/admin/AdminDashboardTypes";
 import {
   ButtonRow,
   ControlRow,
@@ -66,14 +62,11 @@ type AdminPurchasesSectionProps = {
   purchaseStatus: PurchaseRequestStatus | "";
   purchaseSearch: string;
   purchasePage: number;
-  isPurchaseCreateModalOpen: boolean;
-  purchaseCreate: PurchaseCreateState;
   reviewNote: string;
   purchasesQuery: QueryState<{ totalPages?: number }>;
   purchaseDetailQuery: QueryState<PurchaseRequestResponseDto>;
   vendorsQuery: QueryState<VendorResponseDto[]>;
   createVendorMutation: ValueMutationAction<CreateVendorRequestDto>;
-  createPurchaseMutation: VoidMutationAction;
   approvePurchaseMutation: VoidMutationAction;
   rejectPurchaseMutation: VoidMutationAction;
   confirmPurchaseMutation: VoidMutationAction;
@@ -81,11 +74,8 @@ type AdminPurchasesSectionProps = {
   setPurchaseStatus: Dispatch<SetStateAction<PurchaseRequestStatus | "">>;
   setPurchaseSearch: Dispatch<SetStateAction<string>>;
   setPurchasePage: Dispatch<SetStateAction<number>>;
-  setIsPurchaseCreateModalOpen: Dispatch<SetStateAction<boolean>>;
-  setPurchaseCreate: Dispatch<SetStateAction<PurchaseCreateState>>;
   setSelectedPurchaseId: Dispatch<SetStateAction<number | null>>;
   setReviewNote: Dispatch<SetStateAction<string>>;
-  emptyPurchaseCreate: PurchaseCreateState;
 };
 
 function formatPurchaseStatus(status?: PurchaseRequestStatus) {
@@ -120,16 +110,6 @@ function formatPurchaseListAmount(item: PurchaseRequestListItemDto) {
   return formatCurrency(item.totalPrice);
 }
 
-function createPurchaseItem(): PurchaseCreateItemState {
-  return {
-    id: `purchase-item-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    itemName: "",
-    itemQuantity: "1",
-    itemReason: "",
-    itemPaymentType: "ACTUAL",
-  };
-}
-
 function getReceiptsForItem(
   item: PurchaseRequestItemResponseDto,
   transactions?: PurchaseTransactionResponseDto[],
@@ -152,14 +132,11 @@ export function AdminPurchasesSection({
   purchaseStatus,
   purchaseSearch,
   purchasePage,
-  isPurchaseCreateModalOpen,
-  purchaseCreate,
   reviewNote,
   purchasesQuery,
   purchaseDetailQuery,
   vendorsQuery,
   createVendorMutation,
-  createPurchaseMutation,
   approvePurchaseMutation,
   rejectPurchaseMutation,
   confirmPurchaseMutation,
@@ -167,11 +144,8 @@ export function AdminPurchasesSection({
   setPurchaseStatus,
   setPurchaseSearch,
   setPurchasePage,
-  setIsPurchaseCreateModalOpen,
-  setPurchaseCreate,
   setSelectedPurchaseId,
   setReviewNote,
-  emptyPurchaseCreate,
 }: AdminPurchasesSectionProps) {
   const [rejectTargetId, setRejectTargetId] = useState<number | null>(null);
   const [confirmAction, setConfirmAction] = useState<PurchaseConfirmAction | null>(null);
@@ -188,12 +162,6 @@ export function AdminPurchasesSection({
   const isRejecting = rejectTargetId === selectedPurchaseId && canReviewPurchase;
   const canSubmitRejection =
     isRejecting && reviewNote.trim().length > 0 && !rejectPurchaseMutation.isPending;
-  const canSubmitPurchase = Boolean(
-    purchaseCreate.title.trim().length > 0 &&
-    purchaseCreate.classroomId &&
-    purchaseCreate.items.length > 0 &&
-    purchaseCreate.items.every((item) => item.itemName.trim().length > 0),
-  );
   const confirmMessage = {
     approve: "승인하시겠습니까?",
     reject: "반려하시겠습니까?",
@@ -206,24 +174,6 @@ export function AdminPurchasesSection({
     setReviewNote("");
     setRejectTargetId(null);
     setConfirmAction(null);
-  }
-
-  function openCreateModal() {
-    setSelectedPurchaseId(null);
-    setReviewNote("");
-    setRejectTargetId(null);
-    setConfirmAction(null);
-    setPurchaseCreate(emptyPurchaseCreate);
-    setIsPurchaseCreateModalOpen(true);
-  }
-
-  function closeCreateModal() {
-    if (createPurchaseMutation.isPending) {
-      return;
-    }
-
-    setIsPurchaseCreateModalOpen(false);
-    setPurchaseCreate(emptyPurchaseCreate);
   }
 
   function selectPurchase(item: PurchaseRequestListItemDto) {
@@ -292,44 +242,6 @@ export function AdminPurchasesSection({
     setConfirmAction(null);
   }
 
-  function addPurchaseItem() {
-    setPurchaseCreate((current) => ({
-      ...current,
-      items: [...current.items, createPurchaseItem()],
-    }));
-  }
-
-  function updatePurchaseItem(
-    itemId: string,
-    field: keyof Omit<PurchaseCreateItemState, "id">,
-    value: string,
-  ) {
-    setPurchaseCreate((current) => ({
-      ...current,
-      items: current.items.map((item) =>
-        item.id === itemId
-          ? {
-              ...item,
-              [field]: value,
-            }
-          : item,
-      ),
-    }));
-  }
-
-  function removePurchaseItem(itemId: string) {
-    setPurchaseCreate((current) => {
-      if (current.items.length <= 1) {
-        return current;
-      }
-
-      return {
-        ...current,
-        items: current.items.filter((item) => item.id !== itemId),
-      };
-    });
-  }
-
   function handlePurchaseListSectionClick(event: MouseEvent<HTMLElement>) {
     if (!isDetailOpen) {
       return;
@@ -388,9 +300,6 @@ export function AdminPurchasesSection({
           <HeaderButtonGroup>
             <SmallButton type="button" onClick={() => setIsVendorBalanceModalOpen(true)}>
               거래처별 잔액 확인
-            </SmallButton>
-            <SmallButton type="button" onClick={openCreateModal}>
-              요청서 작성
             </SmallButton>
           </HeaderButtonGroup>
         </SectionHeaderRow>
@@ -684,145 +593,6 @@ export function AdminPurchasesSection({
           </>
         ) : null}
       </PurchaseListSection>
-
-      {isPurchaseCreateModalOpen ? (
-        <ModalBackdrop onMouseDown={closeCreateModal}>
-          <ModalDialog
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="purchase-create-modal-title"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
-            <ModalHeader>
-              <SectionTitle id="purchase-create-modal-title">요청서 작성</SectionTitle>
-              <SmallButton
-                type="button"
-                disabled={createPurchaseMutation.isPending}
-                onClick={closeCreateModal}
-              >
-                닫기
-              </SmallButton>
-            </ModalHeader>
-            <FormGrid
-              onSubmit={(event) => {
-                event.preventDefault();
-                createPurchaseMutation.mutate();
-              }}
-            >
-              <Label>
-                제목
-                <TextInput
-                  value={purchaseCreate.title}
-                  onChange={(event) =>
-                    setPurchaseCreate((current) => ({ ...current, title: event.target.value }))
-                  }
-                  required
-                />
-              </Label>
-              <Label>
-                소속
-                <PurchaseSelect
-                  value={purchaseCreate.classroomId}
-                  onChange={(event) =>
-                    setPurchaseCreate((current) => ({
-                      ...current,
-                      classroomId: event.target.value,
-                    }))
-                  }
-                  required
-                >
-                  <option value="">소속 선택</option>
-                  {classrooms.map((classroom) => (
-                    <option key={classroom.id} value={classroom.id}>
-                      {classroom.name}
-                    </option>
-                  ))}
-                </PurchaseSelect>
-              </Label>
-              <CreateItemsStack>
-                {purchaseCreate.items.map((item, index) => (
-                  <CreateItemGroup key={item.id}>
-                    <CreateItemTitle>품목 {index + 1}</CreateItemTitle>
-                    <Label>
-                      품목명
-                      <TextInput
-                        value={item.itemName}
-                        onChange={(event) =>
-                          updatePurchaseItem(item.id, "itemName", event.target.value)
-                        }
-                        required
-                      />
-                    </Label>
-                    <Label>
-                      수량
-                      <TextInput
-                        type="number"
-                        min="1"
-                        step="1"
-                        value={item.itemQuantity}
-                        onChange={(event) =>
-                          updatePurchaseItem(item.id, "itemQuantity", event.target.value)
-                        }
-                        required
-                      />
-                    </Label>
-                    <Label>
-                      구매 사유
-                      <TextInput
-                        value={item.itemReason}
-                        onChange={(event) =>
-                          updatePurchaseItem(item.id, "itemReason", event.target.value)
-                        }
-                      />
-                    </Label>
-                    <Label>
-                      결제 유형
-                      <PurchaseSelect
-                        value={item.itemPaymentType}
-                        onChange={(event) =>
-                          updatePurchaseItem(item.id, "itemPaymentType", event.target.value)
-                        }
-                      >
-                        <option value="ACTUAL">실 결제</option>
-                        <option value="PREPAID">선금 결제</option>
-                      </PurchaseSelect>
-                    </Label>
-                    {purchaseCreate.items.length > 1 ? (
-                      <ItemDeleteRow>
-                        <DangerButton type="button" onClick={() => removePurchaseItem(item.id)}>
-                          삭제
-                        </DangerButton>
-                      </ItemDeleteRow>
-                    ) : null}
-                  </CreateItemGroup>
-                ))}
-              </CreateItemsStack>
-              <ButtonRow>
-                <PurchaseActionButton
-                  type="submit"
-                  disabled={createPurchaseMutation.isPending || !canSubmitPurchase}
-                >
-                  작성
-                </PurchaseActionButton>
-                <SmallButton
-                  type="button"
-                  disabled={createPurchaseMutation.isPending}
-                  onClick={addPurchaseItem}
-                >
-                  품목 추가
-                </SmallButton>
-                <SmallButton
-                  type="button"
-                  disabled={createPurchaseMutation.isPending}
-                  onClick={closeCreateModal}
-                >
-                  취소
-                </SmallButton>
-              </ButtonRow>
-            </FormGrid>
-          </ModalDialog>
-        </ModalBackdrop>
-      ) : null}
 
       {confirmAction ? (
         <ModalBackdrop onMouseDown={() => setConfirmAction(null)}>

--- a/components/admin/subject-teachers/useAdminSubjectTeacherAssign.ts
+++ b/components/admin/subject-teachers/useAdminSubjectTeacherAssign.ts
@@ -8,6 +8,7 @@ import type { SubjectDetailResponseDto } from "@/api/subject/subject.dto";
 import { getUsers } from "@/api/user/user.api";
 import type { UserListItemDto } from "@/api/user/user.dto";
 import { getSubjectId } from "@/components/admin/subjects/shared/subjectDisplay";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 
 export function getTeacherUserId(user: UserListItemDto) {
@@ -76,11 +77,8 @@ export function useAdminSubjectTeacherAssign({ subject }: UseAdminSubjectTeacher
       await queryClient.invalidateQueries({ queryKey: queryKeys.admin.subjects() });
     },
     onError: (error) => {
-      const message =
-        error instanceof Error && error.message.trim()
-          ? error.message
-          : "과목 담당 교사 변경에 실패했습니다.";
-      setSubmitError(message);
+      setSubmitError(null);
+      toast.error(extractApiErrorMessage(error, "과목 담당 교사 변경에 실패했습니다."));
     },
   });
 

--- a/components/admin/subjects/create/AdminSubjectCreateForm.tsx
+++ b/components/admin/subjects/create/AdminSubjectCreateForm.tsx
@@ -27,6 +27,7 @@ import {
   validateSubjectCreateForm,
 } from "@/components/admin/subjects/shared/subjectCreateForm";
 import { queryKeys } from "@/lib/queryKeys";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { colors, spacing, typography } from "@/styles/tokens";
 
 const SubjectLabel = styled(Label)`
@@ -180,11 +181,8 @@ export function AdminSubjectCreateForm() {
       setPeriod("1");
     },
     onError: (error) => {
-      const message =
-        error instanceof Error && error.message.trim()
-          ? error.message
-          : "과목 등록에 실패했습니다.";
-      setSubmitError(message);
+      setSubmitError(null);
+      toast.error(extractApiErrorMessage(error, "과목 등록에 실패했습니다."));
     },
   });
 

--- a/components/admin/subjects/detail/subjectDetailForm.ts
+++ b/components/admin/subjects/detail/subjectDetailForm.ts
@@ -10,6 +10,7 @@ import {
   normalizeLessonTimeForApi,
 } from "@/components/admin/lesson-management/lessonCreateError";
 import { compareIsoDates } from "@/components/admin/subjects/shared/subjectCreateForm";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 
 export type SubjectInfoFormValues = {
   name: string;
@@ -103,19 +104,6 @@ export function resolveSubjectMutationError(error: unknown, fallback: string) {
     if (error.response?.status === 409) {
       return "같은 분반에서 운영 기간·요일·교시가 겹치는 다른 과목이 있습니다.";
     }
-
-    const data = error.response?.data;
-    if (data && typeof data === "object" && "message" in data) {
-      const message = data.message;
-      if (typeof message === "string" && message.trim()) {
-        return message;
-      }
-    }
   }
-
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-
-  return fallback;
+  return extractApiErrorMessage(error, fallback);
 }

--- a/components/admin/subjects/detail/useAdminSubjectDetail.ts
+++ b/components/admin/subjects/detail/useAdminSubjectDetail.ts
@@ -139,7 +139,8 @@ export function useAdminSubjectDetail({ subject, onClearSelection }: UseAdminSub
       await invalidateSubjects();
     },
     onError: (error) => {
-      setActionError(resolveSubjectMutationError(error, "과목 수정에 실패했습니다."));
+      setActionError(null);
+      toast.error(resolveSubjectMutationError(error, "과목 수정에 실패했습니다."));
     },
   });
 
@@ -155,7 +156,8 @@ export function useAdminSubjectDetail({ subject, onClearSelection }: UseAdminSub
       await invalidateSubjects();
     },
     onError: (error) => {
-      setActionError(resolveSubjectMutationError(error, "과목 일정 수정에 실패했습니다."));
+      setActionError(null);
+      toast.error(resolveSubjectMutationError(error, "과목 일정 수정에 실패했습니다."));
     },
   });
 
@@ -171,7 +173,8 @@ export function useAdminSubjectDetail({ subject, onClearSelection }: UseAdminSub
       toast.success("과목이 삭제되었습니다.");
     },
     onError: (error) => {
-      setActionError(resolveSubjectMutationError(error, "과목 삭제에 실패했습니다."));
+      setActionError(null);
+      toast.error(resolveSubjectMutationError(error, "과목 삭제에 실패했습니다."));
     },
   });
 

--- a/components/apply/TeacherApplyFormPage.tsx
+++ b/components/apply/TeacherApplyFormPage.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import { createTeacherApplication, getAvailableTeacherSchedules, getMyTeacherApplication } from "@/api/teacherApplication/teacherApplication.api";
 import type { CreateTeacherApplicationRequestDto } from "@/api/teacherApplication/teacherApplication.dto";
@@ -12,6 +13,7 @@ import ApplyLayout from "@/components/apply/ApplyLayout";
 import { toTeacherScheduleOption } from "@/components/apply/teacherApplicationUtils";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, spacing, typography } from "@/styles/tokens";
 import { toBirthDateInputValue } from "@/utils/birthDate";
@@ -133,12 +135,9 @@ export default function TeacherApplyFormPage() {
       router.replace("/apply/status");
     },
     onError: (error) => {
-      const message =
-        error && typeof error === "object" && "message" in error && typeof error.message === "string"
-          ? error.message
-          : "지원서를 제출하지 못했습니다.";
       setSubmitSuccess("");
-      setSubmitError(message);
+      setSubmitError("");
+      toast.error(extractApiErrorMessage(error, "지원서를 제출하지 못했습니다."));
     },
   });
 

--- a/components/auth/MyPage.tsx
+++ b/components/auth/MyPage.tsx
@@ -10,6 +10,7 @@ import { updateCurrentUser } from "@/api/user/user.api";
 import type { UpdateSelfRequestDto, UserResponseDto } from "@/api/user/user.dto";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import {
   formatBirthDate,
@@ -116,8 +117,8 @@ export default function MyPage() {
       await refreshSession();
       setIsEditing(false);
       toast.success("회원 정보를 수정했습니다.");
-    } catch {
-      toast.error("회원 정보 수정에 실패했습니다.");
+    } catch (error) {
+      toast.error(extractApiErrorMessage(error, "회원 정보 수정에 실패했습니다."));
     } finally {
       setIsSaving(false);
     }

--- a/components/home/DesktopHomePage.tsx
+++ b/components/home/DesktopHomePage.tsx
@@ -45,14 +45,14 @@ const Main = styled.main`
 
 const Content = styled.div`
   display: grid;
-  gap: 1.5rem;
+  gap: 2rem;
   width: 100%;
   max-width: ${layout.homeMaxWidth};
   margin: 0 auto;
   padding: ${spacing.space28} ${spacing.space20} ${spacing.space32};
 
   @media (min-width: 120rem) {
-    gap: ${spacing.space40};
+    gap: ${spacing.space47};
     max-width: ${layout.homeMaxWidthLarge};
     padding-top: ${spacing.space46};
     padding-bottom: ${spacing.space47};
@@ -66,7 +66,7 @@ const Content = styled.div`
 const TopRow = styled.div`
   display: grid;
   grid-template-columns: 23.083rem minmax(0, 1fr);
-  gap: 1.9375rem;
+  gap: 2rem;
   min-height: 18.75rem;
 
   @media (min-width: 120rem) {
@@ -83,19 +83,22 @@ const TopRow = styled.div`
 const BottomGrid = styled.div`
   display: grid;
   grid-template-columns: 34.625rem minmax(0, 1fr);
+  grid-template-rows: minmax(18.5rem, auto) minmax(18.5rem, auto);
   grid-template-areas:
     "notice meeting"
     "notice event";
-  align-items: start;
-  gap: 1.5rem 1.9375rem;
+  align-items: stretch;
+  gap: 2rem 2rem;
 
   @media (min-width: 120rem) {
     grid-template-columns: 51.9375rem minmax(0, 1fr);
-    gap: 2.1875rem 2.9375rem;
+    grid-template-rows: minmax(24.5rem, auto) minmax(24.5rem, auto);
+    gap: ${spacing.space47} ${spacing.space47};
   }
 
   @media (max-width: ${layout.breakpointTablet}) {
     grid-template-columns: 1fr;
+    grid-template-rows: none;
     grid-template-areas:
       "notice"
       "meeting"
@@ -113,18 +116,15 @@ const ScheduleArea = styled.div`
 
 const NoticeArea = styled.div`
   grid-area: notice;
+  height: 100%;
 `;
 
 const MeetingArea = styled.div`
   grid-area: meeting;
-  min-height: 19.5rem;
-
-  @media (min-width: 120rem) {
-    min-height: 27.25rem;
-  }
+  height: 100%;
 `;
 
 const EventArea = styled.div`
   grid-area: event;
-  align-self: start;
+  height: 100%;
 `;

--- a/components/home/DesktopHomePage.tsx
+++ b/components/home/DesktopHomePage.tsx
@@ -83,7 +83,7 @@ const TopRow = styled.div`
 const BottomGrid = styled.div`
   display: grid;
   grid-template-columns: 34.625rem minmax(0, 1fr);
-  grid-template-rows: minmax(18.5rem, auto) minmax(18.5rem, auto);
+  grid-template-rows: minmax(15.5rem, auto) minmax(15.5rem, auto);
   grid-template-areas:
     "notice meeting"
     "notice event";
@@ -92,7 +92,7 @@ const BottomGrid = styled.div`
 
   @media (min-width: 120rem) {
     grid-template-columns: 51.9375rem minmax(0, 1fr);
-    grid-template-rows: minmax(24.5rem, auto) minmax(24.5rem, auto);
+    grid-template-rows: minmax(23.5rem, auto) minmax(23.5rem, auto);
     gap: ${spacing.space47} ${spacing.space47};
   }
 

--- a/components/home/EventPhotoCard.tsx
+++ b/components/home/EventPhotoCard.tsx
@@ -101,7 +101,9 @@ export default function EventPhotoCard() {
   );
 }
 
-const Card = styled(HomeCard)``;
+const Card = styled(HomeCard)`
+  height: 100%;
+`;
 
 const PhotoGrid = styled.div`
   display: grid;

--- a/components/home/MeetingRecordsCard.tsx
+++ b/components/home/MeetingRecordsCard.tsx
@@ -66,11 +66,6 @@ export default function MeetingRecordsCard() {
 
 const Card = styled(HomeCard)`
   height: 100%;
-  min-height: 17.5rem;
-
-  @media (min-width: 120rem) {
-    min-height: 24.5rem;
-  }
 `;
 
 const List = styled.div`
@@ -112,8 +107,7 @@ const ListItem = styled.button`
   text-align: left;
   cursor: pointer;
 
-  &:hover ${Title},
-  &:focus-visible ${Title} {
+  &:hover ${Title}, &:focus-visible ${Title} {
     color: ${colors.point};
   }
 

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -60,11 +60,6 @@ export default function NoticeCard() {
 
 const Card = styled(HomeCard)`
   height: 100%;
-  min-height: 17.5rem;
-
-  @media (min-width: 120rem) {
-    min-height: 24.5rem;
-  }
 `;
 
 const List = styled.div`

--- a/components/home/NoticeCard.tsx
+++ b/components/home/NoticeCard.tsx
@@ -44,7 +44,9 @@ export default function NoticeCard() {
       <List>
         {isLoading && <Fallback>공지사항 불러오는 중...</Fallback>}
         {isError && <Fallback>공지사항을 불러오지 못했습니다.</Fallback>}
-        {!isLoading && !isError && notices.length === 0 && <Fallback>공지사항이 없습니다.</Fallback>}
+        {!isLoading && !isError && notices.length === 0 && (
+          <Fallback>공지사항이 없습니다.</Fallback>
+        )}
         {!isLoading &&
           !isError &&
           notices.map((notice, index) => (
@@ -96,8 +98,7 @@ const ListItem = styled(Link)`
   border-bottom: 0.0625rem solid ${colors.border};
   text-decoration: none;
 
-  &:hover ${Title},
-  &:focus-visible ${Title} {
+  &:hover ${Title}, &:focus-visible ${Title} {
     color: ${colors.point};
   }
 

--- a/components/staff/board/BoardCommentSection.tsx
+++ b/components/staff/board/BoardCommentSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconCornerDownRight } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
 import {
@@ -30,6 +30,9 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
   const [openReplyCommentId, setOpenReplyCommentId] = useState<number | null>(null);
   const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
   const [editDraft, setEditDraft] = useState("");
+  const commentTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const commentsQuery = useQuery({
     queryKey: queryKeys.comments.boardDetail(channelId, postId),
@@ -134,6 +137,18 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
     updateCommentMutation.mutate({ commentId, content });
   };
 
+  useEffect(() => {
+    resizeTextarea(commentTextareaRef.current);
+  }, [commentDraft]);
+
+  useEffect(() => {
+    resizeTextarea(replyTextareaRef.current);
+  }, [replyDraft, openReplyCommentId]);
+
+  useEffect(() => {
+    resizeTextarea(editTextareaRef.current);
+  }, [editDraft, editingCommentId]);
+
   return (
     <Section>
       <HeaderRow>
@@ -148,6 +163,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
       </HeaderRow>
 
       <CommentTextarea
+        ref={commentTextareaRef}
         placeholder={isAuthenticated ? "내용" : "로그인 후 댓글을 작성할 수 있습니다."}
         value={commentDraft}
         disabled={!isAuthenticated || createCommentMutation.isPending}
@@ -173,6 +189,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
               {editingCommentId === comment.id ? (
                 <EditWrap>
                   <CommentTextarea
+                    ref={editTextareaRef}
                     placeholder="내용"
                     value={editDraft}
                     disabled={updateCommentMutation.isPending}
@@ -258,6 +275,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
             {openReplyCommentId === comment.id && comment.status !== "DELETED" ? (
               <ReplyComposerWrap>
                 <CommentTextarea
+                  ref={replyTextareaRef}
                   placeholder={isAuthenticated ? "내용" : "로그인 후 댓글을 작성할 수 있습니다."}
                   value={replyDraft}
                   disabled={!isAuthenticated || createCommentMutation.isPending}
@@ -302,6 +320,7 @@ export default function BoardCommentSection({ channelId, postId }: BoardCommentS
                 {editingCommentId === reply.id ? (
                   <EditWrap $isReply>
                     <CommentTextarea
+                      ref={editTextareaRef}
                       placeholder="내용"
                       value={editDraft}
                       disabled={updateCommentMutation.isPending}
@@ -423,6 +442,12 @@ function canManageComment(
   );
 }
 
+function resizeTextarea(element: HTMLTextAreaElement | null) {
+  if (!element) return;
+  element.style.height = "0px";
+  element.style.height = `${element.scrollHeight}px`;
+}
+
 const Section = styled.section`
   display: flex;
   flex-direction: column;
@@ -518,7 +543,8 @@ const CommentTextarea = styled.textarea`
   font: inherit;
   font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
-  resize: vertical;
+  overflow: hidden;
+  resize: none;
 
   &::placeholder {
     color: ${colors.muted};

--- a/components/staff/calendar/StaffCalendarPage.tsx
+++ b/components/staff/calendar/StaffCalendarPage.tsx
@@ -10,6 +10,7 @@ import {
   IconPlus,
   IconX,
 } from "@tabler/icons-react";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import { createEvent, deleteEvent, getAllEvents, updateEvent } from "@/api/event/event.api";
 import type {
@@ -18,6 +19,7 @@ import type {
   UpdateEventRequestDto,
 } from "@/api/event/event.dto";
 import { Button } from "@/components/common/VariantButton";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
@@ -563,7 +565,7 @@ export default function StaffCalendarPage({
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "일정 추가에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "일정 추가에 실패했습니다."));
     },
   });
 
@@ -585,7 +587,7 @@ export default function StaffCalendarPage({
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "일정 수정에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "일정 수정에 실패했습니다."));
     },
   });
 
@@ -601,7 +603,7 @@ export default function StaffCalendarPage({
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
     onError: (error) => {
-      window.alert(error instanceof Error ? error.message : "일정 삭제에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "일정 삭제에 실패했습니다."));
     },
   });
 

--- a/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
+++ b/components/staff/class-management/absence-request/AbsenceRequestForm.tsx
@@ -4,9 +4,11 @@ import { useRef, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { IconCalendarMonth } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import styled, { css } from "styled-components";
 import { createAbsenceRequest } from "@/api/request/request.api";
 import { getCurrentUser } from "@/api/user/user.api";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { parseKoreanShortDateToIsoDate } from "@/utils/kstShortDate";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
@@ -47,8 +49,8 @@ export default function AbsenceRequestForm() {
       router.push("/staff/class-management/absence-request");
       router.refresh();
     },
-    onError: () => {
-      window.alert("결강 신청서 생성에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결강 신청서 생성에 실패했습니다."));
     },
   });
 

--- a/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalCreatePage.tsx
@@ -22,6 +22,7 @@ import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getStudents } from "@/api/student/student.api";
 import { getMyAssignedSubjects } from "@/api/subject/subject.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
 import { formatPhone } from "@/utils/formatPhone";
@@ -213,7 +214,7 @@ export default function ClassJournalCreatePage() {
       router.push("/staff/class-management/class-journal");
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "수업 일지 등록에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "수업 일지 등록에 실패했습니다."));
     },
   });
 

--- a/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
+++ b/components/staff/class-management/weekly-schedule/WeeklySchedulePageClient.tsx
@@ -16,6 +16,7 @@ import {
   formatSubjectDateRange,
   formatSubjectTeacherName,
 } from "@/components/admin/subjects/shared/subjectDisplay";
+import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import {
@@ -310,6 +311,8 @@ function ScheduleTable({
 }
 
 export default function WeeklySchedulePageClient() {
+  const { status: authStatus } = useAuthSession();
+  const isAuthenticated = authStatus === "authenticated";
   const [anchorDate, setAnchorDate] = useState(() => new Date());
   const [selectedCell, setSelectedCell] = useState<ScheduleCellSelection | null>(null);
   const weekRange = useMemo(() => getWeekRange(anchorDate), [anchorDate]);
@@ -318,16 +321,19 @@ export default function WeeklySchedulePageClient() {
   const classroomsQuery = useQuery({
     queryKey: queryKeys.classrooms.list(),
     queryFn: () => getClassrooms({ page: 0, size: 100 }),
+    enabled: isAuthenticated,
   });
 
   const subjectsQuery = useQuery({
     queryKey: queryKeys.admin.subjects(),
     queryFn: () => getSubjects(),
+    enabled: isAuthenticated,
   });
 
   const lessonsQuery = useQuery({
     queryKey: queryKeys.lessons.weekly(weekRange.from, weekRange.to),
     queryFn: () => getLessons({ from: weekRange.from, to: weekRange.to }),
+    enabled: isAuthenticated,
   });
 
   const classrooms = useMemo(
@@ -342,8 +348,10 @@ export default function WeeklySchedulePageClient() {
   const weekdayClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKDAY"));
   const weekendClassrooms = classrooms.filter((classroom) => isClassroomType(classroom, "WEEKEND"));
   const hasClassrooms = weekdayClassrooms.length > 0 || weekendClassrooms.length > 0;
-  const isBaseLoading = classroomsQuery.isLoading || subjectsQuery.isLoading;
-  const isBaseError = classroomsQuery.isError || subjectsQuery.isError;
+  const requiresLogin = authStatus !== "loading" && !isAuthenticated;
+  const isBaseLoading =
+    authStatus === "loading" || (isAuthenticated && (classroomsQuery.isLoading || subjectsQuery.isLoading));
+  const isBaseError = isAuthenticated && (classroomsQuery.isError || subjectsQuery.isError);
 
   const openDatePicker = () => {
     const input = datePickerRef.current;
@@ -402,14 +410,15 @@ export default function WeeklySchedulePageClient() {
       </HeaderRow>
 
       {isBaseLoading ? <StateText>시간표를 불러오는 중입니다.</StateText> : null}
+      {requiresLogin ? <StateText>로그인이 필요합니다.</StateText> : null}
       {isBaseError ? <StateText role="alert">시간표를 불러오지 못했습니다.</StateText> : null}
-      {!isBaseLoading && !isBaseError && lessonsQuery.isError ? (
+      {!requiresLogin && !isBaseLoading && !isBaseError && lessonsQuery.isError ? (
         <StateText role="alert">시간표를 불러오지 못했습니다.</StateText>
       ) : null}
-      {!isBaseLoading && !isBaseError && !hasClassrooms ? (
+      {!requiresLogin && !isBaseLoading && !isBaseError && !hasClassrooms ? (
         <StateText>주중 또는 주말 분반이 없습니다.</StateText>
       ) : null}
-      {!isBaseLoading && !isBaseError && !lessonsQuery.isError && hasClassrooms ? (
+      {!requiresLogin && !isBaseLoading && !isBaseError && !lessonsQuery.isError && hasClassrooms ? (
         <ScheduleShell>
           <ScheduleStack>
             <ScheduleContentTrack>

--- a/components/staff/common/ListPanel.tsx
+++ b/components/staff/common/ListPanel.tsx
@@ -11,6 +11,7 @@ export type ListPanelRow = {
   title: string;
   author: string;
   date: string;
+  extra?: string;
   status: string;
   statusType?:
     | "PENDING"
@@ -43,6 +44,8 @@ type ListPanelProps = {
   writeTone?: ListPanelTone;
   showClassColumn?: boolean;
   classHeader?: string;
+  showExtraColumn?: boolean;
+  extraHeader?: string;
   showStatusColumn?: boolean;
   statusHeader?: string;
   writeIcon?: ReactNode;
@@ -90,6 +93,8 @@ export default function ListPanel({
   writeTone,
   showClassColumn = true,
   classHeader = "반",
+  showExtraColumn = false,
+  extraHeader = "",
   showStatusColumn = true,
   statusHeader = "신청 현황",
   writeIcon,
@@ -108,7 +113,8 @@ export default function ListPanel({
     ...(persistentQuery ?? {}),
     ...(showMineOnlyToggle && mineOnly ? { mineOnly: 1 } : {}),
   };
-  const columnCount = 2 + Number(showClassColumn) + 2 + Number(showStatusColumn);
+  const columnCount =
+    2 + Number(showClassColumn) + 2 + Number(showExtraColumn) + Number(showStatusColumn);
 
   return (
     <Container>
@@ -147,6 +153,11 @@ export default function ListPanel({
               <Th $width720="10.875rem" $width1080="16.3125rem" $tone={headerTone}>
                 작성일
               </Th>
+              {showExtraColumn ? (
+                <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
+                  {extraHeader}
+                </Th>
+              ) : null}
               {showStatusColumn ? (
                 <Th $width720="5rem" $width1080="7.375rem" $tone={headerTone}>
                   {statusHeader}
@@ -183,6 +194,11 @@ export default function ListPanel({
                   <Td $width720="10.875rem" $width1080="16.3125rem">
                     {row.date}
                   </Td>
+                  {showExtraColumn ? (
+                    <Td $width720="5rem" $width1080="7.375rem">
+                      {row.extra ?? "-"}
+                    </Td>
+                  ) : null}
                   {showStatusColumn ? (
                     <Td $width720="5rem" $width1080="7.375rem">
                       <StatusBadge $status={row.statusType}>{row.status}</StatusBadge>

--- a/components/staff/finance-management/FinanceRequestCreatePage.tsx
+++ b/components/staff/finance-management/FinanceRequestCreatePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { IconX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
@@ -15,29 +16,153 @@ import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
 const fallbackVendorNames = ["예소디자인", "목민서관", "지성문구", "마트"] as const;
+const unitBusinessLabel = "프로그램운영비";
+const detailBusinessOptions = ["경상 운영비", "사업 추진비", "기타 운영비", "인건비"] as const;
+const budgetItemReasonOptions = [
+  "교통비",
+  "교재비",
+  "프로그램추진비",
+  "임차료",
+  "홍보비",
+  "기타 운영비",
+] as const;
+const budgetItemNameOptions = [
+  "무급강사교통비",
+  "무급행정담당자 교통비",
+  "시중교재",
+  "제본교재",
+  "(소풍)식비",
+  "행사물품",
+  "현수막",
+  "다과비",
+  "포스터",
+  "소식지",
+  "입간판 및 배너, 스티커 제작",
+  "이체 수수료",
+  "사무용품비",
+  "통신비",
+  "전기비",
+  "수도세",
+  "정수기 필터교체",
+  "청소용품",
+  "프린트토너",
+] as const;
+const paymentAccountOptions = ["국비04", "구비01", "구비08"] as const;
+const customDetailBusinessOptionValue = "__custom_detail_business__";
+
+type PaymentType = "PREPAID" | "ACTUAL";
 
 type FinanceItemForm = {
   id: number;
+  detailBusiness: string;
   name: string;
   quantity: string;
   reason: string;
-  paymentType: "PREPAID" | "ACTUAL";
+  budgetBalance: string;
+  businessBalance: string;
+};
+
+type PrepaidProductForm = {
+  id: number;
+  description: string;
+  specification: string;
+  quantity: string;
+  unitPrice: string;
+  amount: string;
+};
+
+type ApprovalEntry = {
+  position: string;
+  name: string;
 };
 
 type AffiliationOption = {
   id: number;
   label: string;
   value: string;
-  type: "classroom" | "department";
 };
 
 const initialItem: FinanceItemForm = {
   id: 1,
+  detailBusiness: "",
   name: "",
   quantity: "1",
   reason: "",
-  paymentType: "ACTUAL",
+  budgetBalance: "",
+  businessBalance: "",
 };
+
+const initialPrepaidProduct: PrepaidProductForm = {
+  id: 1,
+  description: "",
+  specification: "",
+  quantity: "1",
+  unitPrice: "",
+  amount: "",
+};
+
+const initialApprovalEntries: ApprovalEntry[] = [
+  { position: "총무", name: "" },
+  { position: "교장", name: "정혜웅" },
+  { position: "", name: "" },
+];
+
+const initialCooperationEntries: ApprovalEntry[] = [
+  { position: "", name: "" },
+  { position: "", name: "" },
+  { position: "", name: "" },
+];
+
+function getTodayInputValue() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getPrepaidSummaryTemplate(referenceDate: string) {
+  const month = Number(referenceDate.slice(5, 7)) || new Date().getMonth() + 1;
+  return `${month}월 [ ] 비용을 다음과 같이 지출하고자 합니다.\n\n1. 청구 비용: 0원`;
+}
+
+function parseAmount(value: string) {
+  const normalized = value.replaceAll(",", "").trim();
+  if (!normalized) return 0;
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatCurrency(value: number) {
+  return value > 0 ? `${value.toLocaleString()}원` : "-";
+}
+
+function getPolicyProjectLabel(referenceDate: string) {
+  const year = referenceDate.slice(0, 4) || String(new Date().getFullYear());
+  return `${year}년 성인문해교육 지원사업`;
+}
+
+function isPresetDetailBusiness(value: string) {
+  return detailBusinessOptions.includes(value as (typeof detailBusinessOptions)[number]);
+}
+
+function isPresetBudgetItemReason(value: string) {
+  return budgetItemReasonOptions.includes(value as (typeof budgetItemReasonOptions)[number]);
+}
+
+function isPresetPaymentAccount(value: string) {
+  return paymentAccountOptions.includes(value as (typeof paymentAccountOptions)[number]);
+}
+
+function getApprovalNumber(referenceDate: string, paymentAccount: string) {
+  if (!paymentAccount.trim()) {
+    return "";
+  }
+
+  const year = referenceDate.slice(0, 4) || String(new Date().getFullYear());
+  return `${year}품-${paymentAccount}-01`;
+}
 
 export default function FinanceRequestCreatePage() {
   const router = useRouter();
@@ -45,7 +170,28 @@ export default function FinanceRequestCreatePage() {
   const { user, status: authStatus } = useAuthSession();
   const [title, setTitle] = useState("");
   const [affiliationValue, setAffiliationValue] = useState("");
+  const [paymentType, setPaymentType] = useState<PaymentType>("ACTUAL");
   const [items, setItems] = useState<FinanceItemForm[]>([initialItem]);
+  const [prepaidSummary, setPrepaidSummary] = useState(() =>
+    getPrepaidSummaryTemplate(getTodayInputValue()),
+  );
+  const [paymentAccount, setPaymentAccount] = useState("");
+  const [requestDepartmentId, setRequestDepartmentId] = useState("");
+  const [approvalDate, setApprovalDate] = useState(getTodayInputValue);
+  const [detailBusiness, setDetailBusiness] = useState<string>("");
+  const [customFieldModal, setCustomFieldModal] = useState<{
+    field: "topDetailBusiness" | "budgetReason" | "budgetName" | "paymentAccount";
+    itemId?: number;
+  } | null>(null);
+  const [customFieldDraft, setCustomFieldDraft] = useState("");
+  const [approvalAmount, setApprovalAmount] = useState("");
+  const [prepaidProducts, setPrepaidProducts] = useState<PrepaidProductForm[]>([
+    initialPrepaidProduct,
+  ]);
+  const [approvalEntries, setApprovalEntries] = useState<ApprovalEntry[]>(initialApprovalEntries);
+  const [cooperationEntries, setCooperationEntries] =
+    useState<ApprovalEntry[]>(initialCooperationEntries);
+  const previousApplicantNameRef = useRef("");
 
   const { data: classroomData } = useQuery({
     queryKey: ["classrooms", "finance-request-create"],
@@ -66,27 +212,22 @@ export default function FinanceRequestCreatePage() {
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
   const departments = useMemo(() => departmentData?.departments ?? [], [departmentData]);
   const affiliationOptions = useMemo<AffiliationOption[]>(
-    () => [
-      ...classrooms
+    () =>
+      classrooms
         .filter((classroom) => typeof classroom.id === "number")
         .map((classroom) => ({
           id: classroom.id as number,
           label: classroom.name ?? `반 ${classroom.id}`,
           value: `classroom:${classroom.id}`,
-          type: "classroom" as const,
         })),
-      ...departments
-        .filter((department) => typeof department.id === "number")
-        .map((department) => ({
-          id: department.id as number,
-          label: department.name ?? `부서 ${department.id}`,
-          value: `department:${department.id}`,
-          type: "department" as const,
-        })),
-    ],
-    [classrooms, departments],
+    [classrooms],
   );
-  const selectedAffiliation = affiliationOptions.find((option) => option.value === affiliationValue);
+  const selectedAffiliation = affiliationOptions.find(
+    (option) => option.value === affiliationValue,
+  );
+  const selectedDepartment = departments.find(
+    (department) => String(department.id) === requestDepartmentId,
+  );
   const vendorBalances = useMemo(
     () =>
       vendorData?.length
@@ -97,6 +238,21 @@ export default function FinanceRequestCreatePage() {
         : fallbackVendorNames.map((name) => ({ name, balance: undefined })),
     [vendorData],
   );
+  const approvalNumber = useMemo(
+    () => getApprovalNumber(approvalDate, paymentAccount),
+    [approvalDate, paymentAccount],
+  );
+
+  useEffect(() => {
+    if (paymentType !== "PREPAID") {
+      return;
+    }
+
+    setItems((current) => {
+      const firstItem = current[0] ?? initialItem;
+      return [{ ...firstItem, quantity: "1" }];
+    });
+  }, [paymentType]);
 
   const mutation = useMutation({
     mutationFn: (body: CreatePurchaseRequestDto) => createPurchaseRequest(body),
@@ -108,12 +264,51 @@ export default function FinanceRequestCreatePage() {
 
   const normalizedItems = items
     .map((item) => ({
+      detailBusiness: item.detailBusiness.trim() || undefined,
       name: item.name.trim(),
-      quantity: item.quantity.trim().length > 0 ? Number(item.quantity) : undefined,
+      quantity:
+        paymentType === "PREPAID"
+          ? 1
+          : item.quantity.trim().length > 0
+            ? Number(item.quantity)
+            : undefined,
       reason: item.reason.trim() || undefined,
-      paymentType: item.paymentType,
     }))
     .filter((item) => item.name.length > 0);
+
+  const normalizedPrepaidProducts = prepaidProducts
+    .map((item) => ({
+      description: item.description.trim(),
+      specification: item.specification.trim(),
+      quantity: parseAmount(item.quantity),
+      unitPrice: parseAmount(item.unitPrice),
+      amount: parseAmount(item.amount),
+    }))
+    .filter(
+      (item) =>
+        item.description.length > 0 ||
+        item.specification.length > 0 ||
+        item.quantity > 0 ||
+        item.unitPrice > 0 ||
+        item.amount > 0,
+    );
+
+  const quantityTotal = normalizedPrepaidProducts.reduce((sum, item) => sum + item.quantity, 0);
+  const unitPriceTotal = normalizedPrepaidProducts.reduce((sum, item) => sum + item.unitPrice, 0);
+  const amountTotal = normalizedPrepaidProducts.reduce((sum, item) => sum + item.amount, 0);
+  const approvalAmountValue = parseAmount(approvalAmount);
+  const budgetBalanceTotal = items.reduce((sum, item) => sum + parseAmount(item.budgetBalance), 0);
+  const businessBalanceTotal = items.reduce(
+    (sum, item) => sum + parseAmount(item.businessBalance),
+    0,
+  );
+
+  const canSubmitPrepaid =
+    prepaidSummary.trim().length > 0 &&
+    requestDepartmentId.length > 0 &&
+    approvalDate.length > 0 &&
+    detailBusiness.length > 0 &&
+    approvalAmountValue > 0;
 
   const canSubmit =
     title.trim().length > 0 &&
@@ -127,14 +322,61 @@ export default function FinanceRequestCreatePage() {
         item.quantity < 1 ||
         !Number.isInteger(item.quantity),
     ) &&
+    (paymentType === "PREPAID" ? canSubmitPrepaid : true) &&
     !mutation.isPending;
 
   const applicantName =
-    authStatus === "authenticated"
-      ? (user?.name ?? user?.nickname ?? user?.email ?? "이름 정보 없음")
-      : authStatus === "loading"
-        ? "사용자 확인 중"
-        : "로그인 필요";
+    user?.name ??
+    user?.nickname ??
+    user?.email ??
+    (authStatus === "loading"
+      ? "사용자 확인 중"
+      : authStatus === "unauthenticated" || authStatus === "error"
+        ? "로그인 필요"
+        : "이름 정보 없음");
+  const applicantNameForApproval =
+    applicantName === "사용자 확인 중" ||
+    applicantName === "로그인 필요" ||
+    applicantName === "이름 정보 없음"
+      ? ""
+      : applicantName;
+
+  useEffect(() => {
+    setApprovalEntries((current) =>
+      current.map((entry, index) => {
+        if (index === 0) {
+          const shouldUpdateName = !entry.name || entry.name === previousApplicantNameRef.current;
+
+          return {
+            position: entry.position || "총무",
+            name: shouldUpdateName ? applicantNameForApproval : entry.name,
+          };
+        }
+
+        if (index === 1) {
+          return {
+            position: entry.position || "교장",
+            name: entry.name || "정혜웅",
+          };
+        }
+
+        return entry;
+      }),
+    );
+
+    previousApplicantNameRef.current = applicantNameForApproval;
+  }, [applicantNameForApproval]);
+
+  useEffect(() => {
+    const nextPosition =
+      selectedDepartment?.name && selectedDepartment.name !== "총무부"
+        ? `${selectedDepartment.name}장`
+        : "";
+
+    setCooperationEntries((current) =>
+      current.map((entry, index) => (index === 0 ? { ...entry, position: nextPosition } : entry)),
+    );
+  }, [selectedDepartment?.name]);
 
   function updateItem(itemId: number, patch: Partial<FinanceItemForm>) {
     setItems((current) =>
@@ -143,6 +385,10 @@ export default function FinanceRequestCreatePage() {
   }
 
   function addItem() {
+    if (paymentType === "PREPAID") {
+      return;
+    }
+
     setItems((current) => [
       ...current,
       {
@@ -161,6 +407,177 @@ export default function FinanceRequestCreatePage() {
     });
   }
 
+  function updatePrepaidProduct(itemId: number, patch: Partial<PrepaidProductForm>) {
+    setPrepaidProducts((current) =>
+      current.map((item) => (item.id === itemId ? { ...item, ...patch } : item)),
+    );
+  }
+
+  function updatePrepaidProductCalculated(
+    itemId: number,
+    field: "quantity" | "unitPrice",
+    value: string,
+  ) {
+    setPrepaidProducts((current) =>
+      current.map((item) => {
+        if (item.id !== itemId) {
+          return item;
+        }
+
+        const next = { ...item, [field]: value };
+        const quantity = parseAmount(next.quantity);
+        const unitPrice = parseAmount(next.unitPrice);
+
+        return {
+          ...next,
+          amount: quantity > 0 && unitPrice > 0 ? String(quantity * unitPrice) : "",
+        };
+      }),
+    );
+  }
+
+  function updateApprovalEntry(
+    kind: "approval" | "cooperation",
+    index: number,
+    patch: Partial<ApprovalEntry>,
+  ) {
+    const setter = kind === "approval" ? setApprovalEntries : setCooperationEntries;
+
+    setter((current) =>
+      current.map((entry, entryIndex) => (entryIndex === index ? { ...entry, ...patch } : entry)),
+    );
+  }
+
+  function openCustomFieldModal(
+    field: "topDetailBusiness" | "budgetReason" | "budgetName" | "paymentAccount",
+    itemId?: number,
+  ) {
+    const currentItem = itemId != null ? items.find((item) => item.id === itemId) : undefined;
+    const draft =
+      field === "topDetailBusiness"
+        ? isPresetDetailBusiness(detailBusiness)
+          ? ""
+          : detailBusiness
+        : field === "paymentAccount"
+          ? isPresetPaymentAccount(paymentAccount)
+            ? ""
+            : paymentAccount
+          : field === "budgetReason"
+            ? (currentItem?.reason ?? "")
+            : (currentItem?.name ?? "");
+
+    setCustomFieldDraft(draft);
+    setCustomFieldModal({ field, itemId });
+  }
+
+  function closeCustomFieldModal() {
+    setCustomFieldModal(null);
+    setCustomFieldDraft("");
+  }
+
+  function confirmCustomFieldModal() {
+    const nextValue = customFieldDraft.trim();
+
+    if (!nextValue || !customFieldModal) {
+      return;
+    }
+
+    if (customFieldModal.field === "topDetailBusiness") {
+      setDetailBusiness(nextValue);
+    }
+
+    if (customFieldModal.field === "paymentAccount") {
+      setPaymentAccount(nextValue);
+    }
+
+    if (customFieldModal.field === "budgetReason" && customFieldModal.itemId != null) {
+      updateItem(customFieldModal.itemId, { reason: nextValue, name: "" });
+    }
+
+    if (customFieldModal.field === "budgetName" && customFieldModal.itemId != null) {
+      updateItem(customFieldModal.itemId, { name: nextValue, quantity: "1" });
+    }
+
+    setCustomFieldModal(null);
+    setCustomFieldDraft("");
+  }
+
+  function addPrepaidProduct() {
+    setPrepaidProducts((current) => [
+      ...current,
+      {
+        ...initialPrepaidProduct,
+        id: Math.max(...current.map((item) => item.id)) + 1,
+      },
+    ]);
+  }
+
+  function removePrepaidProduct(itemId: number) {
+    setPrepaidProducts((current) => {
+      if (current.length <= 1) {
+        return [{ ...initialPrepaidProduct, id: current[0]?.id ?? 1 }];
+      }
+      return current.filter((item) => item.id !== itemId);
+    });
+  }
+
+  function buildActualContent() {
+    const itemContent = normalizedItems
+      .map((item, index) => {
+        const reason = item.reason ? ` - ${item.reason}` : "";
+        const quantity = typeof item.quantity === "number" ? ` ${item.quantity}개` : "";
+        const paymentTypeLabel = paymentType === "PREPAID" ? "선금 결제" : "실 결제";
+
+        return `${index + 1}. ${item.name}${quantity} / ${paymentTypeLabel}${reason}`;
+      })
+      .join("\n");
+
+    return `분반: ${selectedAffiliation?.label ?? "-"}\n신청자: ${applicantName}\n결제 유형: 실 결제\n\n${itemContent}`;
+  }
+
+  function buildPrepaidContent() {
+    const budgetContent = normalizedItems
+      .map(
+        (item, index) =>
+          `${index + 1}. 세부사업: ${item.detailBusiness || detailBusiness || "-"} / 세부 항목: ${item.reason ?? "-"} / 산출 내역: ${item.name}`,
+      )
+      .join("\n");
+    const productContent =
+      normalizedPrepaidProducts.length > 0
+        ? normalizedPrepaidProducts
+            .map(
+              (item, index) =>
+                `${index + 1}. 내용: ${item.description || "-"} / 규격: ${item.specification || "-"} / 수량: ${item.quantity || 0} / 예상 단가: ${item.unitPrice || 0} / 예상 금액: ${item.amount || 0}`,
+            )
+            .join("\n")
+        : "없음";
+
+    return [
+      `분반: ${selectedAffiliation?.label ?? "-"}`,
+      `신청자: ${applicantName}`,
+      "결제 유형: 선금 결제",
+      "",
+      `[품의 번호]`,
+      `품의 번호: ${approvalNumber || "-"}`,
+      `결제 통장: ${paymentAccount || "-"}`,
+      "",
+      `[품의 개요]`,
+      prepaidSummary.trim(),
+      `정책 사업: ${getPolicyProjectLabel(approvalDate)}`,
+      `요구 부서: ${selectedDepartment?.name ?? "-"}`,
+      `단위 사업: ${unitBusinessLabel}`,
+      `품의 일자: ${approvalDate}`,
+      `세부 사업: ${detailBusiness}`,
+      `품의 금액: ${approvalAmountValue.toLocaleString()}원`,
+      "",
+      `[예산 내역]`,
+      budgetContent,
+      "",
+      `[품목 내역]`,
+      productContent,
+    ].join("\n");
+  }
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -170,27 +587,15 @@ export default function FinanceRequestCreatePage() {
       return;
     }
 
-    const itemContent = normalizedItems
-      .map((item, index) => {
-        const reason = item.reason ? ` - ${item.reason}` : "";
-        const quantity = typeof item.quantity === "number" ? ` ${item.quantity}개` : "";
-        const paymentType = item.paymentType === "PREPAID" ? "선금 결제" : "실 결제";
-
-        return `${index + 1}. ${item.name}${quantity} / ${paymentType}${reason}`;
-      })
-      .join("\n");
-
     mutation.mutate({
       title: title.trim(),
-      content: `소속: ${selectedOption.label}\n신청자: ${applicantName}\n\n${itemContent}`,
-      ...(selectedOption.type === "classroom"
-        ? { classroomId: selectedOption.id }
-        : { departmentId: selectedOption.id }),
+      content: paymentType === "PREPAID" ? buildPrepaidContent() : buildActualContent(),
+      classroomId: selectedOption.id,
       items: normalizedItems.map((item) => ({
         name: item.name,
-        quantity: item.quantity ?? 1,
+        quantity: paymentType === "PREPAID" ? 1 : (item.quantity ?? 1),
         reason: item.reason,
-        paymentType: item.paymentType,
+        paymentType,
       })),
     });
   }
@@ -224,7 +629,7 @@ export default function FinanceRequestCreatePage() {
             <Section>
               <SectionTitle>신청자 정보</SectionTitle>
               <InfoRow>
-                <FieldLabel htmlFor="affiliation">소속</FieldLabel>
+                <FieldLabel htmlFor="affiliation">분반</FieldLabel>
                 <InlineSelect
                   id="affiliation"
                   name="affiliation"
@@ -232,7 +637,7 @@ export default function FinanceRequestCreatePage() {
                   onChange={(event) => setAffiliationValue(event.target.value)}
                   required
                 >
-                  <option value="">소속 선택</option>
+                  <option value="">분반 선택</option>
                   {affiliationOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
@@ -242,6 +647,40 @@ export default function FinanceRequestCreatePage() {
                 <FieldLabel htmlFor="applicant">신청자</FieldLabel>
                 <InlineInput id="applicant" name="applicant" value={applicantName} readOnly />
               </InfoRow>
+            </Section>
+
+            <Section>
+              <SectionTitle>결제 유형</SectionTitle>
+              <PaymentTypeGroup>
+                <PaymentTypeOption>
+                  <input
+                    type="checkbox"
+                    name="paymentType"
+                    value="PREPAID"
+                    checked={paymentType === "PREPAID"}
+                    onChange={(event) => {
+                      if (event.target.checked) {
+                        setPaymentType("PREPAID");
+                      }
+                    }}
+                  />
+                  <span>선금 결제</span>
+                </PaymentTypeOption>
+                <PaymentTypeOption>
+                  <input
+                    type="checkbox"
+                    name="paymentType"
+                    value="ACTUAL"
+                    checked={paymentType === "ACTUAL"}
+                    onChange={(event) => {
+                      if (event.target.checked) {
+                        setPaymentType("ACTUAL");
+                      }
+                    }}
+                  />
+                  <span>실 결제</span>
+                </PaymentTypeOption>
+              </PaymentTypeGroup>
             </Section>
 
             <Section>
@@ -262,100 +701,568 @@ export default function FinanceRequestCreatePage() {
               </VendorBalanceTable>
             </Section>
 
-            <Section>
-              <SectionTitle>상세 품목</SectionTitle>
-              <ItemList>
-                {items.map((item, index) => (
-                  <ItemBlock key={item.id}>
-                    <ItemFieldRow>
-                      <ItemLabel htmlFor={`itemName-${item.id}`}>품목 {index + 1}</ItemLabel>
-                      <ItemInput
-                        id={`itemName-${item.id}`}
-                        name={`itemName-${item.id}`}
-                        placeholder="품목"
-                        value={item.name}
-                        onChange={(event) => updateItem(item.id, { name: event.target.value })}
-                        required={index === 0}
-                      />
-                    </ItemFieldRow>
-                    <ItemFieldRow>
-                      <ItemLabel htmlFor={`quantity-${item.id}`}>개수</ItemLabel>
-                      <ItemInput
-                        id={`quantity-${item.id}`}
-                        name={`quantity-${item.id}`}
-                        type="number"
-                        min="1"
-                        step="1"
-                        inputMode="numeric"
-                        placeholder="1"
-                        value={item.quantity}
-                        onChange={(event) => updateItem(item.id, { quantity: event.target.value })}
-                      />
-                    </ItemFieldRow>
-                    <ItemFieldRow>
-                      <ItemLabel htmlFor={`paymentReason-${item.id}`}>결제 사유</ItemLabel>
-                      <ItemInput
-                        id={`paymentReason-${item.id}`}
-                        name={`paymentReason-${item.id}`}
-                        placeholder="결제 사유"
-                        value={item.reason}
-                        onChange={(event) => updateItem(item.id, { reason: event.target.value })}
-                      />
-                    </ItemFieldRow>
-                    <ItemFieldRow>
-                      <ItemLabel>결제 유형</ItemLabel>
-                      <PaymentTypeGroup>
-                        <PaymentTypeOption>
-                          <input
-                            type="checkbox"
-                            name={`paymentType-${item.id}`}
-                            value="PREPAID"
-                            checked={item.paymentType === "PREPAID"}
-                            onChange={(event) => {
-                              if (event.target.checked) {
-                                updateItem(item.id, { paymentType: "PREPAID" });
-                              }
-                            }}
-                          />
-                          <span>선금 결제</span>
-                        </PaymentTypeOption>
-                        <PaymentTypeOption>
-                          <input
-                            type="checkbox"
-                            name={`paymentType-${item.id}`}
-                            value="ACTUAL"
-                            checked={item.paymentType === "ACTUAL"}
-                            onChange={(event) => {
-                              if (event.target.checked) {
-                                updateItem(item.id, { paymentType: "ACTUAL" });
-                              }
-                            }}
-                          />
-                          <span>실 결제</span>
-                        </PaymentTypeOption>
-                      </PaymentTypeGroup>
-                    </ItemFieldRow>
-                    {items.length > 1 ? (
-                      <ItemActionRow>
-                        <DeleteItemButton type="button" onClick={() => removeItem(item.id)}>
-                          품목 삭제
-                        </DeleteItemButton>
-                      </ItemActionRow>
-                    ) : null}
-                  </ItemBlock>
-                ))}
-              </ItemList>
+            {paymentType === "PREPAID" ? (
+              <>
+                <Section>
+                  <SectionTitle>품의 번호</SectionTitle>
+                  <ApprovalNumberRow>
+                    <ApprovalNumberInput value={approvalNumber} readOnly />
+                    <ApprovalNumberSelect
+                      value={paymentAccount}
+                      onChange={(event) => {
+                        if (event.target.value === customDetailBusinessOptionValue) {
+                          openCustomFieldModal("paymentAccount");
+                          return;
+                        }
 
-              <AddItemButton type="button" onClick={addItem}>
-                품목 추가하기
-              </AddItemButton>
-              {mutation.isError ? (
-                <StatusMessage role="alert">결제 신청서 제출에 실패했습니다.</StatusMessage>
-              ) : null}
-            </Section>
+                        setPaymentAccount(event.target.value);
+                      }}
+                    >
+                      <option value="">결제 통장 선택</option>
+                      {paymentAccountOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                      {!isPresetPaymentAccount(paymentAccount) && paymentAccount ? (
+                        <option value={paymentAccount}>{paymentAccount}</option>
+                      ) : null}
+                      <option value={customDetailBusinessOptionValue}>직접 입력</option>
+                    </ApprovalNumberSelect>
+                  </ApprovalNumberRow>
+                </Section>
+
+                <Section>
+                  <SectionTitle>품의 개요</SectionTitle>
+                  <ResponsiveTableWrap>
+                    <SummaryTable>
+                      <tbody>
+                        <tr>
+                          <SummaryLabelCell>품의 개요</SummaryLabelCell>
+                          <SummaryWideCell colSpan={3}>
+                            <SummaryTextarea
+                              value={prepaidSummary}
+                              onChange={(event) => setPrepaidSummary(event.target.value)}
+                              placeholder="품의 개요를 입력해 주세요."
+                              required
+                            />
+                          </SummaryWideCell>
+                        </tr>
+                        <tr>
+                          <SummaryLabelCell>정책 사업</SummaryLabelCell>
+                          <SummaryValueCell>{getPolicyProjectLabel(approvalDate)}</SummaryValueCell>
+                          <SummaryLabelCell>요구 부서</SummaryLabelCell>
+                          <SummaryValueCell>
+                            <SummarySelect
+                              value={requestDepartmentId}
+                              onChange={(event) => setRequestDepartmentId(event.target.value)}
+                              required
+                            >
+                              <option value="">부서 선택</option>
+                              {departments.map((department) => (
+                                <option key={department.id} value={department.id}>
+                                  {department.name ?? `부서 ${department.id}`}
+                                </option>
+                              ))}
+                            </SummarySelect>
+                          </SummaryValueCell>
+                        </tr>
+                        <tr>
+                          <SummaryLabelCell>단위 사업</SummaryLabelCell>
+                          <SummaryValueCell>{unitBusinessLabel}</SummaryValueCell>
+                          <SummaryLabelCell>품의 일자</SummaryLabelCell>
+                          <SummaryValueCell>
+                            <SummaryInput
+                              type="date"
+                              value={approvalDate}
+                              onChange={(event) => setApprovalDate(event.target.value)}
+                              required
+                            />
+                          </SummaryValueCell>
+                        </tr>
+                        <tr>
+                          <SummaryLabelCell>세부 사업</SummaryLabelCell>
+                          <SummaryValueCell>
+                            <SummarySelect
+                              value={detailBusiness}
+                              onChange={(event) => {
+                                if (event.target.value === customDetailBusinessOptionValue) {
+                                  openCustomFieldModal("topDetailBusiness");
+                                  return;
+                                }
+
+                                setDetailBusiness(event.target.value);
+                              }}
+                            >
+                              <option value="">세부 사업 선택</option>
+                              {detailBusinessOptions.map((option) => (
+                                <option key={option} value={option}>
+                                  {option}
+                                </option>
+                              ))}
+                              {!isPresetDetailBusiness(detailBusiness) && detailBusiness ? (
+                                <option value={detailBusiness}>{detailBusiness}</option>
+                              ) : null}
+                              <option value={customDetailBusinessOptionValue}>직접 입력</option>
+                            </SummarySelect>
+                          </SummaryValueCell>
+                          <SummaryLabelCell>품의 금액</SummaryLabelCell>
+                          <SummaryValueCell>
+                            <SummaryInput
+                              type="number"
+                              min="0"
+                              inputMode="numeric"
+                              value={approvalAmount}
+                              onChange={(event) => setApprovalAmount(event.target.value)}
+                              placeholder="0"
+                              required
+                            />
+                          </SummaryValueCell>
+                        </tr>
+                      </tbody>
+                    </SummaryTable>
+                  </ResponsiveTableWrap>
+                </Section>
+
+                <Section>
+                  <SectionTitle>예산 내역</SectionTitle>
+                  <ResponsiveTableWrap>
+                    <BudgetTable>
+                      <thead>
+                        <tr>
+                          <BudgetHeadCell>순번</BudgetHeadCell>
+                          <BudgetHeadCell>세부 사업</BudgetHeadCell>
+                          <BudgetHeadCell>세부 항목</BudgetHeadCell>
+                          <BudgetHeadCell>산출 내역</BudgetHeadCell>
+                          <BudgetHeadCell>품의 금액</BudgetHeadCell>
+                          <BudgetHeadCell>예산 잔액</BudgetHeadCell>
+                          <BudgetHeadCell>사업 잔액</BudgetHeadCell>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {items.map((item, index) => (
+                          <tr key={item.id}>
+                            <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                value={item.detailBusiness || detailBusiness}
+                                placeholder="세부 사업"
+                                readOnly
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineSelect
+                                value={item.reason}
+                                onChange={(event) => {
+                                  if (event.target.value === customDetailBusinessOptionValue) {
+                                    openCustomFieldModal("budgetReason", item.id);
+                                    return;
+                                  }
+
+                                  const nextReason = event.target.value;
+                                  updateItem(item.id, {
+                                    reason: nextReason,
+                                  });
+                                }}
+                              >
+                                <option value="">세부 항목</option>
+                                {budgetItemReasonOptions.map((option) => (
+                                  <option key={`${item.id}-reason-${option}`} value={option}>
+                                    {option}
+                                  </option>
+                                ))}
+                                {!isPresetBudgetItemReason(item.reason) && item.reason ? (
+                                  <option value={item.reason}>{item.reason}</option>
+                                ) : null}
+                                <option value={customDetailBusinessOptionValue}>직접 입력</option>
+                              </BudgetInlineSelect>
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineSelect
+                                value={item.name}
+                                onChange={(event) => {
+                                  if (event.target.value === customDetailBusinessOptionValue) {
+                                    openCustomFieldModal("budgetName", item.id);
+                                    return;
+                                  }
+
+                                  updateItem(item.id, {
+                                    name: event.target.value,
+                                    quantity: "1",
+                                  });
+                                }}
+                                required={index === 0}
+                              >
+                                <option value="">산출 내역</option>
+                                {budgetItemNameOptions.map((option) => (
+                                  <option key={`${item.id}-name-${option}`} value={option}>
+                                    {option}
+                                  </option>
+                                ))}
+                                {item.name &&
+                                !budgetItemNameOptions.some((option) => option === item.name) ? (
+                                  <option value={item.name}>{item.name}</option>
+                                ) : null}
+                                <option value={customDetailBusinessOptionValue}>직접 입력</option>
+                              </BudgetInlineSelect>
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                type="number"
+                                min="0"
+                                inputMode="numeric"
+                                value={approvalAmount}
+                                onChange={(event) => setApprovalAmount(event.target.value)}
+                                placeholder="0"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                type="number"
+                                min="0"
+                                inputMode="numeric"
+                                value={item.budgetBalance}
+                                onChange={(event) =>
+                                  updateItem(item.id, { budgetBalance: event.target.value })
+                                }
+                                placeholder="0"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                type="number"
+                                min="0"
+                                inputMode="numeric"
+                                value={item.businessBalance}
+                                onChange={(event) =>
+                                  updateItem(item.id, { businessBalance: event.target.value })
+                                }
+                                placeholder="0"
+                              />
+                            </BudgetBodyCell>
+                          </tr>
+                        ))}
+                        <tr>
+                          <BudgetTotalLabelCell colSpan={4}>합계</BudgetTotalLabelCell>
+                          <BudgetTotalValueCell>
+                            {formatCurrency(approvalAmountValue)}
+                          </BudgetTotalValueCell>
+                          <BudgetTotalValueCell>
+                            {formatCurrency(budgetBalanceTotal)}
+                          </BudgetTotalValueCell>
+                          <BudgetTotalValueCell>
+                            {formatCurrency(businessBalanceTotal)}
+                          </BudgetTotalValueCell>
+                        </tr>
+                      </tbody>
+                    </BudgetTable>
+                  </ResponsiveTableWrap>
+                </Section>
+
+                <Section>
+                  <SectionTitle>품목 내역</SectionTitle>
+                  <ResponsiveTableWrap>
+                    <BudgetTable>
+                      <thead>
+                        <tr>
+                          <BudgetHeadCell>순번</BudgetHeadCell>
+                          <BudgetHeadCell>내용</BudgetHeadCell>
+                          <BudgetHeadCell>규격</BudgetHeadCell>
+                          <BudgetHeadCell>수량</BudgetHeadCell>
+                          <BudgetHeadCell>예상 단가</BudgetHeadCell>
+                          <BudgetHeadCell>예상 금액</BudgetHeadCell>
+                          {prepaidProducts.length > 1 ? (
+                            <BudgetHeadCell>삭제</BudgetHeadCell>
+                          ) : null}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {prepaidProducts.map((product, index) => (
+                          <tr key={product.id}>
+                            <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                value={product.description}
+                                onChange={(event) =>
+                                  updatePrepaidProduct(product.id, {
+                                    description: event.target.value,
+                                  })
+                                }
+                                placeholder="내용"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                value={product.specification}
+                                onChange={(event) =>
+                                  updatePrepaidProduct(product.id, {
+                                    specification: event.target.value,
+                                  })
+                                }
+                                placeholder="규격"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                type="number"
+                                min="0"
+                                inputMode="numeric"
+                                value={product.quantity}
+                                onChange={(event) =>
+                                  updatePrepaidProductCalculated(
+                                    product.id,
+                                    "quantity",
+                                    event.target.value,
+                                  )
+                                }
+                                placeholder="0"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput
+                                type="number"
+                                min="0"
+                                inputMode="numeric"
+                                value={product.unitPrice}
+                                onChange={(event) =>
+                                  updatePrepaidProductCalculated(
+                                    product.id,
+                                    "unitPrice",
+                                    event.target.value,
+                                  )
+                                }
+                                placeholder="0"
+                              />
+                            </BudgetBodyCell>
+                            <BudgetBodyCell>
+                              <BudgetInlineInput value={product.amount} readOnly placeholder="0" />
+                            </BudgetBodyCell>
+                            {prepaidProducts.length > 1 ? (
+                              <BudgetBodyCell>
+                                <MiniDeleteButton
+                                  type="button"
+                                  aria-label={`${index + 1}번 품목 삭제`}
+                                  onClick={() => removePrepaidProduct(product.id)}
+                                >
+                                  <IconX aria-hidden="true" size={16} stroke={2.4} />
+                                </MiniDeleteButton>
+                              </BudgetBodyCell>
+                            ) : null}
+                          </tr>
+                        ))}
+                        <tr>
+                          <BudgetTotalLabelCell colSpan={3}>합계</BudgetTotalLabelCell>
+                          <BudgetTotalValueCell>
+                            {quantityTotal.toLocaleString()}
+                          </BudgetTotalValueCell>
+                          <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                          <BudgetTotalValueCell>
+                            {amountTotal.toLocaleString()}
+                          </BudgetTotalValueCell>
+                          {prepaidProducts.length > 1 ? <BudgetBodyCell>-</BudgetBodyCell> : null}
+                        </tr>
+                      </tbody>
+                    </BudgetTable>
+                  </ResponsiveTableWrap>
+                  <AddItemButton type="button" onClick={addPrepaidProduct}>
+                    품목 추가하기
+                  </AddItemButton>
+                </Section>
+
+                <Section>
+                  <SectionTitle>결재 & 협조</SectionTitle>
+                  <ResponsiveTableWrap>
+                    <ApprovalTable>
+                      <tbody>
+                        <tr>
+                          <ApprovalTypeCell rowSpan={2}>결재</ApprovalTypeCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                        </tr>
+                        <tr>
+                          {approvalEntries.map((entry, index) => (
+                            <Fragment key={`approval-${index}`}>
+                              <ApprovalBodyCell>
+                                <ApprovalEditableInput
+                                  value={entry.position}
+                                  onChange={(event) =>
+                                    updateApprovalEntry("approval", index, {
+                                      position: event.target.value,
+                                    })
+                                  }
+                                  placeholder="직위"
+                                />
+                              </ApprovalBodyCell>
+                              <ApprovalBodyCell>
+                                <ApprovalEditableInput
+                                  value={entry.name}
+                                  onChange={(event) =>
+                                    updateApprovalEntry("approval", index, {
+                                      name: event.target.value,
+                                    })
+                                  }
+                                  placeholder="이름"
+                                />
+                              </ApprovalBodyCell>
+                            </Fragment>
+                          ))}
+                        </tr>
+                        <tr>
+                          <ApprovalTypeCell rowSpan={2}>협조</ApprovalTypeCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                          <ApprovalHeadCell>직위</ApprovalHeadCell>
+                          <ApprovalHeadCell>이름</ApprovalHeadCell>
+                        </tr>
+                        <tr>
+                          {cooperationEntries.map((entry, index) => (
+                            <Fragment key={`cooperation-${index}`}>
+                              <ApprovalBodyCell>
+                                <ApprovalEditableInput
+                                  value={entry.position}
+                                  onChange={(event) =>
+                                    updateApprovalEntry("cooperation", index, {
+                                      position: event.target.value,
+                                    })
+                                  }
+                                  placeholder="직위"
+                                />
+                              </ApprovalBodyCell>
+                              <ApprovalBodyCell>
+                                <ApprovalEditableInput
+                                  value={entry.name}
+                                  onChange={(event) =>
+                                    updateApprovalEntry("cooperation", index, {
+                                      name: event.target.value,
+                                    })
+                                  }
+                                  placeholder="이름"
+                                />
+                              </ApprovalBodyCell>
+                            </Fragment>
+                          ))}
+                        </tr>
+                      </tbody>
+                    </ApprovalTable>
+                  </ResponsiveTableWrap>
+                </Section>
+              </>
+            ) : (
+              <Section>
+                <SectionTitle>상세 품목</SectionTitle>
+                <ItemList>
+                  {items.map((item, index) => (
+                    <ItemBlock key={item.id}>
+                      <ItemFieldRow>
+                        <ItemLabel htmlFor={`itemName-${item.id}`}>
+                          {items.length > 1 ? `품목 ${index + 1}` : "품목"}
+                        </ItemLabel>
+                        <ItemInput
+                          id={`itemName-${item.id}`}
+                          name={`itemName-${item.id}`}
+                          placeholder="품목"
+                          value={item.name}
+                          onChange={(event) => updateItem(item.id, { name: event.target.value })}
+                          required={index === 0}
+                        />
+                      </ItemFieldRow>
+                      <ItemFieldRow>
+                        <ItemLabel htmlFor={`quantity-${item.id}`}>개수</ItemLabel>
+                        <ItemInput
+                          id={`quantity-${item.id}`}
+                          name={`quantity-${item.id}`}
+                          type="number"
+                          min="1"
+                          step="1"
+                          inputMode="numeric"
+                          placeholder="1"
+                          value={item.quantity}
+                          onChange={(event) =>
+                            updateItem(item.id, { quantity: event.target.value })
+                          }
+                        />
+                      </ItemFieldRow>
+                      <ItemFieldRow>
+                        <ItemLabel htmlFor={`paymentReason-${item.id}`}>결제 사유</ItemLabel>
+                        <ItemInput
+                          id={`paymentReason-${item.id}`}
+                          name={`paymentReason-${item.id}`}
+                          placeholder="결제 사유"
+                          value={item.reason}
+                          onChange={(event) => updateItem(item.id, { reason: event.target.value })}
+                        />
+                      </ItemFieldRow>
+                      {items.length > 1 ? (
+                        <ItemActionRow>
+                          <DeleteItemButton type="button" onClick={() => removeItem(item.id)}>
+                            품목 삭제
+                          </DeleteItemButton>
+                        </ItemActionRow>
+                      ) : null}
+                    </ItemBlock>
+                  ))}
+                </ItemList>
+
+                <AddItemButton type="button" onClick={addItem}>
+                  품목 추가하기
+                </AddItemButton>
+              </Section>
+            )}
+
+            {mutation.isError ? (
+              <StatusMessage role="alert">결제 신청서 제출에 실패했습니다.</StatusMessage>
+            ) : null}
           </Form>
         </Content>
       </Stage>
+      {customFieldModal ? (
+        <ModalOverlay role="presentation">
+          <ModalCard role="dialog" aria-modal="true" aria-labelledby="custom-input-modal-title">
+            <ModalTitle id="custom-input-modal-title">
+              {customFieldModal.field === "topDetailBusiness"
+                ? "세부 사업 직접 입력"
+                : customFieldModal.field === "budgetReason"
+                  ? "세부 항목 직접 입력"
+                  : customFieldModal.field === "paymentAccount"
+                    ? "결제 통장 직접 입력"
+                    : "산출 내역 직접 입력"}
+            </ModalTitle>
+            <ModalInput
+              value={customFieldDraft}
+              onChange={(event) => setCustomFieldDraft(event.target.value)}
+              placeholder={
+                customFieldModal.field === "topDetailBusiness"
+                  ? "세부 사업 입력"
+                  : customFieldModal.field === "budgetReason"
+                    ? "세부 항목 입력"
+                    : customFieldModal.field === "paymentAccount"
+                      ? "결제 통장 입력"
+                      : "산출 내역 입력"
+              }
+              autoFocus
+            />
+            <ModalActionRow>
+              <ModalButton type="button" onClick={closeCustomFieldModal}>
+                취소
+              </ModalButton>
+              <ModalButton
+                type="button"
+                $variant="primary"
+                onClick={confirmCustomFieldModal}
+                disabled={customFieldDraft.trim().length === 0}
+              >
+                확인
+              </ModalButton>
+            </ModalActionRow>
+          </ModalCard>
+        </ModalOverlay>
+      ) : null}
     </Main>
   );
 }
@@ -507,7 +1414,6 @@ const SectionTitle = styled.h2`
 
 const inputBase = `
   min-width: 0;
-  min-height: 2.6875rem;
   border: 1px solid #c0c0c0;
   background-color: ${colors.white};
   color: #000000;
@@ -521,7 +1427,6 @@ const inputBase = `
   }
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
     font-size: ${typography.fontSize20};
   }
 `;
@@ -586,29 +1491,9 @@ const InlineSelect = styled.select`
   }
 `;
 
-const ItemList = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const ItemBlock = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: ${spacing.space12};
-  padding: ${spacing.space20} 0 ${spacing.space20};
-  border-bottom: 1px solid #bcbcbc;
-
-  @media (min-width: 120rem) {
-    gap: ${spacing.space20};
-    padding-bottom: 1.875rem;
-  }
-`;
-
-const ItemFieldRow = styled.div`
+const ApprovalNumberRow = styled.div`
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
   gap: ${spacing.space12};
 
   @media (min-width: 120rem) {
@@ -620,27 +1505,45 @@ const ItemFieldRow = styled.div`
   }
 `;
 
-const ItemLabel = styled(Label)`
-  min-width: 4rem;
-  white-space: nowrap;
+const ApprovalNumberInput = styled(InlineInput)`
+  background-color: ${colors.background};
+  color: #6f6f6f;
 
-  @media (min-width: 120rem) {
-    min-width: 6.125rem;
+  &:read-only {
+    cursor: default;
   }
 `;
 
-const ItemInput = styled(Input)`
-  padding-inline: ${spacing.space20};
-
-  @media (min-width: 120rem) {
-    padding-inline: 1.875rem;
-  }
-`;
+const ApprovalNumberSelect = styled(InlineSelect)``;
 
 const PaymentTypeGroup = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: ${spacing.space8};
+`;
+
+const PaymentTypeOption = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.space8};
+  min-height: 1rem;
+  background-color: ${colors.white};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+  margin-right: 1rem;
+
+  input {
+    accent-color: ${colors.point};
+  }
+
+  @media (min-width: 120rem) {
+    min-height: 2rem;
+    font-size: ${typography.fontSize20};
+    margin-right: 2rem;
+  }
 `;
 
 const VendorBalanceTable = styled.table`
@@ -679,27 +1582,244 @@ const VendorBalanceTable = styled.table`
   }
 `;
 
-const PaymentTypeOption = styled.label`
-  display: inline-flex;
-  align-items: center;
-  gap: ${spacing.space8};
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space16};
-  background-color: ${colors.white};
+const ResponsiveTableWrap = styled.div`
+  width: 100%;
+  overflow-x: auto;
+`;
+
+const tableCellBase = `
+  border: 1px solid ${colors.borderStrong};
+  padding: ${spacing.space12};
   color: #000000;
   font-size: ${typography.fontSize14};
-  font-weight: 600;
-  line-height: ${typography.lineHeight130};
-  cursor: pointer;
+  line-height: ${typography.lineHeight150};
+  vertical-align: middle;
 
-  input {
-    accent-color: ${colors.point};
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryTable = styled.table`
+  width: 100%;
+  min-width: 48rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const SummaryLabelCell = styled.th`
+  ${tableCellBase}
+  width: 10rem;
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const SummaryValueCell = styled.td`
+  ${tableCellBase}
+  background-color: ${colors.white};
+`;
+
+const SummaryWideCell = styled(SummaryValueCell)`
+  min-height: 10rem;
+`;
+
+const SummaryTextarea = styled.textarea`
+  width: 100%;
+  min-height: 9rem;
+  border: 0;
+  resize: vertical;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    min-height: 12rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryInput = styled.input`
+  ${inputBase}
+  width: 100%;
+  min-height: auto;
+  border: 0;
+  padding: 0;
+`;
+
+const SummarySelect = styled.select`
+  ${inputBase}
+  width: 100%;
+  min-height: auto;
+  border: 0;
+  padding: 0;
+  background: transparent;
+`;
+
+const BudgetTable = styled.table`
+  width: 100%;
+  min-width: 58rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const BudgetHeadCell = styled.th`
+  ${tableCellBase}
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const BudgetBodyCell = styled.td`
+  ${tableCellBase}
+  text-align: center;
+`;
+
+const BudgetTotalLabelCell = styled(BudgetBodyCell)`
+  background-color: ${colors.background};
+  font-weight: 600;
+`;
+
+const BudgetTotalValueCell = styled(BudgetBodyCell)`
+  font-weight: 600;
+`;
+
+const BudgetInlineInput = styled.input`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  text-align: center;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const BudgetInlineSelect = styled.select`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  text-align: center;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ApprovalTable = styled.table`
+  width: 100%;
+  min-width: 46rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const ApprovalTypeCell = styled.th`
+  ${tableCellBase}
+  width: 6rem;
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const ApprovalHeadCell = styled.th`
+  ${tableCellBase}
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const ApprovalBodyCell = styled.td`
+  ${tableCellBase}
+  text-align: center;
+`;
+
+const ApprovalEditableInput = styled.input`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+  outline: none;
+
+  &::placeholder {
+    color: ${colors.placeholder};
   }
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20} 1.875rem;
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const ItemList = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: -${spacing.space8};
+`;
+
+const ItemBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space12};
+  padding: ${spacing.space20} 0 ${spacing.space20};
+  border-bottom: 1px solid #bcbcbc;
+
+  &:first-child {
+    padding-top: ${spacing.space8};
+  }
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+    padding-top: ${spacing.space20};
+    padding-bottom: 1.875rem;
+
+    &:first-child {
+      padding-top: ${spacing.space12};
+    }
+  }
+`;
+
+const ItemFieldRow = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ItemLabel = styled(Label)`
+  min-width: 4rem;
+  white-space: nowrap;
+
+  @media (min-width: 120rem) {
+    min-width: 6.125rem;
+  }
+`;
+
+const ItemInput = styled(Input)`
+  padding-inline: ${spacing.space20};
+
+  @media (min-width: 120rem) {
+    padding-inline: 1.875rem;
   }
 `;
 
@@ -731,16 +1851,8 @@ const AddItemButton = styled.button`
 `;
 
 const ItemActionRow = styled.div`
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: ${spacing.space12};
   display: flex;
   justify-content: flex-end;
-
-  @media (min-width: 120rem) {
-    bottom: ${spacing.space20};
-  }
 `;
 
 const DeleteItemButton = styled(AddItemButton)`
@@ -754,5 +1866,86 @@ const DeleteItemButton = styled(AddItemButton)`
     width: 12rem;
     min-height: 3.125rem;
     font-size: ${typography.fontSize20};
+  }
+`;
+
+const MiniDeleteButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 50%;
+  background-color: ${colors.noticeSoft};
+  color: ${colors.notice};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3rem;
+    height: 3rem;
+  }
+`;
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgba(0, 0, 0, 0.4);
+`;
+
+const ModalCard = styled.div`
+  width: min(100%, 28rem);
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space16};
+  border-radius: ${radii.radius20};
+  background-color: ${colors.white};
+  padding: ${spacing.space24};
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.16);
+`;
+
+const ModalTitle = styled.h3`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize18};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalInput = styled.input`
+  ${inputBase}
+  width: 100%;
+  padding: 0.8125rem ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const ModalActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${spacing.space12};
+`;
+
+const ModalButton = styled.button<{ $variant?: "primary" }>`
+  min-width: 5rem;
+  min-height: 2.5rem;
+  border: 1px solid ${({ $variant }) => ($variant === "primary" ? colors.point : colors.border)};
+  border-radius: ${radii.radius12};
+  background-color: ${({ $variant }) => ($variant === "primary" ? colors.point : colors.white)};
+  color: ${({ $variant }) => ($variant === "primary" ? colors.white : colors.text)};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;

--- a/components/staff/finance-management/FinanceRequestCreatePage.tsx
+++ b/components/staff/finance-management/FinanceRequestCreatePage.tsx
@@ -4,6 +4,7 @@ import { FormEvent, Fragment, useEffect, useMemo, useRef, useState } from "react
 import { IconX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import { getClassrooms } from "@/api/classroom/classroom.api";
 import { getDepartments } from "@/api/department/department.api";
@@ -12,6 +13,7 @@ import type { CreatePurchaseRequestDto } from "@/api/request/request.dto";
 import { getVendors } from "@/api/vendor/vendor.api";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 
@@ -259,6 +261,9 @@ export default function FinanceRequestCreatePage() {
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: queryKeys.requests.purchaseList() });
       router.push("/staff/finance-management");
+    },
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결제 신청서 제출에 실패했습니다."));
     },
   });
 
@@ -1215,9 +1220,6 @@ export default function FinanceRequestCreatePage() {
               </Section>
             )}
 
-            {mutation.isError ? (
-              <StatusMessage role="alert">결제 신청서 제출에 실패했습니다.</StatusMessage>
-            ) : null}
           </Form>
         </Content>
       </Stage>

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChangeEvent, FormEvent, useMemo, useState } from "react";
-import { IconDownload, IconFilePlus } from "@tabler/icons-react";
+import { ChangeEvent, FormEvent, Fragment, useMemo, useState } from "react";
+import { IconDownload, IconFilePlus, IconX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
@@ -77,6 +77,75 @@ type ReportItem = {
   receiptFileUrl?: string;
 };
 
+type ParsedPrepaidBudgetItem = {
+  id: number;
+  detailBusiness: string;
+  reason: string;
+  name: string;
+};
+
+type ParsedPrepaidProduct = {
+  id: number;
+  description: string;
+  specification: string;
+  quantity: string;
+  unitPrice: string;
+  amount: string;
+};
+
+type ApprovalEntry = {
+  position: string;
+  name: string;
+};
+
+type ParsedPrepaidContent = {
+  approvalNumber: string;
+  paymentAccount: string;
+  summary: string;
+  policyProject: string;
+  requestDepartmentName: string;
+  approvalDate: string;
+  detailBusiness: string;
+  approvalAmount: string;
+  budgetItems: ParsedPrepaidBudgetItem[];
+  products: ParsedPrepaidProduct[];
+  approvalEntries: ApprovalEntry[];
+  cooperationEntries: ApprovalEntry[];
+};
+
+const unitBusinessLabel = "프로그램운영비";
+const detailBusinessOptions = ["경상 운영비", "사업 추진비", "기타 운영비", "인건비"] as const;
+const budgetItemReasonOptions = [
+  "교통비",
+  "교재비",
+  "프로그램추진비",
+  "임차료",
+  "홍보비",
+  "기타 운영비",
+] as const;
+const budgetItemNameOptions = [
+  "무급강사교통비",
+  "무급행정담당자 교통비",
+  "시중교재",
+  "제본교재",
+  "(소풍)식비",
+  "행사물품",
+  "현수막",
+  "다과비",
+  "포스터",
+  "소식지",
+  "입간판 및 배너, 스티커 제작",
+  "이체 수수료",
+  "사무용품비",
+  "통신비",
+  "전기비",
+  "수도세",
+  "정수기 필터교체",
+  "청소용품",
+  "프린트토너",
+] as const;
+const paymentAccountOptions = ["국비04", "구비01", "구비08"] as const;
+
 const statusLabels: Record<PurchaseRequestStatus, string> = {
   PENDING: "대기 중",
   APPROVED: "승인 완료",
@@ -145,6 +214,142 @@ function getRequestPaymentType(items?: PurchaseRequestItemResponseDto[]): Paymen
   return paymentType === "PREPAID" ? "PREPAID" : "ACTUAL";
 }
 
+function parseNumericValue(value: string) {
+  const normalized = value.replaceAll(",", "").replaceAll("원", "").trim();
+  if (!normalized) return 0;
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getApprovalNumber(referenceDate: string, paymentAccount: string) {
+  if (!paymentAccount.trim()) {
+    return "";
+  }
+
+  const year = referenceDate.slice(0, 4) || String(new Date().getFullYear());
+  return `${year}품-${paymentAccount}-01`;
+}
+
+function getContentLineValue(content: string | undefined, label: string) {
+  if (!content) {
+    return "";
+  }
+
+  const line = content.split(/\r?\n/).find((currentLine) => currentLine.startsWith(`${label}:`));
+
+  return line ? line.slice(label.length + 1).trim() : "";
+}
+
+function getContentSection(content: string | undefined, label: string, nextLabels: string[]) {
+  if (!content) {
+    return "";
+  }
+
+  const lines = content.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === label);
+
+  if (startIndex < 0) {
+    return "";
+  }
+
+  const endIndex = lines.findIndex(
+    (line, index) => index > startIndex && nextLabels.includes(line.trim()),
+  );
+  const sectionLines = lines.slice(startIndex + 1, endIndex >= 0 ? endIndex : undefined);
+
+  return sectionLines.join("\n").trim();
+}
+
+function buildApprovalEntries(requestedByName?: string) {
+  return [
+    { position: "총무", name: requestedByName ?? "" },
+    { position: "교장", name: "정혜웅" },
+    { position: "", name: "" },
+  ];
+}
+
+function buildCooperationEntries(departmentName?: string) {
+  const firstPosition = departmentName && departmentName !== "총무부" ? `${departmentName}장` : "";
+
+  return [
+    { position: firstPosition, name: "" },
+    { position: "", name: "" },
+    { position: "", name: "" },
+  ];
+}
+
+function parsePrepaidContent(purchase?: PurchaseRequestResponseDto): ParsedPrepaidContent | null {
+  if (!purchase) {
+    return null;
+  }
+
+  const content = purchase.content ?? "";
+  const summary =
+    getContentSection(content, "[품의 개요]", ["정책 사업:", "[예산 내역]"]) ||
+    purchase.content ||
+    "";
+  const budgetSection = getContentSection(content, "[예산 내역]", ["[품목 내역]"]);
+  const productSection = getContentSection(content, "[품목 내역]", []);
+
+  const budgetLines = budgetSection
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const productLines = productSection
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => Boolean(line) && line !== "없음");
+
+  const budgetItems =
+    purchase.items?.map((item, index) => {
+      const matchedLine = budgetLines[index] ?? "";
+      const matched = matchedLine.match(
+        /^\d+\.\s*세부사업:\s*(.*?)\s*\/\s*세부 항목:\s*(.*?)\s*\/\s*산출 내역:\s*(.*)$/,
+      );
+
+      return {
+        id: item.id ?? index + 1,
+        detailBusiness: matched?.[1]?.trim() ?? "",
+        reason: matched?.[2]?.trim() ?? item.reason ?? "",
+        name: matched?.[3]?.trim() ?? item.name ?? "",
+      };
+    }) ?? [];
+
+  const products = productLines.map((line, index) => {
+    const matched = line.match(
+      /^\d+\.\s*내용:\s*(.*?)\s*\/\s*규격:\s*(.*?)\s*\/\s*수량:\s*(.*?)\s*\/\s*예상 단가:\s*(.*?)\s*\/\s*예상 금액:\s*(.*)$/,
+    );
+
+    return {
+      id: index + 1,
+      description: matched?.[1]?.trim() ?? "",
+      specification: matched?.[2]?.trim() ?? "",
+      quantity: matched?.[3]?.trim() ?? "0",
+      unitPrice: matched?.[4]?.trim() ?? "0",
+      amount: matched?.[5]?.trim() ?? "0",
+    };
+  });
+
+  return {
+    approvalNumber: getContentLineValue(content, "품의 번호"),
+    paymentAccount: getContentLineValue(content, "결제 통장"),
+    summary,
+    policyProject: getContentLineValue(content, "정책 사업"),
+    requestDepartmentName:
+      getContentLineValue(content, "요구 부서") || purchase.departmentName || "-",
+    approvalDate: getContentLineValue(content, "품의 일자"),
+    detailBusiness: getContentLineValue(content, "세부 사업"),
+    approvalAmount: getContentLineValue(content, "품의 금액").replaceAll("원", "").trim(),
+    budgetItems,
+    products,
+    approvalEntries: buildApprovalEntries(purchase.requestedByName),
+    cooperationEntries: buildCooperationEntries(
+      getContentLineValue(content, "요구 부서") || purchase.departmentName,
+    ),
+  };
+}
+
 function mapPurchaseItemsToReportItems(purchase?: ExtendedPurchaseRequest): ReportItem[] {
   if (purchase?.transactions?.length) {
     return purchase.transactions.map((transaction, index) => {
@@ -201,6 +406,8 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const [editTitle, setEditTitle] = useState("");
   const [editAffiliationValue, setEditAffiliationValue] = useState("");
   const [editItems, setEditItems] = useState<EditableItem[]>([]);
+  const [editPrepaidContent, setEditPrepaidContent] = useState<ParsedPrepaidContent | null>(null);
+  const [editPrepaidDepartmentId, setEditPrepaidDepartmentId] = useState("");
   const [reportItems, setReportItems] = useState<ReportItem[]>([]);
   const [isReportEditing, setIsReportEditing] = useState(false);
   const {
@@ -240,10 +447,16 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   });
 
   const purchase = request as ExtendedPurchaseRequest | undefined;
+  const requestPaymentType = getRequestPaymentType(request?.items);
   const initialEditItems = useMemo(
     () => mapPurchaseItemsToEditableItems(request?.items),
     [request?.items],
   );
+  const parsedPrepaidContent = useMemo(
+    () => (requestPaymentType === "PREPAID" ? parsePrepaidContent(purchase) : null),
+    [purchase, requestPaymentType],
+  );
+  const activePrepaidContent = isEditing ? editPrepaidContent : parsedPrepaidContent;
   const initialReportItems = useMemo(() => mapPurchaseItemsToReportItems(purchase), [purchase]);
   const activeReportItems = reportItems.length ? reportItems : initialReportItems;
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
@@ -417,6 +630,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
         Number(item.price) >= 1,
     ) &&
     !reportMutation.isPending;
+  const prepaidQuantityTotal =
+    activePrepaidContent?.products.reduce(
+      (sum, item) => sum + parseNumericValue(item.quantity),
+      0,
+    ) ?? 0;
+  const prepaidAmountTotal =
+    activePrepaidContent?.products.reduce((sum, item) => sum + parseNumericValue(item.amount), 0) ??
+    0;
 
   function updateReportItem(
     itemId: number,
@@ -490,6 +711,173 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     });
   }
 
+  function updateEditPrepaidContent(patch: Partial<ParsedPrepaidContent>) {
+    setEditPrepaidContent((current) => (current ? { ...current, ...patch } : current));
+  }
+
+  function syncEditPrepaidDepartment(departmentId: string) {
+    setEditPrepaidDepartmentId(departmentId);
+    setEditPrepaidContent((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const department = departments.find((item) => String(item.id) === departmentId);
+      const nextDepartmentName = department?.name ?? "";
+      const nextCooperationPosition =
+        nextDepartmentName && nextDepartmentName !== "총무부" ? `${nextDepartmentName}장` : "";
+
+      return {
+        ...current,
+        requestDepartmentName: nextDepartmentName,
+        cooperationEntries: current.cooperationEntries.map((entry, index) =>
+          index === 0 ? { ...entry, position: nextCooperationPosition } : entry,
+        ),
+      };
+    });
+  }
+
+  function syncEditPrepaidDetailBusiness(value: string) {
+    setEditPrepaidContent((current) =>
+      current
+        ? {
+            ...current,
+            detailBusiness: value,
+            budgetItems: current.budgetItems.map((item) => ({
+              ...item,
+              detailBusiness: value,
+            })),
+          }
+        : current,
+    );
+  }
+
+  function updateEditPrepaidBudgetItem(itemId: number, patch: Partial<ParsedPrepaidBudgetItem>) {
+    setEditPrepaidContent((current) =>
+      current
+        ? {
+            ...current,
+            budgetItems: current.budgetItems.map((item) =>
+              item.id === itemId ? { ...item, ...patch } : item,
+            ),
+          }
+        : current,
+    );
+  }
+
+  function updateEditPrepaidProduct(itemId: number, patch: Partial<ParsedPrepaidProduct>) {
+    setEditPrepaidContent((current) =>
+      current
+        ? {
+            ...current,
+            products: current.products.map((item) =>
+              item.id === itemId ? { ...item, ...patch } : item,
+            ),
+          }
+        : current,
+    );
+  }
+
+  function updateEditPrepaidProductCalculated(
+    itemId: number,
+    field: "quantity" | "unitPrice",
+    value: string,
+  ) {
+    setEditPrepaidContent((current) => {
+      if (!current) {
+        return current;
+      }
+
+      return {
+        ...current,
+        products: current.products.map((item) => {
+          if (item.id !== itemId) {
+            return item;
+          }
+
+          const next = { ...item, [field]: value };
+          const quantity = parseNumericValue(next.quantity);
+          const unitPrice = parseNumericValue(next.unitPrice);
+
+          return {
+            ...next,
+            amount: quantity > 0 && unitPrice > 0 ? String(quantity * unitPrice) : "",
+          };
+        }),
+      };
+    });
+  }
+
+  function addEditPrepaidProduct() {
+    setEditPrepaidContent((current) =>
+      current
+        ? {
+            ...current,
+            products: [
+              ...current.products,
+              {
+                id: Math.max(0, ...current.products.map((item) => item.id)) + 1,
+                description: "",
+                specification: "",
+                quantity: "1",
+                unitPrice: "",
+                amount: "",
+              },
+            ],
+          }
+        : current,
+    );
+  }
+
+  function removeEditPrepaidProduct(itemId: number) {
+    setEditPrepaidContent((current) => {
+      if (!current) {
+        return current;
+      }
+
+      if (current.products.length <= 1) {
+        return {
+          ...current,
+          products: [
+            {
+              id: current.products[0]?.id ?? 1,
+              description: "",
+              specification: "",
+              quantity: "1",
+              unitPrice: "",
+              amount: "",
+            },
+          ],
+        };
+      }
+
+      return {
+        ...current,
+        products: current.products.filter((item) => item.id !== itemId),
+      };
+    });
+  }
+
+  function updateEditApprovalEntry(
+    kind: "approval" | "cooperation",
+    index: number,
+    patch: Partial<ApprovalEntry>,
+  ) {
+    setEditPrepaidContent((current) => {
+      if (!current) {
+        return current;
+      }
+
+      const key = kind === "approval" ? "approvalEntries" : "cooperationEntries";
+      return {
+        ...current,
+        [key]: current[key].map((entry, entryIndex) =>
+          entryIndex === index ? { ...entry, ...patch } : entry,
+        ),
+      } as ParsedPrepaidContent;
+    });
+  }
+
   function startEditing() {
     if (!request) {
       return;
@@ -497,7 +885,18 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
 
     setEditTitle(request.title ?? "");
     setEditAffiliationValue(requestAffiliationValue);
-    setEditItems(initialEditItems);
+    if (requestPaymentType === "PREPAID" && parsedPrepaidContent) {
+      setEditPrepaidContent(parsedPrepaidContent);
+      const matchedDepartment = departments.find(
+        (department) => department.name === parsedPrepaidContent.requestDepartmentName,
+      );
+      setEditPrepaidDepartmentId(matchedDepartment?.id != null ? String(matchedDepartment.id) : "");
+      setEditItems([]);
+    } else {
+      setEditItems(initialEditItems);
+      setEditPrepaidContent(null);
+      setEditPrepaidDepartmentId("");
+    }
     setIsEditing(true);
   }
 
@@ -522,6 +921,98 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   function handleEditSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!request) {
+      return;
+    }
+
+    if (requestPaymentType === "PREPAID" && editPrepaidContent) {
+      const selectedDepartment = departments.find(
+        (department) => String(department.id) === editPrepaidDepartmentId,
+      );
+      const nextApprovalNumber = getApprovalNumber(
+        editPrepaidContent.approvalDate,
+        editPrepaidContent.paymentAccount,
+      );
+      const budgetContent = editPrepaidContent.budgetItems
+        .map(
+          (item, index) =>
+            `${index + 1}. 세부사업: ${item.detailBusiness || editPrepaidContent.detailBusiness || "-"} / 세부 항목: ${item.reason || "-"} / 산출 내역: ${item.name || "-"}`,
+        )
+        .join("\n");
+      const productContent =
+        editPrepaidContent.products.length > 0
+          ? editPrepaidContent.products
+              .map(
+                (item, index) =>
+                  `${index + 1}. 내용: ${item.description || "-"} / 규격: ${item.specification || "-"} / 수량: ${item.quantity || 0} / 예상 단가: ${item.unitPrice || 0} / 예상 금액: ${item.amount || 0}`,
+              )
+              .join("\n")
+          : "없음";
+      const nextContent = [
+        `분반: ${selectedAffiliation?.label ?? getAffiliationLabel(request)}`,
+        `신청자: ${request.requestedByName ?? "-"}`,
+        "결제 유형: 선금 결제",
+        "",
+        `[품의 번호]`,
+        `품의 번호: ${nextApprovalNumber || "-"}`,
+        `결제 통장: ${editPrepaidContent.paymentAccount || "-"}`,
+        "",
+        `[품의 개요]`,
+        editPrepaidContent.summary.trim(),
+        `정책 사업: ${editPrepaidContent.policyProject || "-"}`,
+        `요구 부서: ${selectedDepartment?.name ?? editPrepaidContent.requestDepartmentName ?? "-"}`,
+        `단위 사업: ${unitBusinessLabel}`,
+        `품의 일자: ${editPrepaidContent.approvalDate || "-"}`,
+        `세부 사업: ${editPrepaidContent.detailBusiness || "-"}`,
+        `품의 금액: ${editPrepaidContent.approvalAmount || "0"}원`,
+        "",
+        `[예산 내역]`,
+        budgetContent,
+        "",
+        `[품목 내역]`,
+        productContent,
+      ].join("\n");
+
+      const nextRequest = {
+        ...request,
+        title: editTitle.trim() || request.title,
+        classroomId:
+          selectedAffiliation?.type === "classroom" ? selectedAffiliation.id : request.classroomId,
+        classroomName:
+          selectedAffiliation?.type === "classroom"
+            ? selectedAffiliation.label
+            : request.classroomName,
+        departmentId:
+          selectedAffiliation?.type === "department"
+            ? selectedAffiliation.id
+            : request.departmentId,
+        departmentName:
+          selectedAffiliation?.type === "department"
+            ? selectedAffiliation.label
+            : request.departmentName,
+        content: nextContent,
+        items: editPrepaidContent.budgetItems.map((item) => ({
+          id: item.id,
+          name: item.name.trim(),
+          reason: item.reason.trim() || undefined,
+          quantity: 1,
+          paymentType: "PREPAID" as const,
+        })),
+      };
+
+      queryClient.setQueryData(queryKeys.requests.purchaseDetail(requestId), nextRequest);
+      queryClient.setQueryData<PurchaseRequestListResponseDto | undefined>(
+        queryKeys.requests.purchaseList(),
+        (current) =>
+          current
+            ? {
+                ...current,
+                content: current.content.map((item) =>
+                  item.id === requestId ? { ...item, ...nextRequest } : item,
+                ),
+              }
+            : current,
+      );
+      setIsEditing(false);
       return;
     }
 
@@ -703,114 +1194,947 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 </PaymentTypeGroup>
               </Section>
 
-              <Section>
-                <DetailSectionHeader>
-                  <SectionTitle>상세 품목</SectionTitle>
-                  {canEditPurchaseReport && !isReportEditing ? (
-                    <ReportEditTextButton type="button" onClick={startReportEditing}>
-                      수정
-                    </ReportEditTextButton>
+              {requestPaymentType === "PREPAID" ? (
+                <>
+                  {isEditing && editPrepaidContent ? (
+                    <>
+                      <Section>
+                        <SectionTitle>품의 번호</SectionTitle>
+                        <ApprovalNumberRow>
+                          <ApprovalNumberField>
+                            {getApprovalNumber(
+                              editPrepaidContent.approvalDate,
+                              editPrepaidContent.paymentAccount,
+                            ) || "-"}
+                          </ApprovalNumberField>
+                          <EditSelect
+                            value={editPrepaidContent.paymentAccount}
+                            onChange={(event) =>
+                              updateEditPrepaidContent({ paymentAccount: event.target.value })
+                            }
+                          >
+                            <option value="">결제 통장 선택</option>
+                            {paymentAccountOptions.map((option) => (
+                              <option key={option} value={option}>
+                                {option}
+                              </option>
+                            ))}
+                            {editPrepaidContent.paymentAccount &&
+                            !paymentAccountOptions.some(
+                              (option) => option === editPrepaidContent.paymentAccount,
+                            ) ? (
+                              <option value={editPrepaidContent.paymentAccount}>
+                                {editPrepaidContent.paymentAccount}
+                              </option>
+                            ) : null}
+                          </EditSelect>
+                        </ApprovalNumberRow>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품의 개요</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <SummaryTable>
+                            <tbody>
+                              <tr>
+                                <SummaryLabelCell>품의 개요</SummaryLabelCell>
+                                <SummaryWideCell colSpan={3}>
+                                  <SummaryTextareaInput
+                                    value={editPrepaidContent.summary}
+                                    onChange={(event) =>
+                                      updateEditPrepaidContent({ summary: event.target.value })
+                                    }
+                                  />
+                                </SummaryWideCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>정책 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {editPrepaidContent.policyProject || "-"}
+                                </SummaryValueCell>
+                                <SummaryLabelCell>요구 부서</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  <SummaryCellSelect
+                                    value={editPrepaidDepartmentId}
+                                    onChange={(event) =>
+                                      syncEditPrepaidDepartment(event.target.value)
+                                    }
+                                  >
+                                    <option value="">부서 선택</option>
+                                    {departments.map((department) => (
+                                      <option key={department.id} value={department.id}>
+                                        {department.name ?? `부서 ${department.id}`}
+                                      </option>
+                                    ))}
+                                  </SummaryCellSelect>
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>단위 사업</SummaryLabelCell>
+                                <SummaryValueCell>{unitBusinessLabel}</SummaryValueCell>
+                                <SummaryLabelCell>품의 일자</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  <SummaryCellInput
+                                    type="date"
+                                    value={editPrepaidContent.approvalDate}
+                                    onChange={(event) =>
+                                      updateEditPrepaidContent({
+                                        approvalDate: event.target.value,
+                                        policyProject: `${
+                                          event.target.value.slice(0, 4) || new Date().getFullYear()
+                                        }년 성인문해교육 지원사업`,
+                                      })
+                                    }
+                                  />
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>세부 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  <SummaryCellSelect
+                                    value={editPrepaidContent.detailBusiness}
+                                    onChange={(event) =>
+                                      syncEditPrepaidDetailBusiness(event.target.value)
+                                    }
+                                  >
+                                    <option value="">세부 사업 선택</option>
+                                    {detailBusinessOptions.map((option) => (
+                                      <option key={option} value={option}>
+                                        {option}
+                                      </option>
+                                    ))}
+                                    {editPrepaidContent.detailBusiness &&
+                                    !detailBusinessOptions.some(
+                                      (option) => option === editPrepaidContent.detailBusiness,
+                                    ) ? (
+                                      <option value={editPrepaidContent.detailBusiness}>
+                                        {editPrepaidContent.detailBusiness}
+                                      </option>
+                                    ) : null}
+                                  </SummaryCellSelect>
+                                </SummaryValueCell>
+                                <SummaryLabelCell>품의 금액</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  <SummaryCellInput
+                                    type="number"
+                                    min="0"
+                                    inputMode="numeric"
+                                    value={editPrepaidContent.approvalAmount}
+                                    onChange={(event) =>
+                                      updateEditPrepaidContent({
+                                        approvalAmount: event.target.value,
+                                      })
+                                    }
+                                  />
+                                </SummaryValueCell>
+                              </tr>
+                            </tbody>
+                          </SummaryTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>예산 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>세부 사업</BudgetHeadCell>
+                                <BudgetHeadCell>세부 항목</BudgetHeadCell>
+                                <BudgetHeadCell>산출 내역</BudgetHeadCell>
+                                <BudgetHeadCell>품의 금액</BudgetHeadCell>
+                                <BudgetHeadCell>예산 잔액</BudgetHeadCell>
+                                <BudgetHeadCell>사업 잔액</BudgetHeadCell>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {editPrepaidContent.budgetItems.map((item, index) => (
+                                <tr key={item.id}>
+                                  <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      value={
+                                        item.detailBusiness || editPrepaidContent.detailBusiness
+                                      }
+                                      onChange={(event) =>
+                                        updateEditPrepaidBudgetItem(item.id, {
+                                          detailBusiness: event.target.value,
+                                        })
+                                      }
+                                      placeholder="세부 사업"
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineSelect
+                                      value={item.reason}
+                                      onChange={(event) =>
+                                        updateEditPrepaidBudgetItem(item.id, {
+                                          reason: event.target.value,
+                                        })
+                                      }
+                                    >
+                                      <option value="">세부 항목</option>
+                                      {budgetItemReasonOptions.map((option) => (
+                                        <option key={`${item.id}-${option}`} value={option}>
+                                          {option}
+                                        </option>
+                                      ))}
+                                      {item.reason &&
+                                      !budgetItemReasonOptions.some(
+                                        (option) => option === item.reason,
+                                      ) ? (
+                                        <option value={item.reason}>{item.reason}</option>
+                                      ) : null}
+                                    </BudgetInlineSelect>
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineSelect
+                                      value={item.name}
+                                      onChange={(event) =>
+                                        updateEditPrepaidBudgetItem(item.id, {
+                                          name: event.target.value,
+                                        })
+                                      }
+                                    >
+                                      <option value="">산출 내역</option>
+                                      {budgetItemNameOptions.map((option) => (
+                                        <option key={`${item.id}-name-${option}`} value={option}>
+                                          {option}
+                                        </option>
+                                      ))}
+                                      {item.name &&
+                                      !budgetItemNameOptions.some(
+                                        (option) => option === item.name,
+                                      ) ? (
+                                        <option value={item.name}>{item.name}</option>
+                                      ) : null}
+                                    </BudgetInlineSelect>
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      type="number"
+                                      min="0"
+                                      inputMode="numeric"
+                                      value={editPrepaidContent.approvalAmount}
+                                      onChange={(event) =>
+                                        updateEditPrepaidContent({
+                                          approvalAmount: event.target.value,
+                                        })
+                                      }
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                </tr>
+                              ))}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={4}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {editPrepaidContent.approvalAmount || "-"}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품목 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>내용</BudgetHeadCell>
+                                <BudgetHeadCell>규격</BudgetHeadCell>
+                                <BudgetHeadCell>수량</BudgetHeadCell>
+                                <BudgetHeadCell>예상 단가</BudgetHeadCell>
+                                <BudgetHeadCell>예상 금액</BudgetHeadCell>
+                                {editPrepaidContent.products.length > 1 ? (
+                                  <BudgetHeadCell>삭제</BudgetHeadCell>
+                                ) : null}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {editPrepaidContent.products.map((product, index) => (
+                                <tr key={product.id}>
+                                  <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      value={product.description}
+                                      onChange={(event) =>
+                                        updateEditPrepaidProduct(product.id, {
+                                          description: event.target.value,
+                                        })
+                                      }
+                                      placeholder="내용"
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      value={product.specification}
+                                      onChange={(event) =>
+                                        updateEditPrepaidProduct(product.id, {
+                                          specification: event.target.value,
+                                        })
+                                      }
+                                      placeholder="규격"
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      type="number"
+                                      min="0"
+                                      inputMode="numeric"
+                                      value={product.quantity}
+                                      onChange={(event) =>
+                                        updateEditPrepaidProductCalculated(
+                                          product.id,
+                                          "quantity",
+                                          event.target.value,
+                                        )
+                                      }
+                                      placeholder="0"
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput
+                                      type="number"
+                                      min="0"
+                                      inputMode="numeric"
+                                      value={product.unitPrice}
+                                      onChange={(event) =>
+                                        updateEditPrepaidProductCalculated(
+                                          product.id,
+                                          "unitPrice",
+                                          event.target.value,
+                                        )
+                                      }
+                                      placeholder="0"
+                                    />
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    <BudgetInlineInput value={product.amount} readOnly />
+                                  </BudgetBodyCell>
+                                  {editPrepaidContent.products.length > 1 ? (
+                                    <BudgetBodyCell>
+                                      <MiniDeleteButton
+                                        type="button"
+                                        aria-label={`${index + 1}번 품목 삭제`}
+                                        onClick={() => removeEditPrepaidProduct(product.id)}
+                                      >
+                                        <IconX aria-hidden="true" size={16} stroke={2.4} />
+                                      </MiniDeleteButton>
+                                    </BudgetBodyCell>
+                                  ) : null}
+                                </tr>
+                              ))}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={3}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidQuantityTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidAmountTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                                {editPrepaidContent.products.length > 1 ? (
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                ) : null}
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                        <AddItemButton type="button" onClick={addEditPrepaidProduct}>
+                          품목 추가하기
+                        </AddItemButton>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>결재 & 협조</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <ApprovalTable>
+                            <tbody>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>결재</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {editPrepaidContent.approvalEntries.map((entry, index) => (
+                                  <Fragment key={`edit-approval-${index}`}>
+                                    <ApprovalBodyCell>
+                                      <ApprovalEditableInput
+                                        value={entry.position}
+                                        onChange={(event) =>
+                                          updateEditApprovalEntry("approval", index, {
+                                            position: event.target.value,
+                                          })
+                                        }
+                                      />
+                                    </ApprovalBodyCell>
+                                    <ApprovalBodyCell>
+                                      <ApprovalEditableInput
+                                        value={entry.name}
+                                        onChange={(event) =>
+                                          updateEditApprovalEntry("approval", index, {
+                                            name: event.target.value,
+                                          })
+                                        }
+                                      />
+                                    </ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>협조</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {editPrepaidContent.cooperationEntries.map((entry, index) => (
+                                  <Fragment key={`edit-cooperation-${index}`}>
+                                    <ApprovalBodyCell>
+                                      <ApprovalEditableInput
+                                        value={entry.position}
+                                        onChange={(event) =>
+                                          updateEditApprovalEntry("cooperation", index, {
+                                            position: event.target.value,
+                                          })
+                                        }
+                                      />
+                                    </ApprovalBodyCell>
+                                    <ApprovalBodyCell>
+                                      <ApprovalEditableInput
+                                        value={entry.name}
+                                        onChange={(event) =>
+                                          updateEditApprovalEntry("cooperation", index, {
+                                            name: event.target.value,
+                                          })
+                                        }
+                                      />
+                                    </ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                            </tbody>
+                          </ApprovalTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+                    </>
+                  ) : activePrepaidContent ? (
+                    <>
+                      <Section>
+                        <SectionTitle>품의 번호</SectionTitle>
+                        <ApprovalNumberRow>
+                          <ApprovalNumberField>
+                            {activePrepaidContent.approvalNumber || "-"}
+                          </ApprovalNumberField>
+                          <ApprovalNumberField>
+                            {activePrepaidContent.paymentAccount || "-"}
+                          </ApprovalNumberField>
+                        </ApprovalNumberRow>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품의 개요</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <SummaryTable>
+                            <tbody>
+                              <tr>
+                                <SummaryLabelCell>품의 개요</SummaryLabelCell>
+                                <SummaryWideCell colSpan={3}>
+                                  <SummaryReadOnlyBlock>
+                                    {activePrepaidContent.summary || "-"}
+                                  </SummaryReadOnlyBlock>
+                                </SummaryWideCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>정책 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.policyProject || "-"}
+                                </SummaryValueCell>
+                                <SummaryLabelCell>요구 부서</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.requestDepartmentName || "-"}
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>단위 사업</SummaryLabelCell>
+                                <SummaryValueCell>{unitBusinessLabel}</SummaryValueCell>
+                                <SummaryLabelCell>품의 일자</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.approvalDate || "-"}
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>세부 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.detailBusiness || "-"}
+                                </SummaryValueCell>
+                                <SummaryLabelCell>품의 금액</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.approvalAmount || "-"}
+                                </SummaryValueCell>
+                              </tr>
+                            </tbody>
+                          </SummaryTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>예산 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>세부 사업</BudgetHeadCell>
+                                <BudgetHeadCell>세부 항목</BudgetHeadCell>
+                                <BudgetHeadCell>산출 내역</BudgetHeadCell>
+                                <BudgetHeadCell>품의 금액</BudgetHeadCell>
+                                <BudgetHeadCell>예산 잔액</BudgetHeadCell>
+                                <BudgetHeadCell>사업 잔액</BudgetHeadCell>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {activePrepaidContent.budgetItems.map((item, index) => (
+                                <tr key={item.id}>
+                                  <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.detailBusiness || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.reason || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.name || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    {activePrepaidContent.approvalAmount || "-"}
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                </tr>
+                              ))}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={4}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {activePrepaidContent.approvalAmount || "-"}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품목 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>내용</BudgetHeadCell>
+                                <BudgetHeadCell>규격</BudgetHeadCell>
+                                <BudgetHeadCell>수량</BudgetHeadCell>
+                                <BudgetHeadCell>예상 단가</BudgetHeadCell>
+                                <BudgetHeadCell>예상 금액</BudgetHeadCell>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {activePrepaidContent.products.length > 0 ? (
+                                activePrepaidContent.products.map((product, index) => (
+                                  <tr key={product.id}>
+                                    <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.description || "-"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.specification || "-"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.quantity || "0"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.unitPrice || "0"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.amount || "0"}</BudgetBodyCell>
+                                  </tr>
+                                ))
+                              ) : (
+                                <tr>
+                                  <BudgetBodyCell colSpan={6}>-</BudgetBodyCell>
+                                </tr>
+                              )}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={3}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidQuantityTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidAmountTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>결재 & 협조</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <ApprovalTable>
+                            <tbody>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>결재</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {activePrepaidContent.approvalEntries.map((entry, index) => (
+                                  <Fragment key={`detail-approval-${index}`}>
+                                    <ApprovalBodyCell>{entry.position || "-"}</ApprovalBodyCell>
+                                    <ApprovalBodyCell>{entry.name || "-"}</ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>협조</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {activePrepaidContent.cooperationEntries.map((entry, index) => (
+                                  <Fragment key={`detail-cooperation-${index}`}>
+                                    <ApprovalBodyCell>{entry.position || "-"}</ApprovalBodyCell>
+                                    <ApprovalBodyCell>{entry.name || "-"}</ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                            </tbody>
+                          </ApprovalTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+                    </>
                   ) : null}
-                </DetailSectionHeader>
-                {isEditing ? (
-                  <>
-                    <EditItemList>
-                      {(editItems.length ? editItems : initialEditItems).map((item, index) => (
-                        <EditItemBlock key={item.id}>
-                          <ItemFieldRow>
-                            <ItemLabel htmlFor={`editItemName-${item.id}`}>
-                              품목 {index + 1}
-                            </ItemLabel>
-                            <EditInput
-                              id={`editItemName-${item.id}`}
-                              value={item.name}
-                              onChange={(event) =>
-                                updateEditItem(item.id, { name: event.target.value })
-                              }
-                            />
-                          </ItemFieldRow>
-                          <ItemFieldRow>
-                            <ItemLabel htmlFor={`editQuantity-${item.id}`}>개수</ItemLabel>
-                            <EditInput
-                              id={`editQuantity-${item.id}`}
-                              type="number"
-                              min="1"
-                              step="1"
-                              inputMode="numeric"
-                              value={item.quantity}
-                              onChange={(event) =>
-                                updateEditItem(item.id, { quantity: event.target.value })
-                              }
-                            />
-                          </ItemFieldRow>
-                          <ItemFieldRow>
-                            <ItemLabel htmlFor={`editReason-${item.id}`}>결제 사유</ItemLabel>
-                            <EditInput
-                              id={`editReason-${item.id}`}
-                              value={item.reason}
-                              onChange={(event) =>
-                                updateEditItem(item.id, { reason: event.target.value })
-                              }
-                            />
-                          </ItemFieldRow>
-                          {(editItems.length ? editItems : initialEditItems).length > 1 ? (
-                            <EditItemActionRow>
-                              <DeleteItemButton
-                                type="button"
-                                onClick={() => removeEditItem(item.id)}
-                              >
-                                품목 삭제
-                              </DeleteItemButton>
-                            </EditItemActionRow>
-                          ) : null}
-                        </EditItemBlock>
-                      ))}
-                    </EditItemList>
-                    <AddItemButton type="button" onClick={addEditItem}>
-                      품목 추가하기
-                    </AddItemButton>
-                  </>
-                ) : (
-                  <DetailTable>
-                    <thead>
-                      <tr>
-                        <th>거래처</th>
-                        <th>품목</th>
-                        <th>개수</th>
-                        <th>결제 사유</th>
-                        <th>결제 금액</th>
-                        <th>영수증</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {detailItems.map((item, index) => (
-                        <tr key={`${item.id}-${index}`}>
-                          <td>{item.vendorName ?? "-"}</td>
-                          <td>{item.name}</td>
-                          <td>{typeof item.quantity === "number" ? item.quantity : "-"}</td>
-                          <td>{item.reason}</td>
-                          <td>{formatAmount(item.price)}</td>
-                          <td>
-                            {item.receipt ? (
-                              <InlineReceiptLink
-                                href={item.receipt.fileUrl ?? "#"}
-                                download={getReceiptName(item.receipt)}
-                              >
-                                영수증
-                                <ReceiptIcon aria-hidden="true">
-                                  <IconDownload size={12} stroke={2.25} />
-                                </ReceiptIcon>
-                              </InlineReceiptLink>
-                            ) : (
-                              "-"
-                            )}
-                          </td>
+                </>
+              ) : (
+                <Section>
+                  <DetailSectionHeader>
+                    <SectionTitle>상세 품목</SectionTitle>
+                    {canEditPurchaseReport && !isReportEditing ? (
+                      <ReportEditTextButton type="button" onClick={startReportEditing}>
+                        수정
+                      </ReportEditTextButton>
+                    ) : null}
+                  </DetailSectionHeader>
+                  {isEditing ? (
+                    <>
+                      <EditItemList>
+                        {(editItems.length ? editItems : initialEditItems).map((item, index) => (
+                          <EditItemBlock key={item.id}>
+                            <ItemFieldRow>
+                              <ItemLabel htmlFor={`editItemName-${item.id}`}>
+                                품목 {index + 1}
+                              </ItemLabel>
+                              <EditInput
+                                id={`editItemName-${item.id}`}
+                                value={item.name}
+                                onChange={(event) =>
+                                  updateEditItem(item.id, { name: event.target.value })
+                                }
+                              />
+                            </ItemFieldRow>
+                            <ItemFieldRow>
+                              <ItemLabel htmlFor={`editQuantity-${item.id}`}>개수</ItemLabel>
+                              <EditInput
+                                id={`editQuantity-${item.id}`}
+                                type="number"
+                                min="1"
+                                step="1"
+                                inputMode="numeric"
+                                value={item.quantity}
+                                onChange={(event) =>
+                                  updateEditItem(item.id, { quantity: event.target.value })
+                                }
+                              />
+                            </ItemFieldRow>
+                            <ItemFieldRow>
+                              <ItemLabel htmlFor={`editReason-${item.id}`}>결제 사유</ItemLabel>
+                              <EditInput
+                                id={`editReason-${item.id}`}
+                                value={item.reason}
+                                onChange={(event) =>
+                                  updateEditItem(item.id, { reason: event.target.value })
+                                }
+                              />
+                            </ItemFieldRow>
+                            {(editItems.length ? editItems : initialEditItems).length > 1 ? (
+                              <EditItemActionRow>
+                                <DeleteItemButton
+                                  type="button"
+                                  onClick={() => removeEditItem(item.id)}
+                                >
+                                  품목 삭제
+                                </DeleteItemButton>
+                              </EditItemActionRow>
+                            ) : null}
+                          </EditItemBlock>
+                        ))}
+                      </EditItemList>
+                      <AddItemButton type="button" onClick={addEditItem}>
+                        품목 추가하기
+                      </AddItemButton>
+                    </>
+                  ) : activePrepaidContent ? (
+                    <>
+                      <Section>
+                        <SectionTitle>품의 번호</SectionTitle>
+                        <ApprovalNumberRow>
+                          <ApprovalNumberField>
+                            {activePrepaidContent.approvalNumber || "-"}
+                          </ApprovalNumberField>
+                          <ApprovalNumberField>
+                            {activePrepaidContent.paymentAccount || "-"}
+                          </ApprovalNumberField>
+                        </ApprovalNumberRow>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품의 개요</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <SummaryTable>
+                            <tbody>
+                              <tr>
+                                <SummaryLabelCell>품의 개요</SummaryLabelCell>
+                                <SummaryWideCell colSpan={3}>
+                                  <SummaryReadOnlyBlock>
+                                    {activePrepaidContent.summary || "-"}
+                                  </SummaryReadOnlyBlock>
+                                </SummaryWideCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>정책 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.policyProject || "-"}
+                                </SummaryValueCell>
+                                <SummaryLabelCell>요구 부서</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.requestDepartmentName || "-"}
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>단위 사업</SummaryLabelCell>
+                                <SummaryValueCell>{unitBusinessLabel}</SummaryValueCell>
+                                <SummaryLabelCell>품의 일자</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.approvalDate || "-"}
+                                </SummaryValueCell>
+                              </tr>
+                              <tr>
+                                <SummaryLabelCell>세부 사업</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.detailBusiness || "-"}
+                                </SummaryValueCell>
+                                <SummaryLabelCell>품의 금액</SummaryLabelCell>
+                                <SummaryValueCell>
+                                  {activePrepaidContent.approvalAmount
+                                    ? `${activePrepaidContent.approvalAmount}`
+                                    : "-"}
+                                </SummaryValueCell>
+                              </tr>
+                            </tbody>
+                          </SummaryTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>예산 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>세부 사업</BudgetHeadCell>
+                                <BudgetHeadCell>세부 항목</BudgetHeadCell>
+                                <BudgetHeadCell>산출 내역</BudgetHeadCell>
+                                <BudgetHeadCell>품의 금액</BudgetHeadCell>
+                                <BudgetHeadCell>예산 잔액</BudgetHeadCell>
+                                <BudgetHeadCell>사업 잔액</BudgetHeadCell>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {activePrepaidContent.budgetItems.map((item, index) => (
+                                <tr key={item.id}>
+                                  <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.detailBusiness || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.reason || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>{item.name || "-"}</BudgetBodyCell>
+                                  <BudgetBodyCell>
+                                    {activePrepaidContent.approvalAmount
+                                      ? `${activePrepaidContent.approvalAmount}`
+                                      : "-"}
+                                  </BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                  <BudgetBodyCell>-</BudgetBodyCell>
+                                </tr>
+                              ))}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={4}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {activePrepaidContent.approvalAmount
+                                    ? `${activePrepaidContent.approvalAmount}`
+                                    : "-"}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>품목 내역</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <BudgetTable>
+                            <thead>
+                              <tr>
+                                <BudgetHeadCell>순번</BudgetHeadCell>
+                                <BudgetHeadCell>내용</BudgetHeadCell>
+                                <BudgetHeadCell>규격</BudgetHeadCell>
+                                <BudgetHeadCell>수량</BudgetHeadCell>
+                                <BudgetHeadCell>예상 단가</BudgetHeadCell>
+                                <BudgetHeadCell>예상 금액</BudgetHeadCell>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {activePrepaidContent.products.length > 0 ? (
+                                activePrepaidContent.products.map((product, index) => (
+                                  <tr key={product.id}>
+                                    <BudgetBodyCell>{index + 1}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.description || "-"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.specification || "-"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.quantity || "0"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.unitPrice || "0"}</BudgetBodyCell>
+                                    <BudgetBodyCell>{product.amount || "0"}</BudgetBodyCell>
+                                  </tr>
+                                ))
+                              ) : (
+                                <tr>
+                                  <BudgetBodyCell colSpan={6}>-</BudgetBodyCell>
+                                </tr>
+                              )}
+                              <tr>
+                                <BudgetTotalLabelCell colSpan={3}>합계</BudgetTotalLabelCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidQuantityTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                                <BudgetTotalValueCell>-</BudgetTotalValueCell>
+                                <BudgetTotalValueCell>
+                                  {prepaidAmountTotal.toLocaleString()}
+                                </BudgetTotalValueCell>
+                              </tr>
+                            </tbody>
+                          </BudgetTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+
+                      <Section>
+                        <SectionTitle>결재 & 협조</SectionTitle>
+                        <ResponsiveTableWrap>
+                          <ApprovalTable>
+                            <tbody>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>결재</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {activePrepaidContent.approvalEntries.map((entry, index) => (
+                                  <Fragment key={`detail-approval-${index}`}>
+                                    <ApprovalBodyCell>{entry.position || "-"}</ApprovalBodyCell>
+                                    <ApprovalBodyCell>{entry.name || "-"}</ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                              <tr>
+                                <ApprovalTypeCell rowSpan={2}>협조</ApprovalTypeCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                                <ApprovalHeadCell>직위</ApprovalHeadCell>
+                                <ApprovalHeadCell>이름</ApprovalHeadCell>
+                              </tr>
+                              <tr>
+                                {activePrepaidContent.cooperationEntries.map((entry, index) => (
+                                  <Fragment key={`detail-cooperation-${index}`}>
+                                    <ApprovalBodyCell>{entry.position || "-"}</ApprovalBodyCell>
+                                    <ApprovalBodyCell>{entry.name || "-"}</ApprovalBodyCell>
+                                  </Fragment>
+                                ))}
+                              </tr>
+                            </tbody>
+                          </ApprovalTable>
+                        </ResponsiveTableWrap>
+                      </Section>
+                    </>
+                  ) : (
+                    <DetailTable>
+                      <thead>
+                        <tr>
+                          <th>거래처</th>
+                          <th>품목</th>
+                          <th>개수</th>
+                          <th>결제 사유</th>
+                          <th>결제 금액</th>
+                          <th>영수증</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </DetailTable>
-                )}
-              </Section>
+                      </thead>
+                      <tbody>
+                        {detailItems.map((item, index) => (
+                          <tr key={`${item.id}-${index}`}>
+                            <td>{item.vendorName ?? "-"}</td>
+                            <td>{item.name}</td>
+                            <td>{typeof item.quantity === "number" ? item.quantity : "-"}</td>
+                            <td>{item.reason}</td>
+                            <td>{formatAmount(item.price)}</td>
+                            <td>
+                              {item.receipt ? (
+                                <InlineReceiptLink
+                                  href={item.receipt.fileUrl ?? "#"}
+                                  download={getReceiptName(item.receipt)}
+                                >
+                                  영수증
+                                  <ReceiptIcon aria-hidden="true">
+                                    <IconDownload size={12} stroke={2.25} />
+                                  </ReceiptIcon>
+                                </InlineReceiptLink>
+                              ) : (
+                                "-"
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </DetailTable>
+                  )}
+                </Section>
+              )}
 
               <Section>
                 <SectionTitle>현재 거래처별 잔액</SectionTitle>
@@ -1236,6 +2560,224 @@ const InlineLabel = styled.span`
 
 const InlineField = styled(Field)``;
 
+const ApprovalNumberRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: ${spacing.space12};
+
+  @media (min-width: 120rem) {
+    gap: ${spacing.space20};
+  }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ApprovalNumberField = styled(Field)``;
+
+const ResponsiveTableWrap = styled.div`
+  width: 100%;
+  overflow-x: auto;
+`;
+
+const tableCellBase = `
+  border: 1px solid ${colors.borderStrong};
+  padding: ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  vertical-align: middle;
+
+  @media (min-width: 120rem) {
+    padding: ${spacing.space20};
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryTable = styled.table`
+  width: 100%;
+  min-width: 48rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const SummaryLabelCell = styled.th`
+  ${tableCellBase}
+  width: 10rem;
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const SummaryValueCell = styled.td`
+  ${tableCellBase}
+  background-color: ${colors.white};
+`;
+
+const SummaryWideCell = styled(SummaryValueCell)`
+  min-height: 10rem;
+`;
+
+const SummaryReadOnlyBlock = styled.pre`
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  font-family: inherit;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryTextareaInput = styled.textarea`
+  width: 100%;
+  min-height: 9rem;
+  border: 0;
+  resize: vertical;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight150};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    min-height: 12rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryCellInput = styled.input`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const SummaryCellSelect = styled.select`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const BudgetTable = styled.table`
+  width: 100%;
+  min-width: 58rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const BudgetHeadCell = styled.th`
+  ${tableCellBase}
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const BudgetBodyCell = styled.td`
+  ${tableCellBase}
+  text-align: center;
+`;
+
+const BudgetTotalLabelCell = styled(BudgetBodyCell)`
+  background-color: ${colors.background};
+  font-weight: 600;
+`;
+
+const BudgetTotalValueCell = styled(BudgetBodyCell)`
+  font-weight: 600;
+`;
+
+const BudgetInlineInput = styled.input`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  text-align: center;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const BudgetInlineSelect = styled.select`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  text-align: center;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const ApprovalTable = styled.table`
+  width: 100%;
+  min-width: 46rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+`;
+
+const ApprovalTypeCell = styled.th`
+  ${tableCellBase}
+  width: 6rem;
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const ApprovalHeadCell = styled.th`
+  ${tableCellBase}
+  background-color: ${colors.background};
+  font-weight: 600;
+  text-align: center;
+`;
+
+const ApprovalBodyCell = styled.td`
+  ${tableCellBase}
+  text-align: center;
+`;
+
+const ApprovalEditableInput = styled.input`
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  line-height: ${typography.lineHeight130};
+  text-align: center;
+  outline: none;
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize20};
+  }
+`;
+
 const DetailTable = styled.table`
   width: 100%;
   border-collapse: collapse;
@@ -1319,7 +2861,6 @@ const EditInput = styled.input`
 
 const EditSelect = styled.select`
   min-width: 0;
-  min-height: 2.6875rem;
   border: 1px solid #c0c0c0;
   background-color: ${colors.white};
   color: #000000;
@@ -1459,6 +3000,24 @@ const DeleteItemButton = styled(AddItemButton)`
 
   @media (min-width: 120rem) {
     width: 12rem;
+  }
+`;
+
+const MiniDeleteButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 50%;
+  background-color: ${colors.noticeSoft};
+  color: ${colors.notice};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    width: 3rem;
+    height: 3rem;
   }
 `;
 

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -71,10 +71,12 @@ type ReportItem = {
   vendorName: string;
   name: string;
   price: string;
+  paymentMethod: string;
   receiptFile: File | null;
   receiptFileName: string;
   receiptFileId?: string;
   receiptFileUrl?: string;
+  receiptPreviewUrl?: string;
 };
 
 type ParsedPrepaidBudgetItem = {
@@ -145,6 +147,8 @@ const budgetItemNameOptions = [
   "프린트토너",
 ] as const;
 const paymentAccountOptions = ["국비04", "구비01", "구비08"] as const;
+const paymentMethodOptions = ["현금", "법인카드", "계좌이체", "자동이체", "기타 납부"] as const;
+const reportCustomOptionValue = "__report_custom__";
 
 const statusLabels: Record<PurchaseRequestStatus, string> = {
   PENDING: "대기 중",
@@ -361,6 +365,7 @@ function mapPurchaseItemsToReportItems(purchase?: ExtendedPurchaseRequest): Repo
         vendorName: transaction.vendorName ?? "",
         name: transaction.itemNames?.join(", ") || item?.name || "",
         price: typeof transaction.amount === "number" ? String(transaction.amount) : "0",
+        paymentMethod: "",
         receiptFile: null,
         receiptFileName:
           transaction.receiptFileId || transaction.receiptFileUrl
@@ -380,9 +385,14 @@ function mapPurchaseItemsToReportItems(purchase?: ExtendedPurchaseRequest): Repo
       vendorName: purchase?.vendorName ?? "",
       name: item.name ?? "",
       price: "0",
+      paymentMethod: "",
       receiptFile: null,
       receiptFileName: "",
     }));
+}
+
+function cloneReportItems(items: ReportItem[]) {
+  return items.map((item) => ({ ...item }));
 }
 
 function findPurchaseItemForTransaction(
@@ -409,6 +419,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const [editPrepaidContent, setEditPrepaidContent] = useState<ParsedPrepaidContent | null>(null);
   const [editPrepaidDepartmentId, setEditPrepaidDepartmentId] = useState("");
   const [reportItems, setReportItems] = useState<ReportItem[]>([]);
+  const [savedPrepaidReportItems, setSavedPrepaidReportItems] = useState<ReportItem[]>([]);
+  const [customReportFieldModal, setCustomReportFieldModal] = useState<{
+    field: "vendor" | "paymentMethod";
+    itemId: number;
+  } | null>(null);
+  const [customReportFieldDraft, setCustomReportFieldDraft] = useState("");
   const [isReportEditing, setIsReportEditing] = useState(false);
   const {
     data: request,
@@ -458,7 +474,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   );
   const activePrepaidContent = isEditing ? editPrepaidContent : parsedPrepaidContent;
   const initialReportItems = useMemo(() => mapPurchaseItemsToReportItems(purchase), [purchase]);
-  const activeReportItems = reportItems.length ? reportItems : initialReportItems;
+  const persistedPrepaidReportItems =
+    savedPrepaidReportItems.length > 0 ? savedPrepaidReportItems : initialReportItems;
+  const activeReportItems =
+    reportItems.length > 0
+      ? reportItems
+      : requestPaymentType === "PREPAID"
+        ? persistedPrepaidReportItems
+        : initialReportItems;
   const classrooms = useMemo(() => classroomData?.content ?? [], [classroomData]);
   const departments = useMemo(() => departmentData?.departments ?? [], [departmentData]);
   const affiliationOptions = useMemo<AffiliationOption[]>(
@@ -535,6 +558,9 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       return reportPurchase({ requestId }, body);
     },
     onSuccess: () => {
+      if (requestPaymentType === "PREPAID") {
+        setSavedPrepaidReportItems(cloneReportItems(activeReportItems));
+      }
       setIsReportEditing(false);
       setReportItems([]);
       queryClient.invalidateQueries({ queryKey: queryKeys.requests.purchaseDetail(requestId) });
@@ -601,8 +627,20 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const canEditRequest = request?.status === "PENDING" && canManageRequest;
   const canDeleteRequest = request?.status === "PENDING" && canManageRequest;
   const canShowReportForm = request?.status === "APPROVED" && isRequester;
-  const canEditPurchaseReport = request?.status === "PURCHASED" && canManagePurchaseReport;
-  const canShowReportEditor = canShowReportForm || isReportEditing;
+  const canEditPurchaseReport =
+    (request?.status === "PURCHASED" || request?.status === "CONFIRMED") &&
+    canManagePurchaseReport;
+  const canShowReportSection =
+    requestPaymentType === "PREPAID"
+      ? canShowReportForm || canEditPurchaseReport || isReportEditing
+      : canShowReportForm || isReportEditing;
+  const isPrepaidReportReadOnly =
+    requestPaymentType === "PREPAID" && canEditPurchaseReport && !isReportEditing;
+  const canPrintApprovalForm =
+    request?.status === "APPROVED" ||
+    request?.status === "PURCHASED" ||
+    request?.status === "CONFIRMED";
+  const canPrintResolutionForm = request?.status === "CONFIRMED";
   const vendorBalances: VendorBalance[] = vendorData?.length
     ? vendorData.map((vendor) => ({
         vendorId: vendor.id,
@@ -619,7 +657,8 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     .filter((vendor) => typeof vendor.vendorId === "number" && Boolean(vendor.vendorName))
     .map((vendor) => ({ id: vendor.vendorId as number, name: vendor.vendorName as string }));
   const canSubmitReport =
-    canShowReportEditor &&
+    canShowReportSection &&
+    !isPrepaidReportReadOnly &&
     activeReportItems.length > 0 &&
     activeReportItems.every(
       (item) =>
@@ -627,7 +666,8 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
         item.name.trim().length > 0 &&
         item.price.trim().length > 0 &&
         Number.isFinite(Number(item.price)) &&
-        Number(item.price) >= 1,
+        Number(item.price) >= 1 &&
+        (requestPaymentType !== "PREPAID" || item.paymentMethod.trim().length > 0),
     ) &&
     !reportMutation.isPending;
   const prepaidQuantityTotal =
@@ -646,10 +686,12 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       vendorId: string;
       name: string;
       price: string;
+      paymentMethod: string;
       receiptFile: File | null;
       receiptFileName: string;
       receiptFileId: string;
       receiptFileUrl: string;
+      receiptPreviewUrl: string;
     }>,
   ) {
     setReportItems((current) =>
@@ -661,10 +703,55 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
 
   function handleReceiptChange(itemId: number, event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
+    const previewUrl = file ? URL.createObjectURL(file) : undefined;
     updateReportItem(itemId, {
       receiptFile: file,
       receiptFileName: file?.name ?? "",
+      receiptPreviewUrl: previewUrl,
     });
+  }
+
+  function openCustomReportFieldModal(field: "vendor" | "paymentMethod", itemId: number) {
+    const currentItem = activeReportItems.find((item) => item.itemId === itemId);
+    const draft =
+      field === "vendor"
+        ? currentItem?.vendorId === reportCustomOptionValue
+          ? (currentItem.vendorName ?? "")
+          : ""
+        : paymentMethodOptions.includes(
+              (currentItem?.paymentMethod ?? "") as (typeof paymentMethodOptions)[number],
+            )
+          ? ""
+          : (currentItem?.paymentMethod ?? "");
+
+    setCustomReportFieldDraft(draft);
+    setCustomReportFieldModal({ field, itemId });
+  }
+
+  function closeCustomReportFieldModal() {
+    setCustomReportFieldModal(null);
+    setCustomReportFieldDraft("");
+  }
+
+  function confirmCustomReportFieldModal() {
+    const nextValue = customReportFieldDraft.trim();
+
+    if (!customReportFieldModal || !nextValue) {
+      return;
+    }
+
+    if (customReportFieldModal.field === "vendor") {
+      updateReportItem(customReportFieldModal.itemId, {
+        vendorId: reportCustomOptionValue,
+        vendorName: nextValue,
+      });
+    }
+
+    if (customReportFieldModal.field === "paymentMethod") {
+      updateReportItem(customReportFieldModal.itemId, { paymentMethod: nextValue });
+    }
+
+    closeCustomReportFieldModal();
   }
 
   function updateEditItem(itemId: number, patch: Partial<EditableItem>) {
@@ -901,7 +988,9 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   }
 
   function startReportEditing() {
-    setReportItems(initialReportItems);
+    const sourceItems =
+      requestPaymentType === "PREPAID" ? persistedPrepaidReportItems : initialReportItems;
+    setReportItems(cloneReportItems(sourceItems));
     setIsReportEditing(true);
   }
 
@@ -1063,50 +1152,64 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
 
         <Content>
           <Actions>
-            {isEditing ? (
-              <>
-                <ActionButton type="submit" form="finance-request-edit-form" $variant="edit">
-                  수정 완료
+            {!isEditing && requestPaymentType === "PREPAID" ? (
+              <ActionGroup>
+                <ActionButton type="button" $variant="edit" disabled={!canPrintApprovalForm}>
+                  품의서 출력
                 </ActionButton>
-                <CancelTopButton type="button" onClick={() => setIsEditing(false)}>
-                  취소
-                </CancelTopButton>
-              </>
+                <ActionButton type="button" $variant="edit" disabled={!canPrintResolutionForm}>
+                  결의서 출력
+                </ActionButton>
+              </ActionGroup>
             ) : (
-              <>
-                {canManageRequest ? (
-                  <>
-                    <ActionButton
-                      type="button"
-                      $variant="danger"
-                      disabled={!canDeleteRequest || deleteMutation.isPending || isLoading}
-                      title={
-                        canDeleteRequest
-                          ? undefined
-                          : "관리자이거나 대기 중인 본인 작성 글만 삭제할 수 있습니다."
-                      }
-                      onClick={() => deleteMutation.mutate()}
-                    >
-                      {deleteMutation.isPending ? "삭제 중" : "삭제"}
-                    </ActionButton>
-                    <ActionButton
-                      type="button"
-                      $variant="edit"
-                      disabled={!canEditRequest}
-                      title={
-                        canEditRequest
-                          ? undefined
-                          : "관리자이거나 대기 중인 본인 작성 글만 수정할 수 있습니다."
-                      }
-                      onClick={startEditing}
-                    >
-                      수정
-                    </ActionButton>
-                  </>
-                ) : null}
-                <ListButton href="/staff/finance-management">목록</ListButton>
-              </>
+              <div />
             )}
+            <ActionGroup>
+              {isEditing ? (
+                <>
+                  <ActionButton type="submit" form="finance-request-edit-form" $variant="edit">
+                    수정 완료
+                  </ActionButton>
+                  <CancelTopButton type="button" onClick={() => setIsEditing(false)}>
+                    취소
+                  </CancelTopButton>
+                </>
+              ) : (
+                <>
+                  {canManageRequest ? (
+                    <>
+                      <ActionButton
+                        type="button"
+                        $variant="danger"
+                        disabled={!canDeleteRequest || deleteMutation.isPending || isLoading}
+                        title={
+                          canDeleteRequest
+                            ? undefined
+                            : "관리자이거나 대기 중인 본인 작성 글만 삭제할 수 있습니다."
+                        }
+                        onClick={() => deleteMutation.mutate()}
+                      >
+                        {deleteMutation.isPending ? "삭제 중" : "삭제"}
+                      </ActionButton>
+                      <ActionButton
+                        type="button"
+                        $variant="edit"
+                        disabled={!canEditRequest}
+                        title={
+                          canEditRequest
+                            ? undefined
+                            : "관리자이거나 대기 중인 본인 작성 글만 수정할 수 있습니다."
+                        }
+                        onClick={startEditing}
+                      >
+                        수정
+                      </ActionButton>
+                    </>
+                  ) : null}
+                  <ListButton href="/staff/finance-management">목록</ListButton>
+                </>
+              )}
+            </ActionGroup>
           </Actions>
 
           {isLoading ? <StateMessage>결제 신청 정보를 불러오는 중입니다.</StateMessage> : null}
@@ -1842,14 +1945,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       <EditItemList>
                         {(editItems.length ? editItems : initialEditItems).map((item, index) => (
                           <EditItemBlock key={item.id}>
-                          <ItemFieldRow>
-                            <ItemLabel htmlFor={`editItemName-${item.id}`}>
-                              {(editItems.length ? editItems : initialEditItems).length > 1
-                                ? `품목 ${index + 1}`
-                                : "품목"}
-                            </ItemLabel>
-                            <EditInput
-                              id={`editItemName-${item.id}`}
+                            <ItemFieldRow>
+                              <ItemLabel htmlFor={`editItemName-${item.id}`}>
+                                {(editItems.length ? editItems : initialEditItems).length > 1
+                                  ? `품목 ${index + 1}`
+                                  : "품목"}
+                              </ItemLabel>
+                              <EditInput
+                                id={`editItemName-${item.id}`}
                                 value={item.name}
                                 onChange={(event) =>
                                   updateEditItem(item.id, { name: event.target.value })
@@ -2164,87 +2267,200 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 ) : null}
               </Section>
 
-              {canShowReportEditor ? (
+              {canShowReportSection ? (
                 <ReportForm onSubmit={handleReportSubmit}>
-                  <SectionTitle>
-                    {isReportEditing ? "구매 완료 보고 수정" : "구매 완료 보고"}
-                  </SectionTitle>
-                  {activeReportItems.map((item, index) => (
-                    <ReportGrid key={item.itemId}>
-                      <ReportLabel htmlFor={`reportName-${item.itemId}`}>
-                        {activeReportItems.length > 1 ? `품목 ${index + 1}` : "품목"}
-                      </ReportLabel>
-                      <ReadOnlyReportField id={`reportName-${item.itemId}`}>
-                        {item.name || "-"}
-                      </ReadOnlyReportField>
-                      <ReportLabel htmlFor={`vendor-${item.itemId}`}>거래처</ReportLabel>
-                      <ReportSelect
-                        id={`vendor-${item.itemId}`}
-                        value={item.vendorId}
-                        onChange={(event) => {
-                          const vendor = vendorOptions.find(
-                            (option) => String(option.id) === event.target.value,
-                          );
+                  {requestPaymentType === "PREPAID" ? (
+                    <DetailSectionHeader>
+                      <SectionTitle>
+                        {isReportEditing ? "구매 완료 보고 수정" : "구매 완료 보고"}
+                      </SectionTitle>
+                      {canEditPurchaseReport && !isReportEditing ? (
+                        <ReportEditTextButton type="button" onClick={startReportEditing}>
+                          수정
+                        </ReportEditTextButton>
+                      ) : null}
+                    </DetailSectionHeader>
+                  ) : (
+                    <SectionTitle>
+                      {isReportEditing ? "구매 완료 보고 수정" : "구매 완료 보고"}
+                    </SectionTitle>
+                  )}
+                  <ResponsiveTableWrap>
+                    <ReportTable>
+                      <thead>
+                        <tr>
+                          <ReportHeadCell>품목</ReportHeadCell>
+                          <ReportHeadCell>거래처</ReportHeadCell>
+                          <ReportHeadCell>결제 금액</ReportHeadCell>
+                          {requestPaymentType === "PREPAID" ? (
+                            <ReportHeadCell>지급 구분</ReportHeadCell>
+                          ) : null}
+                          <ReportHeadCell>영수증</ReportHeadCell>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {activeReportItems.map((item, index) => (
+                          <tr key={item.itemId}>
+                            <ReportBodyCell>
+                              <ReportInlineText id={`reportName-${item.itemId}`}>
+                                {item.name ||
+                                  (activeReportItems.length > 1 ? `품목 ${index + 1}` : "품목")}
+                              </ReportInlineText>
+                            </ReportBodyCell>
+                            <ReportBodyCell>
+                              {isPrepaidReportReadOnly ? (
+                                <ReportInlineText>{item.vendorName || "-"}</ReportInlineText>
+                              ) : (
+                                <ReportSelect
+                                  id={`vendor-${item.itemId}`}
+                                  value={
+                                    item.vendorId && item.vendorId !== reportCustomOptionValue
+                                      ? item.vendorId
+                                      : item.vendorName.trim().length > 0
+                                        ? reportCustomOptionValue
+                                        : ""
+                                  }
+                                  onChange={(event) => {
+                                    if (event.target.value === reportCustomOptionValue) {
+                                      openCustomReportFieldModal("vendor", item.itemId);
+                                      return;
+                                    }
 
-                          updateReportItem(item.itemId, {
-                            vendorId: event.target.value,
-                            vendorName: vendor?.name ?? "",
-                          });
-                        }}
-                      >
-                        <option value="">거래처 선택</option>
-                        {vendorOptions.map((vendor) => (
-                          <option key={vendor.id} value={vendor.id}>
-                            {vendor.name}
-                          </option>
+                                    const vendor = vendorOptions.find(
+                                      (option) => String(option.id) === event.target.value,
+                                    );
+
+                                    updateReportItem(item.itemId, {
+                                      vendorId: event.target.value,
+                                      vendorName: vendor?.name ?? "",
+                                    });
+                                  }}
+                                >
+                                  <option value="">거래처 선택</option>
+                                  {vendorOptions.map((vendor) => (
+                                    <option key={vendor.id} value={vendor.id}>
+                                      {vendor.name}
+                                    </option>
+                                  ))}
+                                  <option value={reportCustomOptionValue}>직접 입력</option>
+                                </ReportSelect>
+                              )}
+                            </ReportBodyCell>
+                            <ReportBodyCell>
+                              {isPrepaidReportReadOnly ? (
+                                <ReportInlineText>
+                                  {item.price.trim().length > 0
+                                    ? `${Number(item.price).toLocaleString()}원`
+                                    : "-"}
+                                </ReportInlineText>
+                              ) : (
+                                <ReportInput
+                                  id={`price-${item.itemId}`}
+                                  type="number"
+                                  min="1"
+                                  inputMode="numeric"
+                                  placeholder="0"
+                                  value={item.price}
+                                  onChange={(event) =>
+                                    updateReportItem(item.itemId, { price: event.target.value })
+                                  }
+                                />
+                              )}
+                            </ReportBodyCell>
+                            {requestPaymentType === "PREPAID" ? (
+                              <ReportBodyCell>
+                                {isPrepaidReportReadOnly ? (
+                                  <ReportInlineText>{item.paymentMethod || "-"}</ReportInlineText>
+                                ) : (
+                                  <ReportSelect
+                                    value={
+                                      item.paymentMethod &&
+                                      !paymentMethodOptions.includes(
+                                        item.paymentMethod as (typeof paymentMethodOptions)[number],
+                                      )
+                                        ? reportCustomOptionValue
+                                        : item.paymentMethod
+                                    }
+                                    onChange={(event) => {
+                                      if (event.target.value === reportCustomOptionValue) {
+                                        openCustomReportFieldModal("paymentMethod", item.itemId);
+                                        return;
+                                      }
+
+                                      updateReportItem(item.itemId, {
+                                        paymentMethod: event.target.value,
+                                      });
+                                    }}
+                                  >
+                                    <option value="">지급 구분 선택</option>
+                                    {paymentMethodOptions.map((option) => (
+                                      <option key={option} value={option}>
+                                        {option}
+                                      </option>
+                                    ))}
+                                    <option value={reportCustomOptionValue}>직접 입력</option>
+                                  </ReportSelect>
+                                )}
+                              </ReportBodyCell>
+                            ) : null}
+                            <ReportBodyCell>
+                              {isPrepaidReportReadOnly ? (
+                                item.receiptFileUrl || item.receiptPreviewUrl ? (
+                                  <InlineReceiptLink
+                                    href={item.receiptFileUrl ?? item.receiptPreviewUrl ?? "#"}
+                                    download={item.receiptFileName || "영수증"}
+                                  >
+                                    영수증
+                                    <ReceiptIcon aria-hidden="true">
+                                      <IconDownload size={12} stroke={2.25} />
+                                    </ReceiptIcon>
+                                  </InlineReceiptLink>
+                                ) : (
+                                  <ReportInlineText>
+                                    {item.receiptFileName ? "영수증" : "-"}
+                                  </ReportInlineText>
+                                )
+                              ) : (
+                                <UploadControl>
+                                  <UploadInput
+                                    id={`receipt-${item.itemId}`}
+                                    type="file"
+                                    onChange={(event) => handleReceiptChange(item.itemId, event)}
+                                  />
+                                  <UploadBox htmlFor={`receipt-${item.itemId}`}>
+                                    <IconFilePlus size={20} stroke={1.8} aria-hidden="true" />
+                                    <span>{item.receiptFileName || "파일 추가하기"}</span>
+                                  </UploadBox>
+                                </UploadControl>
+                              )}
+                            </ReportBodyCell>
+                          </tr>
                         ))}
-                      </ReportSelect>
-                      <ReportLabel htmlFor={`price-${item.itemId}`}>결제 금액</ReportLabel>
-                      <ReportInput
-                        id={`price-${item.itemId}`}
-                        type="number"
-                        min="1"
-                        inputMode="numeric"
-                        placeholder="0"
-                        value={item.price}
-                        onChange={(event) =>
-                          updateReportItem(item.itemId, { price: event.target.value })
-                        }
-                      />
-                      <ReportLabel htmlFor={`receipt-${item.itemId}`}>영수증</ReportLabel>
-                      <UploadControl>
-                        <UploadInput
-                          id={`receipt-${item.itemId}`}
-                          type="file"
-                          onChange={(event) => handleReceiptChange(item.itemId, event)}
-                        />
-                        <UploadBox htmlFor={`receipt-${item.itemId}`}>
-                          <IconFilePlus size={20} stroke={1.8} aria-hidden="true" />
-                          <span>{item.receiptFileName || "파일 추가하기"}</span>
-                        </UploadBox>
-                      </UploadControl>
-                    </ReportGrid>
-                  ))}
-                  <ReportActionRow>
-                    <ReportSubmitButton type="submit" disabled={!canSubmitReport}>
-                      {reportMutation.isPending
-                        ? isReportEditing
-                          ? "수정 중"
-                          : "보고 중"
-                        : isReportEditing
-                          ? "수정 완료"
-                          : "구매 완료 보고하기"}
-                    </ReportSubmitButton>
-                    {isReportEditing ? (
-                      <CancelEditButton
-                        type="button"
-                        disabled={reportMutation.isPending}
-                        onClick={cancelReportEditing}
-                      >
-                        취소
-                      </CancelEditButton>
-                    ) : null}
-                  </ReportActionRow>
+                      </tbody>
+                    </ReportTable>
+                  </ResponsiveTableWrap>
+                  {!isPrepaidReportReadOnly ? (
+                    <ReportActionRow>
+                      <ReportSubmitButton type="submit" disabled={!canSubmitReport}>
+                        {reportMutation.isPending
+                          ? isReportEditing
+                            ? "수정 중"
+                            : "보고 중"
+                          : isReportEditing
+                            ? "수정 완료"
+                            : "구매 완료 보고하기"}
+                      </ReportSubmitButton>
+                      {isReportEditing ? (
+                        <CancelEditButton
+                          type="button"
+                          disabled={reportMutation.isPending}
+                          onClick={cancelReportEditing}
+                        >
+                          취소
+                        </CancelEditButton>
+                      ) : null}
+                    </ReportActionRow>
+                  ) : null}
                   {reportMutation.isError ? (
                     <StateMessage role="alert">
                       {isReportEditing
@@ -2253,6 +2469,43 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                     </StateMessage>
                   ) : null}
                 </ReportForm>
+              ) : null}
+
+              {customReportFieldModal ? (
+                <ModalOverlay role="presentation">
+                  <ModalCard
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="report-custom-input-modal-title"
+                  >
+                    <ModalTitle id="report-custom-input-modal-title">
+                      {customReportFieldModal.field === "vendor"
+                        ? "거래처 직접 입력"
+                        : "지급 구분 직접 입력"}
+                    </ModalTitle>
+                    <ModalInput
+                      value={customReportFieldDraft}
+                      onChange={(event) => setCustomReportFieldDraft(event.target.value)}
+                      placeholder={
+                        customReportFieldModal.field === "vendor" ? "거래처 입력" : "지급 구분 입력"
+                      }
+                      autoFocus
+                    />
+                    <ModalActionRow>
+                      <ModalButton type="button" onClick={closeCustomReportFieldModal}>
+                        취소
+                      </ModalButton>
+                      <ModalButton
+                        type="button"
+                        $variant="primary"
+                        onClick={confirmCustomReportFieldModal}
+                        disabled={customReportFieldDraft.trim().length === 0}
+                      >
+                        확인
+                      </ModalButton>
+                    </ModalActionRow>
+                  </ModalCard>
+                </ModalOverlay>
               ) : null}
             </ContentColumn>
           ) : null}
@@ -2305,7 +2558,8 @@ const Content = styled.section`
 
 const Actions = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: flex-start;
   gap: ${spacing.space20};
   margin-bottom: 2.25rem;
 
@@ -2313,6 +2567,16 @@ const Actions = styled.div`
     gap: 1.875rem;
     margin-bottom: 3rem;
   }
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    flex-wrap: wrap;
+  }
+`;
+
+const ActionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
 
   @media (max-width: ${layout.breakpointMobile}) {
     flex-wrap: wrap;
@@ -2369,9 +2633,8 @@ const BaseAction = styled.button<{ $variant?: "default" | "danger" | "edit" }>`
   cursor: pointer;
 
   &:disabled {
-    background-color: #d4d4d4;
-    border-color: #d4d4d4;
-    color: #7b7b7b;
+    opacity: 0.45;
+    filter: saturate(0.7);
     cursor: not-allowed;
   }
 
@@ -3144,55 +3407,34 @@ const ReportForm = styled.form`
   }
 `;
 
-const ReportActionRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${spacing.space12};
-  flex-wrap: wrap;
+const ReportTable = styled.table`
+  width: 100%;
+  min-width: 44rem;
+  border-collapse: collapse;
+  table-layout: fixed;
 `;
 
-const ReportGrid = styled.div`
-  display: grid;
-  grid-template-columns:
-    auto minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 0.8fr)
-    auto minmax(8rem, auto);
-  align-items: center;
-  gap: ${spacing.space12};
-
-  @media (min-width: 120rem) {
-    gap: ${spacing.space20};
-  }
-
-  @media (max-width: ${layout.breakpointTablet}) {
-    grid-template-columns: auto minmax(0, 1fr);
-  }
-
-  @media (max-width: ${layout.breakpointMobile}) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const ReportLabel = styled.label`
-  color: #000000;
-  font-size: ${typography.fontSize14};
+const ReportHeadCell = styled.th`
+  ${tableCellBase}
+  background-color: ${colors.background};
   font-weight: 600;
-  line-height: ${typography.lineHeight130};
-  white-space: nowrap;
+  text-align: center;
+`;
 
-  @media (min-width: 120rem) {
-    font-size: ${typography.fontSize20};
-  }
+const ReportBodyCell = styled.td`
+  ${tableCellBase}
+  text-align: center;
 `;
 
 const ReportInput = styled.input`
-  min-width: 8rem;
-  min-height: 2.6875rem;
-  border: 1px solid ${colors.muted};
-  background-color: ${colors.white};
-  padding: 0.8125rem ${spacing.space12};
+  width: 100%;
+  border: 0;
+  background-color: transparent;
+  padding: 0;
   color: #000000;
   font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
+  text-align: center;
   outline: none;
 
   &::placeholder {
@@ -3200,57 +3442,60 @@ const ReportInput = styled.input`
   }
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20};
     font-size: ${typography.fontSize20};
   }
 `;
 
-const ReadOnlyReportField = styled.div`
-  min-width: 0;
-  min-height: 2.6875rem;
+const ReportInlineText = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
-  background-color: ${colors.background};
-  padding: 0.8125rem ${spacing.space12};
+  justify-content: center;
+  background-color: transparent;
+  padding: 0;
   color: #000000;
   font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
   overflow-wrap: anywhere;
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20};
     font-size: ${typography.fontSize20};
   }
 `;
 
+const ReportActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space12};
+  flex-wrap: wrap;
+`;
+
 const ReportSelect = styled.select`
-  min-width: 0;
-  min-height: 2.6875rem;
-  border: 1px solid ${colors.muted};
-  background-color: ${colors.white};
+  width: 100%;
+  border: 0;
+  background-color: transparent;
   appearance: none;
-  padding: 0.8125rem ${spacing.space32} 0.8125rem ${spacing.space12};
+  padding: 0 ${spacing.space24} 0 0;
   color: #000000;
   font-size: ${typography.fontSize14};
   line-height: ${typography.lineHeight130};
+  text-align: center;
+  text-align-last: center;
   outline: none;
   background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23000000' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-position: right ${spacing.space12} center;
+  background-position: right ${spacing.space8} center;
   background-repeat: no-repeat;
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20} 3rem ${spacing.space20} ${spacing.space20};
+    padding-right: 2rem;
     font-size: ${typography.fontSize20};
-    background-position: right ${spacing.space20} center;
+    background-position: right ${spacing.space12} center;
   }
 `;
 
 const UploadControl = styled.div`
   display: flex;
-  align-items: flex-start;
+  justify-content: center;
 `;
 
 const UploadInput = styled.input`
@@ -3266,38 +3511,105 @@ const UploadInput = styled.input`
 
 const UploadBox = styled.label`
   display: inline-flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: ${spacing.space8};
-  min-width: 5.5rem;
-  min-height: 4.125rem;
-  padding: ${spacing.space20};
-  background-color: ${colors.background};
-  color: #969696;
-  font-size: 0.5rem;
+  padding: 0;
+  background-color: transparent;
+  color: ${colors.text};
+  font-size: ${typography.fontSize14};
   font-weight: 500;
   line-height: ${typography.lineHeight130};
   cursor: pointer;
 
   span {
-    max-width: 12rem;
+    max-width: 10rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   @media (min-width: 120rem) {
-    min-width: 8.375rem;
-    min-height: 6.25rem;
-    gap: 0.9375rem;
-    padding: 1.875rem;
-    font-size: 0.75rem;
+    font-size: ${typography.fontSize20};
 
     svg {
-      width: 2rem;
-      height: 2rem;
+      width: 1.5rem;
+      height: 1.5rem;
     }
+  }
+`;
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${spacing.space20};
+  background-color: rgba(0, 0, 0, 0.4);
+`;
+
+const ModalCard = styled.div`
+  width: min(100%, 28rem);
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.space16};
+  border-radius: ${radii.radius20};
+  background-color: ${colors.white};
+  padding: ${spacing.space24};
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.16);
+`;
+
+const ModalTitle = styled.h3`
+  margin: 0;
+  color: #000000;
+  font-size: ${typography.fontSize18};
+  font-weight: 700;
+  line-height: ${typography.lineHeight130};
+`;
+
+const ModalInput = styled.input`
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #c0c0c0;
+  background-color: ${colors.white};
+  padding: 0.8125rem ${spacing.space12};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 400;
+  line-height: ${typography.lineHeight130};
+  outline: none;
+
+  &::placeholder {
+    color: #b1b1b1;
+  }
+
+  @media (min-width: 120rem) {
+    font-size: ${typography.fontSize18};
+  }
+`;
+
+const ModalActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${spacing.space12};
+`;
+
+const ModalButton = styled.button<{ $variant?: "primary" }>`
+  min-width: 5rem;
+  min-height: 2.5rem;
+  border: 1px solid ${({ $variant }) => ($variant === "primary" ? colors.point : colors.border)};
+  border-radius: ${radii.radius12};
+  background-color: ${({ $variant }) => ($variant === "primary" ? colors.point : colors.white)};
+  color: ${({ $variant }) => ($variant === "primary" ? colors.white : colors.text)};
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 
@@ -3318,9 +3630,8 @@ const ReportSubmitButton = styled.button`
   cursor: pointer;
 
   &:disabled {
-    border-color: #d4d4d4;
-    background-color: #d4d4d4;
-    color: #7b7b7b;
+    opacity: 0.45;
+    filter: saturate(0.7);
     cursor: not-allowed;
   }
 

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, FormEvent, Fragment, useMemo, useState } from "react";
 import { IconDownload, IconFilePlus, IconX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
 import styled from "styled-components";
 import { getClassrooms } from "@/api/classroom/classroom.api";
 import { getDepartments } from "@/api/department/department.api";
@@ -25,6 +26,7 @@ import type {
 import { getVendors } from "@/api/vendor/vendor.api";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { formatUtcToKstShortDate } from "@/utils/formatUtcToKstShortDate";
@@ -460,6 +462,9 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       queryClient.removeQueries({ queryKey: queryKeys.requests.purchaseList() });
       router.replace("/staff/finance-management");
     },
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결제 신청 삭제에 실패했습니다."));
+    },
   });
 
   const purchase = request as ExtendedPurchaseRequest | undefined;
@@ -566,6 +571,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       queryClient.invalidateQueries({ queryKey: queryKeys.requests.purchaseDetail(requestId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.requests.purchaseList() });
       queryClient.invalidateQueries({ queryKey: queryKeys.vendors.list() });
+    },
+    onError: (error) => {
+      toast.error(
+        extractApiErrorMessage(
+          error,
+          isReportEditing ? "구매 완료 보고 수정에 실패했습니다." : "구매 완료 보고에 실패했습니다.",
+        ),
+      );
     },
   });
 
@@ -1216,10 +1229,6 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
           {isError ? (
             <StateMessage role="alert">결제 신청 정보를 불러오지 못했습니다.</StateMessage>
           ) : null}
-          {deleteMutation.isError ? (
-            <StateMessage role="alert">결제 신청 삭제에 실패했습니다.</StateMessage>
-          ) : null}
-
           {request ? (
             <ContentColumn
               as={isEditing ? "form" : "article"}
@@ -2460,13 +2469,6 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                         </CancelEditButton>
                       ) : null}
                     </ReportActionRow>
-                  ) : null}
-                  {reportMutation.isError ? (
-                    <StateMessage role="alert">
-                      {isReportEditing
-                        ? "구매 완료 보고 수정에 실패했습니다."
-                        : "구매 완료 보고에 실패했습니다."}
-                    </StateMessage>
                   ) : null}
                 </ReportForm>
               ) : null}

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -63,7 +63,6 @@ type EditableItem = {
   name: string;
   quantity: string;
   reason: string;
-  paymentType: PaymentType;
 };
 
 type ReportItem = {
@@ -138,16 +137,18 @@ function getReceiptName(receipt: {
 
 function mapPurchaseItemsToEditableItems(items?: PurchaseRequestItemResponseDto[]) {
   return (items ?? []).map((item, index) => {
-    const extendedItem = item as ExtendedPurchaseItem;
-
     return {
       id: item.id ?? index + 1,
       name: item.name ?? "",
-      quantity: typeof extendedItem.quantity === "number" ? String(extendedItem.quantity) : "1",
+      quantity: typeof item.quantity === "number" ? String(item.quantity) : "1",
       reason: item.reason ?? "",
-      paymentType: extendedItem.paymentType ?? "ACTUAL",
     };
   });
+}
+
+function getRequestPaymentType(items?: PurchaseRequestItemResponseDto[]): PaymentType {
+  const paymentType = items?.find((item) => item.paymentType)?.paymentType;
+  return paymentType === "PREPAID" ? "PREPAID" : "ACTUAL";
 }
 
 function mapPurchaseItemsToReportItems(purchase?: ExtendedPurchaseRequest): ReportItem[] {
@@ -280,9 +281,9 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
   const requestAffiliationValue = useMemo(() => {
     const currentAffiliation = affiliationOptions.find((option) =>
       option.type === "department"
-        ? (typeof request?.departmentId === "number"
-            ? option.id === request.departmentId
-            : option.label === request?.departmentName)
+        ? typeof request?.departmentId === "number"
+          ? option.id === request.departmentId
+          : option.label === request?.departmentName
         : typeof request?.classroomId === "number"
           ? option.id === request.classroomId
           : option.label === request?.classroomName,
@@ -389,8 +390,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     user.id === request.requestedById;
   const isAdmin = authStatus === "authenticated" && user?.role === "ADMIN";
   const canManageRequest = isAdmin || isRequester;
-  const canManagePurchaseReport =
-    authStatus === "authenticated" && canManageRequest;
+  const canManagePurchaseReport = authStatus === "authenticated" && canManageRequest;
   const canEditRequest = request?.status === "PENDING" && canManageRequest;
   const canDeleteRequest = request?.status === "PENDING" && canManageRequest;
   const canShowReportForm = request?.status === "APPROVED" && isRequester;
@@ -460,6 +460,42 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
     );
   }
 
+  function addEditItem() {
+    setEditItems((current) => {
+      const source = current.length ? current : initialEditItems;
+      const nextId = source.length ? Math.max(...source.map((item) => item.id)) + 1 : 1;
+
+      return [
+        ...source,
+        {
+          id: nextId,
+          name: "",
+          quantity: "1",
+          reason: "",
+        },
+      ];
+    });
+  }
+
+  function removeEditItem(itemId: number) {
+    setEditItems((current) => {
+      const source = current.length ? current : initialEditItems;
+
+      if (source.length <= 1) {
+        return [
+          {
+            id: source[0]?.id ?? 1,
+            name: "",
+            quantity: "1",
+            reason: "",
+          },
+        ];
+      }
+
+      return source.filter((item) => item.id !== itemId);
+    });
+  }
+
   function startEditing() {
     if (!request) {
       return;
@@ -499,17 +535,13 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
       ...request,
       title: editTitle.trim() || request.title,
       classroomId:
-        selectedAffiliation?.type === "classroom"
-          ? selectedAffiliation.id
-          : request.classroomId,
+        selectedAffiliation?.type === "classroom" ? selectedAffiliation.id : request.classroomId,
       classroomName:
         selectedAffiliation?.type === "classroom"
           ? selectedAffiliation.label
           : request.classroomName,
       departmentId:
-        selectedAffiliation?.type === "department"
-          ? selectedAffiliation.id
-          : request.departmentId,
+        selectedAffiliation?.type === "department" ? selectedAffiliation.id : request.departmentId,
       departmentName:
         selectedAffiliation?.type === "department"
           ? selectedAffiliation.label
@@ -519,7 +551,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
         name: item.name.trim(),
         reason: item.reason.trim() || undefined,
         quantity: Number(item.quantity),
-        paymentType: item.paymentType,
+        paymentType: getRequestPaymentType(request.items),
       })),
     };
 
@@ -649,6 +681,36 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 </InfoRow>
               </Section>
 
+              {isEditing ? (
+                <Section>
+                  <SectionTitle>결제 유형</SectionTitle>
+                  <PaymentTypeGroup aria-disabled="true">
+                    <PaymentTypeOption>
+                      <input
+                        type="checkbox"
+                        name="edit-paymentType"
+                        value="PREPAID"
+                        checked={getRequestPaymentType(request.items) === "PREPAID"}
+                        disabled
+                        readOnly
+                      />
+                      <span>선금 결제</span>
+                    </PaymentTypeOption>
+                    <PaymentTypeOption>
+                      <input
+                        type="checkbox"
+                        name="edit-paymentType"
+                        value="ACTUAL"
+                        checked={getRequestPaymentType(request.items) === "ACTUAL"}
+                        disabled
+                        readOnly
+                      />
+                      <span>실 결제</span>
+                    </PaymentTypeOption>
+                  </PaymentTypeGroup>
+                </Section>
+              ) : null}
+
               <Section>
                 <DetailSectionHeader>
                   <SectionTitle>상세 품목</SectionTitle>
@@ -659,77 +721,63 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                   ) : null}
                 </DetailSectionHeader>
                 {isEditing ? (
-                  <EditItemList>
-                    {(editItems.length ? editItems : initialEditItems).map((item, index) => (
-                      <EditItemBlock key={item.id}>
-                        <ItemFieldRow>
-                          <ItemLabel htmlFor={`editItemName-${item.id}`}>
-                            품목 {index + 1}
-                          </ItemLabel>
-                          <EditInput
-                            id={`editItemName-${item.id}`}
-                            value={item.name}
-                            onChange={(event) =>
-                              updateEditItem(item.id, { name: event.target.value })
-                            }
-                          />
-                        </ItemFieldRow>
-                        <ItemFieldRow>
-                          <ItemLabel htmlFor={`editQuantity-${item.id}`}>개수</ItemLabel>
-                          <EditInput
-                            id={`editQuantity-${item.id}`}
-                            type="number"
-                            min="1"
-                            step="1"
-                            inputMode="numeric"
-                            value={item.quantity}
-                            onChange={(event) =>
-                              updateEditItem(item.id, { quantity: event.target.value })
-                            }
-                          />
-                        </ItemFieldRow>
-                        <ItemFieldRow>
-                          <ItemLabel htmlFor={`editReason-${item.id}`}>결제 사유</ItemLabel>
-                          <EditInput
-                            id={`editReason-${item.id}`}
-                            value={item.reason}
-                            onChange={(event) =>
-                              updateEditItem(item.id, { reason: event.target.value })
-                            }
-                          />
-                        </ItemFieldRow>
-                        <ItemFieldRow>
-                          <ItemLabel>결제 유형</ItemLabel>
-                          <PaymentTypeGroup>
-                            <PaymentTypeOption>
-                              <input
-                                type="checkbox"
-                                checked={item.paymentType === "PREPAID"}
-                                onChange={(event) => {
-                                  if (event.target.checked) {
-                                    updateEditItem(item.id, { paymentType: "PREPAID" });
-                                  }
-                                }}
-                              />
-                              <span>선금 결제</span>
-                            </PaymentTypeOption>
-                            <PaymentTypeOption>
-                              <input
-                                type="checkbox"
-                                checked={item.paymentType === "ACTUAL"}
-                                onChange={(event) => {
-                                  if (event.target.checked) {
-                                    updateEditItem(item.id, { paymentType: "ACTUAL" });
-                                  }
-                                }}
-                              />
-                              <span>실 결제</span>
-                            </PaymentTypeOption>
-                          </PaymentTypeGroup>
-                        </ItemFieldRow>
-                      </EditItemBlock>
-                    ))}
-                  </EditItemList>
+                  <>
+                    <EditItemList>
+                      {(editItems.length ? editItems : initialEditItems).map((item, index) => (
+                        <EditItemBlock key={item.id}>
+                          <ItemFieldRow>
+                            <ItemLabel htmlFor={`editItemName-${item.id}`}>
+                              품목 {index + 1}
+                            </ItemLabel>
+                            <EditInput
+                              id={`editItemName-${item.id}`}
+                              value={item.name}
+                              onChange={(event) =>
+                                updateEditItem(item.id, { name: event.target.value })
+                              }
+                            />
+                          </ItemFieldRow>
+                          <ItemFieldRow>
+                            <ItemLabel htmlFor={`editQuantity-${item.id}`}>개수</ItemLabel>
+                            <EditInput
+                              id={`editQuantity-${item.id}`}
+                              type="number"
+                              min="1"
+                              step="1"
+                              inputMode="numeric"
+                              value={item.quantity}
+                              onChange={(event) =>
+                                updateEditItem(item.id, { quantity: event.target.value })
+                              }
+                            />
+                          </ItemFieldRow>
+                          <ItemFieldRow>
+                            <ItemLabel htmlFor={`editReason-${item.id}`}>결제 사유</ItemLabel>
+                            <EditInput
+                              id={`editReason-${item.id}`}
+                              value={item.reason}
+                              onChange={(event) =>
+                                updateEditItem(item.id, { reason: event.target.value })
+                              }
+                            />
+                          </ItemFieldRow>
+                          {(editItems.length ? editItems : initialEditItems).length > 1 ? (
+                            <EditItemActionRow>
+                              <DeleteItemButton
+                                type="button"
+                                onClick={() => removeEditItem(item.id)}
+                              >
+                                품목 삭제
+                              </DeleteItemButton>
+                            </EditItemActionRow>
+                          ) : null}
+                        </EditItemBlock>
+                      ))}
+                    </EditItemList>
+                    <AddItemButton type="button" onClick={addEditItem}>
+                      품목 추가하기
+                    </AddItemButton>
+                  </>
                 ) : (
                   <DetailTable>
                     <thead>
@@ -1302,6 +1350,7 @@ const EditSelect = styled.select`
 const EditItemList = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top: -${spacing.space8};
 `;
 
 const EditItemBlock = styled.div`
@@ -1311,9 +1360,18 @@ const EditItemBlock = styled.div`
   padding: ${spacing.space20} 0;
   border-bottom: 1px solid #bcbcbc;
 
+  &:first-child {
+    padding-top: ${spacing.space8};
+  }
+
   @media (min-width: 120rem) {
     gap: ${spacing.space20};
+    padding-top: ${spacing.space20};
     padding-bottom: 1.875rem;
+
+    &:first-child {
+      padding-top: ${spacing.space12};
+    }
   }
 `;
 
@@ -1356,23 +1414,58 @@ const PaymentTypeOption = styled.label`
   display: inline-flex;
   align-items: center;
   gap: ${spacing.space8};
-  min-height: 2.6875rem;
-  padding: 0.8125rem ${spacing.space16};
+  min-height: 1rem;
   background-color: ${colors.white};
   color: #000000;
   font-size: ${typography.fontSize14};
   font-weight: 600;
   line-height: ${typography.lineHeight130};
   cursor: pointer;
+  margin-right: 1rem;
 
   input {
     accent-color: ${colors.point};
   }
 
   @media (min-width: 120rem) {
-    min-height: 4rem;
-    padding: ${spacing.space20} 1.875rem;
+    min-height: 2rem;
     font-size: ${typography.fontSize20};
+    margin-right: 2rem;
+  }
+`;
+
+const EditItemActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const AddItemButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.125rem;
+  border: 0;
+  background-color: ${colors.background};
+  color: #000000;
+  font-size: ${typography.fontSize14};
+  font-weight: 600;
+  line-height: ${typography.lineHeight130};
+  cursor: pointer;
+
+  @media (min-width: 120rem) {
+    min-height: 3.125rem;
+    font-size: ${typography.fontSize20};
+  }
+`;
+
+const DeleteItemButton = styled(AddItemButton)`
+  width: 9rem;
+  border-color: #e45a52;
+  background-color: #fde4e2;
+  color: #da3a30;
+
+  @media (min-width: 120rem) {
+    width: 12rem;
   }
 `;
 

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -1842,12 +1842,14 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                       <EditItemList>
                         {(editItems.length ? editItems : initialEditItems).map((item, index) => (
                           <EditItemBlock key={item.id}>
-                            <ItemFieldRow>
-                              <ItemLabel htmlFor={`editItemName-${item.id}`}>
-                                품목 {index + 1}
-                              </ItemLabel>
-                              <EditInput
-                                id={`editItemName-${item.id}`}
+                          <ItemFieldRow>
+                            <ItemLabel htmlFor={`editItemName-${item.id}`}>
+                              {(editItems.length ? editItems : initialEditItems).length > 1
+                                ? `품목 ${index + 1}`
+                                : "품목"}
+                            </ItemLabel>
+                            <EditInput
+                              id={`editItemName-${item.id}`}
                                 value={item.name}
                                 onChange={(event) =>
                                   updateEditItem(item.id, { name: event.target.value })
@@ -2170,7 +2172,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                   {activeReportItems.map((item, index) => (
                     <ReportGrid key={item.itemId}>
                       <ReportLabel htmlFor={`reportName-${item.itemId}`}>
-                        품목 {index + 1}
+                        {activeReportItems.length > 1 ? `품목 ${index + 1}` : "품목"}
                       </ReportLabel>
                       <ReadOnlyReportField id={`reportName-${item.itemId}`}>
                         {item.name || "-"}

--- a/components/staff/finance-management/FinanceRequestDetailPage.tsx
+++ b/components/staff/finance-management/FinanceRequestDetailPage.tsx
@@ -89,12 +89,6 @@ function getStatusLabel(status?: PurchaseRequestStatus) {
   return status ? (statusLabels[status] ?? status) : "-";
 }
 
-function getPaymentTypeLabel(paymentType?: PaymentType) {
-  if (paymentType === "PREPAID") return "선금 결제";
-  if (paymentType === "ACTUAL") return "실 결제";
-  return "-";
-}
-
 function formatAmount(amount?: number) {
   return typeof amount === "number" ? `${amount.toLocaleString()}원` : "-";
 }
@@ -681,35 +675,33 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                 </InfoRow>
               </Section>
 
-              {isEditing ? (
-                <Section>
-                  <SectionTitle>결제 유형</SectionTitle>
-                  <PaymentTypeGroup aria-disabled="true">
-                    <PaymentTypeOption>
-                      <input
-                        type="checkbox"
-                        name="edit-paymentType"
-                        value="PREPAID"
-                        checked={getRequestPaymentType(request.items) === "PREPAID"}
-                        disabled
-                        readOnly
-                      />
-                      <span>선금 결제</span>
-                    </PaymentTypeOption>
-                    <PaymentTypeOption>
-                      <input
-                        type="checkbox"
-                        name="edit-paymentType"
-                        value="ACTUAL"
-                        checked={getRequestPaymentType(request.items) === "ACTUAL"}
-                        disabled
-                        readOnly
-                      />
-                      <span>실 결제</span>
-                    </PaymentTypeOption>
-                  </PaymentTypeGroup>
-                </Section>
-              ) : null}
+              <Section>
+                <SectionTitle>결제 유형</SectionTitle>
+                <PaymentTypeGroup aria-disabled="true">
+                  <PaymentTypeOption>
+                    <input
+                      type="checkbox"
+                      name="edit-paymentType"
+                      value="PREPAID"
+                      checked={getRequestPaymentType(request.items) === "PREPAID"}
+                      disabled
+                      readOnly
+                    />
+                    <span>선금 결제</span>
+                  </PaymentTypeOption>
+                  <PaymentTypeOption>
+                    <input
+                      type="checkbox"
+                      name="edit-paymentType"
+                      value="ACTUAL"
+                      checked={getRequestPaymentType(request.items) === "ACTUAL"}
+                      disabled
+                      readOnly
+                    />
+                    <span>실 결제</span>
+                  </PaymentTypeOption>
+                </PaymentTypeGroup>
+              </Section>
 
               <Section>
                 <DetailSectionHeader>
@@ -786,7 +778,6 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                         <th>품목</th>
                         <th>개수</th>
                         <th>결제 사유</th>
-                        <th>결제 유형</th>
                         <th>결제 금액</th>
                         <th>영수증</th>
                       </tr>
@@ -798,7 +789,6 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                           <td>{item.name}</td>
                           <td>{typeof item.quantity === "number" ? item.quantity : "-"}</td>
                           <td>{item.reason}</td>
-                          <td>{getPaymentTypeLabel(item.paymentType)}</td>
                           <td>{formatAmount(item.price)}</td>
                           <td>
                             {item.receipt ? (
@@ -806,7 +796,7 @@ export default function FinanceRequestDetailPage({ requestId }: FinanceRequestDe
                                 href={item.receipt.fileUrl ?? "#"}
                                 download={getReceiptName(item.receipt)}
                               >
-                                파일
+                                영수증
                                 <ReceiptIcon aria-hidden="true">
                                   <IconDownload size={12} stroke={2.25} />
                                 </ReceiptIcon>
@@ -1271,17 +1261,21 @@ const DetailTable = styled.table`
 
   td {
     font-weight: 400;
+    text-align: center;
+  }
+
+  td:nth-child(4) {
+    text-align: left;
   }
 
   th:nth-child(1),
   th:nth-child(2),
+  th:nth-child(5),
   th:nth-child(6) {
     width: 8.25rem;
   }
 
-  th:nth-child(3),
-  th:nth-child(5),
-  th:nth-child(7) {
+  th:nth-child(3) {
     width: 6rem;
   }
 
@@ -1294,13 +1288,12 @@ const DetailTable = styled.table`
 
     th:nth-child(1),
     th:nth-child(2),
+    th:nth-child(5),
     th:nth-child(6) {
       width: 12rem;
     }
 
-    th:nth-child(3),
-    th:nth-child(5),
-    th:nth-child(7) {
+    th:nth-child(3) {
       width: 8.25rem;
     }
   }
@@ -1517,11 +1510,17 @@ const ReceiptIcon = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.2em;
-  height: 1.2rem;
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   background-color: ${colors.point};
   color: ${colors.white};
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
 
   @media (min-width: 120rem) {
     width: 2.25rem;

--- a/components/staff/finance-management/FinanceRequestListPage.tsx
+++ b/components/staff/finance-management/FinanceRequestListPage.tsx
@@ -7,7 +7,8 @@ import styled from "styled-components";
 import { useQuery } from "@tanstack/react-query";
 import { getAccessToken, getRefreshToken } from "@/api/client/tokenStorage";
 import { getPurchaseRequests } from "@/api/request/request.api";
-import type { PurchaseRequestStatus } from "@/api/request/request.dto";
+import type { PaymentType, PurchaseRequestStatus } from "@/api/request/request.dto";
+import BoardDropdown, { type DropdownOption } from "@/components/staff/board/BoardDropdown";
 import ListPanel, { type ListPanelRow } from "@/components/staff/common/ListPanel";
 import { FINANCE_REQUESTS_PER_PAGE } from "@/components/staff/finance-management/financeRequestConstants";
 import StaffSidebar from "@/components/staff/common/StaffSidebar";
@@ -20,6 +21,15 @@ type FinanceRequestListPageProps = {
   currentPage: number;
   initialKeyword: string;
 };
+
+type PaymentTypeFilter = "all" | PaymentType;
+type OpenDropdown = "paymentType" | null;
+
+const paymentTypeFilterOptions: readonly DropdownOption<PaymentTypeFilter>[] = [
+  { label: "전체", value: "all" },
+  { label: "선금 결제", value: "PREPAID" },
+  { label: "실 결제", value: "ACTUAL" },
+] as const;
 
 const statusLabels: Record<PurchaseRequestStatus, string> = {
   PENDING: "대기 중",
@@ -44,6 +54,37 @@ function getAffiliationLabel(request: { departmentName?: string; classroomName?:
   return request.departmentName ?? request.classroomName ?? "-";
 }
 
+function getPaymentTypeLabel(paymentType?: PaymentType) {
+  if (paymentType === "PREPAID") return "선금 결제";
+  if (paymentType === "ACTUAL") return "실 결제";
+  return "-";
+}
+
+function getListPaymentType(request: {
+  paymentType?: PaymentType;
+  items?: { paymentType?: PaymentType }[];
+  content?: string;
+}) {
+  if (request.paymentType) {
+    return request.paymentType;
+  }
+
+  const itemPaymentType = request.items?.find((item) => item.paymentType)?.paymentType;
+  if (itemPaymentType) {
+    return itemPaymentType;
+  }
+
+  if (request.content?.includes("결제 유형: 선금 결제")) {
+    return "PREPAID";
+  }
+
+  if (request.content?.includes("결제 유형: 실 결제")) {
+    return "ACTUAL";
+  }
+
+  return undefined;
+}
+
 function buildFinanceListUrl(keyword: string) {
   const trimmedKeyword = keyword.trim();
   return trimmedKeyword
@@ -58,6 +99,8 @@ export default function FinanceRequestListPage({
   const router = useRouter();
   const { user, status: authStatus } = useAuthSession();
   const [mineOnly, setMineOnly] = useState(false);
+  const [paymentTypeFilter, setPaymentTypeFilter] = useState<PaymentTypeFilter>("all");
+  const [openDropdown, setOpenDropdown] = useState<OpenDropdown>(null);
   const [searchInput, setSearchInput] = useState(initialKeyword);
   const [searchKeyword, setSearchKeyword] = useState(initialKeyword);
   const isAuthenticated = authStatus === "authenticated";
@@ -93,7 +136,11 @@ export default function FinanceRequestListPage({
             request.requestedByName === user?.nickname ||
             request.requestedByName === user?.email),
         );
-      return matchesMine;
+      const paymentType = getListPaymentType(request as never);
+      const matchesPaymentType =
+        paymentTypeFilter === "all" || paymentType === paymentTypeFilter;
+
+      return matchesMine && matchesPaymentType;
     })
     .sort((a, b) => getRequestTime(b.createdAt) - getRequestTime(a.createdAt));
   const totalPages = Math.max(1, isAuthenticated ? (data?.totalPages ?? 1) : 1);
@@ -112,6 +159,7 @@ export default function FinanceRequestListPage({
     title: request.title ?? "제목 없음",
     author: request.requestedByName ?? "-",
     date: formatUtcToKstShortDate(request.createdAt),
+    extra: getPaymentTypeLabel(getListPaymentType(request as never)),
     status: getStatusLabel(request.status),
     statusType: request.status,
     detailHref: `/staff/finance-management/${request.id}`,
@@ -148,6 +196,8 @@ export default function FinanceRequestListPage({
             persistentQuery={{
               keyword: trimmedKeyword || undefined,
             }}
+            showExtraColumn
+            extraHeader="결제 유형"
             classHeader="소속"
             showMineOnlyToggle
             toggleLabel="내가 작성한 글만 보기"
@@ -158,6 +208,26 @@ export default function FinanceRequestListPage({
             emptyMessage={emptyMessage}
             headerTone="archive"
             writeIcon={<IconEdit aria-hidden="true" size={16} stroke={2} />}
+            filterSlot={
+              <FilterBar aria-label="결제 신청 필터">
+                <BoardDropdown
+                  label="결제 유형"
+                  options={paymentTypeFilterOptions}
+                  value={paymentTypeFilter}
+                  isOpen={openDropdown === "paymentType"}
+                  onToggle={() =>
+                    setOpenDropdown((current) =>
+                      current === "paymentType" ? null : "paymentType",
+                    )
+                  }
+                  onSelect={(nextValue) => {
+                    setPaymentTypeFilter(nextValue);
+                    setOpenDropdown(null);
+                  }}
+                  width="compact"
+                />
+              </FilterBar>
+            }
             searchSlot={
               <SearchForm
                 role="search"
@@ -221,6 +291,17 @@ const SearchForm = styled.form`
 
   @media (max-width: ${layout.breakpointMobile}) {
     width: 100%;
+  }
+`;
+
+const FilterBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.space20};
+
+  @media (max-width: ${layout.breakpointMobile}) {
+    align-items: stretch;
+    flex-direction: column;
   }
 `;
 

--- a/lib/extractApiErrorMessage.ts
+++ b/lib/extractApiErrorMessage.ts
@@ -1,0 +1,64 @@
+import { isAxiosError } from "axios";
+
+type ApiErrorItem = {
+  message?: unknown;
+};
+
+type ApiErrorPayload = {
+  detail?: unknown;
+  message?: unknown;
+  title?: unknown;
+  errors?: ApiErrorItem[];
+};
+
+function isMeaningfulText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isErrorCodeLike(value: string) {
+  return /^[A-Z]{2,}\d+$/.test(value.trim());
+}
+
+export function extractApiErrorMessage(error: unknown, fallback: string) {
+  if (isAxiosError(error)) {
+    const data = error.response?.data;
+
+    if (isMeaningfulText(data)) {
+      return data;
+    }
+
+    if (data && typeof data === "object") {
+      const payload = data as ApiErrorPayload;
+
+      if (isMeaningfulText(payload.detail)) {
+        return payload.detail;
+      }
+
+      if (isMeaningfulText(payload.message)) {
+        return payload.message;
+      }
+
+      const firstFieldError = payload.errors?.find((item) => isMeaningfulText(item.message));
+      if (firstFieldError && isMeaningfulText(firstFieldError.message)) {
+        return firstFieldError.message;
+      }
+
+      if (isMeaningfulText(payload.title) && !isErrorCodeLike(payload.title)) {
+        return payload.title;
+      }
+    }
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (isMeaningfulText(message)) {
+      return message;
+    }
+  }
+
+  return fallback;
+}

--- a/pwa/components/MobileClassJournalWritePage.tsx
+++ b/pwa/components/MobileClassJournalWritePage.tsx
@@ -23,6 +23,7 @@ import { getStudents } from "@/api/student/student.api";
 import type { StudentListResponseDto } from "@/api/student/student.dto";
 import { getMyAssignedSubjects } from "@/api/subject/subject.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import { markPendingAttendanceSuccessOverlay } from "@/pwa/pages/mobile-home/attendanceSuccessFlag";
 import MobileRequestShell from "@/pwa/requests/components/MobileRequestShell";
@@ -283,7 +284,7 @@ export default function MobileClassJournalWritePage() {
       router.push("/");
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "제출에 실패했습니다.");
+      toast.error(extractApiErrorMessage(error, "제출에 실패했습니다."));
     },
   });
 

--- a/pwa/components/MobileClassRequestsPage.tsx
+++ b/pwa/components/MobileClassRequestsPage.tsx
@@ -23,6 +23,7 @@ import {
   getLessonExchangeRequests,
 } from "@/api/lessonExchange/lessonExchange.api";
 import { getAbsenceRequests } from "@/api/request/request.api";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { useAuthSession } from "@/hooks/useAuthSession";
 import { queryKeys } from "@/lib/queryKeys";
 import AuthStatusSpinner from "@/pwa/pages/mobile-home/components/AuthStatusSpinner";
@@ -312,8 +313,8 @@ export default function MobileClassRequestsPage() {
         setActiveTab("exchange");
       }
     },
-    onError: () => {
-      toast.error("수업 교환 신청서 제출에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "수업 교환 신청서 제출에 실패했습니다."));
     },
   });
 
@@ -337,8 +338,8 @@ export default function MobileClassRequestsPage() {
         setActiveTab("absence");
       }
     },
-    onError: () => {
-      toast.error("결강 신청서 제출에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결강 신청서 제출에 실패했습니다."));
     },
   });
 

--- a/pwa/components/MobileExchangeProposalsPage.tsx
+++ b/pwa/components/MobileExchangeProposalsPage.tsx
@@ -17,6 +17,7 @@ import {
   withdrawLessonExchangeProposal,
 } from "@/api/lessonExchange/lessonExchange.api";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { queryKeys } from "@/lib/queryKeys";
 import AuthStatusSpinner from "@/pwa/pages/mobile-home/components/AuthStatusSpinner";
 import MobileRequestShell from "@/pwa/requests/components/MobileRequestShell";
@@ -192,8 +193,8 @@ export default function MobileExchangeProposalsPage({
       setProposalContent("");
       toast.success("교환 제안을 등록했습니다.");
     },
-    onError: () => {
-      toast.error("교환 제안 등록에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "교환 제안 등록에 실패했습니다."));
     },
   });
 
@@ -212,8 +213,8 @@ export default function MobileExchangeProposalsPage({
       });
       toast.success("교환 제안을 수락했습니다.");
     },
-    onError: () => {
-      toast.error("교환 제안 수락에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "교환 제안 수락에 실패했습니다."));
     },
   });
 
@@ -244,8 +245,8 @@ export default function MobileExchangeProposalsPage({
       setEditingProposalContent("");
       toast.success("교환 제안을 수정했습니다.");
     },
-    onError: () => {
-      toast.error("교환 제안 수정에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "교환 제안 수정에 실패했습니다."));
     },
   });
 
@@ -262,8 +263,8 @@ export default function MobileExchangeProposalsPage({
       setEditingProposalContent("");
       toast.success("교환 제안을 삭제했습니다.");
     },
-    onError: () => {
-      toast.error("교환 제안 삭제에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "교환 제안 삭제에 실패했습니다."));
     },
   });
 

--- a/pwa/components/MobileMyPage.tsx
+++ b/pwa/components/MobileMyPage.tsx
@@ -10,6 +10,7 @@ import { baseURL } from "@/api/client/publicClient";
 import { updateCurrentUser } from "@/api/user/user.api";
 import type { UpdateSelfRequestDto, UserResponseDto } from "@/api/user/user.dto";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { colors, radii, spacing, typography } from "@/styles/tokens";
 import {
   formatBirthDate,
@@ -106,8 +107,8 @@ export default function MobileMyPage() {
       await refreshSession();
       setIsEditing(false);
       toast.success("회원 정보를 수정했습니다.");
-    } catch {
-      toast.error("회원 정보 수정에 실패했습니다.");
+    } catch (error) {
+      toast.error(extractApiErrorMessage(error, "회원 정보 수정에 실패했습니다."));
     } finally {
       setIsSaving(false);
     }

--- a/pwa/components/MobilePaymentRequestsPage.tsx
+++ b/pwa/components/MobilePaymentRequestsPage.tsx
@@ -383,7 +383,7 @@ export default function MobilePaymentRequestsPage() {
       name: item.name.trim(),
       quantity: item.quantity.trim().length > 0 ? Number(item.quantity) : Number.NaN,
       reason: item.reason.trim() || undefined,
-      paymentType: item.paymentType,
+      paymentType: "ACTUAL" as PaymentType,
     }))
     .filter((item) => item.name.length > 0);
 
@@ -570,6 +570,7 @@ export default function MobilePaymentRequestsPage() {
           {showComposer ? (
             <ComposerPanel>
               <PanelTitle>새 결제 신청서</PanelTitle>
+              <PanelNote>선금 결제 요청은 PC에서만 가능합니다.</PanelNote>
               <Form onSubmit={handleSubmit}>
                 <FieldGroup>
                   <FieldLabel htmlFor="mobile-payment-title">제목</FieldLabel>
@@ -605,6 +606,11 @@ export default function MobilePaymentRequestsPage() {
                 </TwoColumn>
 
                 <FieldGroup>
+                  <FieldLabel htmlFor="mobile-payment-type">결제 유형</FieldLabel>
+                  <ReadOnlyInput id="mobile-payment-type" value="실 결제" readOnly />
+                </FieldGroup>
+
+                <FieldGroup>
                   <FieldLabel>거래처 잔액</FieldLabel>
                   <VendorGrid>
                     {vendorBalances.map((vendor) => (
@@ -626,7 +632,7 @@ export default function MobilePaymentRequestsPage() {
                     {items.map((item, index) => (
                       <ItemCard key={item.id}>
                         <ItemCardHeader>
-                          <strong>품목 {index + 1}</strong>
+                          <strong>{items.length > 1 ? `품목 ${index + 1}` : "품목"}</strong>
                           {items.length > 1 ? (
                             <InlineMutedButton type="button" onClick={() => removeItem(item.id)}>
                               삭제
@@ -674,22 +680,6 @@ export default function MobilePaymentRequestsPage() {
                           </FieldGroup>
                         </TwoColumn>
 
-                        <SegmentRow>
-                          <SegmentButton
-                            type="button"
-                            $active={item.paymentType === "ACTUAL"}
-                            onClick={() => updateItem(item.id, { paymentType: "ACTUAL" })}
-                          >
-                            실 결제
-                          </SegmentButton>
-                          <SegmentButton
-                            type="button"
-                            $active={item.paymentType === "PREPAID"}
-                            onClick={() => updateItem(item.id, { paymentType: "PREPAID" })}
-                          >
-                            선금 결제
-                          </SegmentButton>
-                        </SegmentRow>
                       </ItemCard>
                     ))}
                   </ItemStack>
@@ -1156,6 +1146,13 @@ const PanelTitle = styled.h2`
   color: ${colors.text};
   font-size: ${typography.fontSize18};
   font-weight: 800;
+`;
+
+const PanelNote = styled.p`
+  margin: -${spacing.space12} 0 0;
+  color: #72806a;
+  font-size: ${typography.fontSize13};
+  line-height: ${typography.lineHeight130};
 `;
 
 const SearchForm = styled.form`

--- a/pwa/components/MobilePaymentRequestsPage.tsx
+++ b/pwa/components/MobilePaymentRequestsPage.tsx
@@ -28,6 +28,7 @@ import type {
   PurchaseRequestItemResponseDto,
   PurchaseRequestResponseDto,
 } from "@/api/request/request.dto";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { getVendors } from "@/api/vendor/vendor.api";
 import { getAccessToken, getRefreshToken } from "@/api/client/tokenStorage";
 import { useAuthSession } from "@/hooks/useAuthSession";
@@ -263,8 +264,8 @@ export default function MobilePaymentRequestsPage() {
         setSelectedRequestId(created.id);
       }
     },
-    onError: () => {
-      toast.error("결제 신청서 제출에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "결제 신청서 제출에 실패했습니다."));
     },
   });
 
@@ -322,8 +323,8 @@ export default function MobilePaymentRequestsPage() {
       });
       toast.success("구매 보고를 저장했습니다.");
     },
-    onError: () => {
-      toast.error("구매 보고 저장에 실패했습니다.");
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "구매 보고 저장에 실패했습니다."));
     },
   });
 

--- a/pwa/pages/mobile-home/hooks/useMobileHomeScreen.ts
+++ b/pwa/pages/mobile-home/hooks/useMobileHomeScreen.ts
@@ -13,6 +13,7 @@ import {
 import { getAllEvents } from "@/api/event/event.api";
 import { filterEventsInDateRange } from "@/api/event/eventDisplay";
 import { getMyLessons } from "@/api/lesson/lesson.api";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { useNotificationInbox } from "@/pwa/hooks/useNotificationInbox";
 import { consumePendingAttendanceSuccessOverlay } from "@/pwa/pages/mobile-home/attendanceSuccessFlag";
 import { useAttendanceSuccessPopup } from "@/pwa/pages/mobile-home/hooks/useAttendanceSuccessPopup";
@@ -175,9 +176,9 @@ export function useMobileHomeScreen() {
       toast.success("출근이 완료되었습니다.");
       attendanceQuery.refetch().catch(() => undefined);
     },
-    onError: () => {
+    onError: (error) => {
       setIsAttendanceResolving(false);
-      toast.error("출석 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      toast.error(extractApiErrorMessage(error, "출석 처리에 실패했습니다. 잠시 후 다시 시도해주세요."));
     },
   });
   const isAttendanceReady =
@@ -201,9 +202,9 @@ export function useMobileHomeScreen() {
       toast.success("퇴근이 완료되었습니다.");
       attendanceQuery.refetch().catch(() => undefined);
     },
-    onError: () => {
+    onError: (error) => {
       setIsCheckoutResolving(false);
-      toast.error("퇴근 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      toast.error(extractApiErrorMessage(error, "퇴근 처리에 실패했습니다. 잠시 후 다시 시도해주세요."));
     },
   });
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 선금 결제 요청 UI 개편
   \- 요청서를 결제 유형 단위로 분리하고, "선금 결제 UI"를 재구성하였습니다.
   \- 모바일(PWA)에서는 "실 결제"만 가능하도록 제한하였습니다.

   [작성 & 수정]

   <img width="1898" height="866" alt="스크린샷 2026-07-07 000237" src="https://github.com/user-attachments/assets/73311c29-6740-4697-adc9-84b568e82481" />

   <img width="1898" height="863" alt="스크린샷 2026-07-07 000308" src="https://github.com/user-attachments/assets/281dace4-a943-4ff5-996e-eafd3b731052" />

   \- 결제 유형을 "선금 결제"로 선택 시, "품의서" 양식에 맞춘 UI가 나타납니다.

   <img width="1263" height="567" alt="스크린샷 2026-07-07 000633" src="https://github.com/user-attachments/assets/130df99b-aacc-4e50-a089-1fe6dd36c794" />

   \- "품의 번호"는 선택한 "결제 통장" 기준으로 자동 생성됩니다.
   \- “품의 개요”란에는 위 이미지와 같이 기본 양식이 자동으로 입력되어 있습니다. (월은 작성월에 따라 자동으로 변경)
   \- "정책 사업”란은 작성 연도와 “성인문해교육 지원사업”의 조합으로 고정되어 있습니다.
   \- “요구 부서”란에서 선택한 부서는, 하위 “결재 & 협조” 섹션의 "직위"란에도 자동 기입됩니다.
   \- "단위 사업"란은 "프로그램운영비"로 고정되어 있습니다.
   \- "품의 일자"란은 결제 요청서 작성일로 자동 기입됩니다.
   \- “세부 사업”란에서 선택한 항목은, 하위 “예산 내역” 섹션의 "세부 사업"란에도 자동 기입됩니다.
   \- “품의 금액”란에 입력한 금액은, 하위 “예산 내역” 섹션의 "품의 금액"란에도 자동 기입됩니다.

   <img width="1897" height="863" alt="스크린샷 2026-07-07 000339" src="https://github.com/user-attachments/assets/834ab4d1-15d1-4293-a790-86eeefc70a30" />

   \- “예산 내역”에 입력된 품의 금액이 최종 승인 후 거래처에 충전되는 금액입니다.
   \- “품목 내역” 섹션은 예산 내역에 대한 상세 품목을 입력하는 영역입니다.
   \- 수량과 예상 단가에 따라 각 품목의 예상 금액이 자동으로 계산되며, 입력된 품목들의 총합계도 자동으로 계산됩니다.

   <img width="1888" height="311" alt="스크린샷 2026-07-07 000420" src="https://github.com/user-attachments/assets/802a3ac8-e6ab-4f0c-90a3-8a3f12124097" />

   [구매 완료 보고]

   <img width="1260" height="391" alt="스크린샷 2026-07-07 003603" src="https://github.com/user-attachments/assets/fcec54be-a163-4791-a457-a75186b2864d" />

   \- 선금 결제에 대한 구매 완료 보고에는 “결의서” 작성을 위한 “지급 구분” 항목이 추가되어 있습니다.
   \- 선금 결제의 구매 완료 보고 내용은, 작성 시와 동일한 위치에 표시됩니다.

2. 공통 서버 에러 메시지 토스트 처리 추가
   \- 서버 응답의 `detail`, `message`, `errors[].message`를 우선 추출하는 공통 유틸을 추가하였습니다.
   \- 웹/PWA의 주요 요청 액션 실패를 서버 메시지 기반 토스트로 통일하였습니다.

3. 댓글 입력 자동 높이 확장 적용
   \- 입력한 내용의 양에 따라, 댓글 입력 영역의 높이가 자동으로 확장되도록 개선하였습니다.

4. 메인 홈 레이아웃 간격/높이 보정
   \- 교학회의록, 행사 사진, 공지사항 컴포넌트의 높이 및 컴포넌트 간 간격을 정리하였습니다.

5. 관리자 페이지 UX 개선
   \- 관리자 페이지의 결제 요청 관리에서 "요청서 작성 기능"을 제거했습니다.
   \- 관리자 페이지의 뒤로가기 버튼 흐름을 정리하고 "홈 이동" 버튼을 별도로 정의하였습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #193 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
