### PR TITLE
[FEAT] 서비스 사용성 개선 (7)

### DIFF
--- a/api/dailySchedule/dailySchedule.api.test.ts
+++ b/api/dailySchedule/dailySchedule.api.test.ts
@@ -13,6 +13,8 @@ import {
   getDailyScheduleDetail,
   getDailyScheduleDetailIfExists,
   getDailySchedules,
+  getJournalSheetLink,
+  getStudentAttendanceSheet,
   getVolunteerHours,
   updateStudentAttendances,
   updateTeacherAttendance,
@@ -98,6 +100,54 @@ describe("dailySchedule.api", () => {
     expect(observedVolunteerQueryString).toContain("teacherId=3");
     expect(observedVolunteerQueryString).toContain("from=2026-06-01");
     expect(observedVolunteerQueryString).toContain("to=2026-06-30");
+  });
+
+  it("returns the journal sheet link and student attendance sheet", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedAttendanceQueryString = "";
+
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/daily-schedules/journal-sheet-link`, () => {
+        return HttpResponse.json({
+          url: "https://docs.google.com/spreadsheets/d/example/edit",
+        });
+      }),
+      http.get(`${API_BASE_URL}/api/v1/attendance-sheets`, ({ request }) => {
+        observedAttendanceQueryString = new URL(request.url).search;
+        return HttpResponse.json({
+          year: 2026,
+          month: 6,
+          classroomId: 2,
+          classroomName: "한글반",
+          students: [{ studentId: 5, studentName: "김학생" }],
+          schedules: [
+            {
+              dailyScheduleId: 1,
+              lessonDate: "2026-06-01",
+              day: 1,
+              dayOfWeek: "월",
+              status: "SCHEDULED",
+              studentAttendances: [{ attendanceId: 1, studentId: 5, status: "PRESENT" }],
+            },
+          ],
+        });
+      }),
+    );
+
+    await expect(getJournalSheetLink()).resolves.toEqual({
+      url: "https://docs.google.com/spreadsheets/d/example/edit",
+    });
+    await expect(
+      getStudentAttendanceSheet({ year: 2026, month: 6, classroomId: 2 }),
+    ).resolves.toMatchObject({
+      classroomName: "한글반",
+      students: [expect.objectContaining({ studentId: 5 })],
+    });
+
+    expect(observedAttendanceQueryString).toContain("year=2026");
+    expect(observedAttendanceQueryString).toContain("month=6");
+    expect(observedAttendanceQueryString).toContain("classroomId=2");
   });
 
   it("returns null when no daily schedule exists", async () => {

--- a/api/dailySchedule/dailySchedule.api.ts
+++ b/api/dailySchedule/dailySchedule.api.ts
@@ -4,11 +4,14 @@ import type {
   CreateDailyScheduleJournalRequestDto,
   DailyScheduleDetailQueryParamsDto,
   DailyScheduleDetailResponseDto,
+  DailyScheduleJournalSheetLinkResponseDto,
   DailyScheduleListResponseDto,
   DailyScheduleListQueryParamsDto,
   DailySchedulePathParamsDto,
   DailyScheduleVolunteerHoursQueryParamsDto,
   DailyScheduleVolunteerHoursResponseDto,
+  StudentAttendanceSheetQueryParamsDto,
+  StudentAttendanceSheetResponseDto,
   UpdateDailyScheduleJournalRequestDto,
   UpdateDailyScheduleStatusRequestDto,
   UpdateDailyStudentAttendancesRequestDto,
@@ -60,6 +63,27 @@ export async function getDailyScheduleDetailIfExists(query: DailyScheduleDetailQ
 export async function getVolunteerHours(query?: DailyScheduleVolunteerHoursQueryParamsDto) {
   const response = await authClient.get<DailyScheduleVolunteerHoursResponseDto>(
     "/api/v1/daily-schedules/volunteer-hours",
+    {
+      params: query,
+    },
+  );
+
+  return response.data;
+}
+
+// 수업일지 관리 시트 링크를 조회하는 요청
+export async function getJournalSheetLink() {
+  const response = await authClient.get<DailyScheduleJournalSheetLinkResponseDto>(
+    "/api/v1/daily-schedules/journal-sheet-link",
+  );
+
+  return response.data;
+}
+
+// 월간 학생 출석부를 조회하는 요청
+export async function getStudentAttendanceSheet(query: StudentAttendanceSheetQueryParamsDto) {
+  const response = await authClient.get<StudentAttendanceSheetResponseDto>(
+    "/api/v1/attendance-sheets",
     {
       params: query,
     },

--- a/api/dailySchedule/dailySchedule.dto.ts
+++ b/api/dailySchedule/dailySchedule.dto.ts
@@ -24,6 +24,12 @@ export interface DailyScheduleVolunteerHoursQueryParamsDto {
   teacherId?: number;
 }
 
+export interface StudentAttendanceSheetQueryParamsDto {
+  year: number;
+  month: number;
+  classroomId: number;
+}
+
 export interface DailyScheduleLessonResponseDto {
   lessonId?: number;
   period?: number;
@@ -139,4 +145,37 @@ export interface DailyScheduleVolunteerHoursResponseDto {
   to?: string | null;
   totalVolunteerServiceMinutes?: number;
   totalVolunteerServiceHours?: number;
+}
+
+export interface DailyScheduleJournalSheetLinkResponseDto {
+  url?: string;
+}
+
+export interface StudentAttendanceSheetAttendanceResponseDto {
+  attendanceId?: number;
+  studentId?: number;
+  status?: DailyStudentAttendanceStatus;
+}
+
+export interface StudentAttendanceSheetStudentResponseDto {
+  studentId?: number;
+  studentName?: string;
+}
+
+export interface StudentAttendanceSheetScheduleResponseDto {
+  dailyScheduleId?: number;
+  lessonDate?: string;
+  day?: number;
+  dayOfWeek?: string;
+  status?: DailyScheduleStatus;
+  studentAttendances?: StudentAttendanceSheetAttendanceResponseDto[];
+}
+
+export interface StudentAttendanceSheetResponseDto {
+  year?: number;
+  month?: number;
+  classroomId?: number;
+  classroomName?: string;
+  students?: StudentAttendanceSheetStudentResponseDto[];
+  schedules?: StudentAttendanceSheetScheduleResponseDto[];
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -15,6 +15,9 @@ export * as channelDto from "./channel/channel.dto";
 export * as commentApi from "./comment/comment.api";
 export * as commentDto from "./comment/comment.dto";
 
+export * as dailyScheduleApi from "./dailySchedule/dailySchedule.api";
+export * as dailyScheduleDto from "./dailySchedule/dailySchedule.dto";
+
 export * as departmentApi from "./department/department.api";
 export * as departmentDto from "./department/department.dto";
 

--- a/api/request/request.api.test.ts
+++ b/api/request/request.api.test.ts
@@ -18,8 +18,9 @@ import { setAccessToken } from "../client/tokenStorage";
 import {
   approvePurchaseRequest,
   createAdminPurchaseRequest,
-  createPurchaseRequest,
   createLessonExchangeRequest,
+  createPurchaseRequest,
+  generateExpenseDocument,
   getAbsenceRequests,
   getAllPurchaseRequests,
   getLessonExchangeRequests,
@@ -398,6 +399,49 @@ describe("request.api", () => {
     );
 
     expect(observedPathname).toBe("/api/v1/admin/purchase-requests/4/report");
+  });
+
+  it("generates an expense document blob through the admin endpoint", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let observedPathname = "";
+    let observedBody: unknown;
+
+    server.use(
+      http.post(
+        `${API_BASE_URL}/api/v1/admin/purchase-requests/4/expense-document`,
+        async ({ request }) => {
+          observedPathname = new URL(request.url).pathname;
+          observedBody = await request.json();
+          return new HttpResponse(new Blob(["docx-content"]), {
+            status: 200,
+            headers: {
+              "Content-Type":
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await generateExpenseDocument(
+      { requestId: 4 },
+      {
+        fiscalYear: "2026년",
+        paymentMethod: "TRANSFER",
+        items: [{ spec: "A4", unitPrice: 3000 }],
+        draftApprovals: [{ position: "담당", name: "김담당" }],
+      },
+    );
+
+    expect(response).toBeInstanceOf(Blob);
+    expect(observedPathname).toBe("/api/v1/admin/purchase-requests/4/expense-document");
+    expect(observedBody).toEqual({
+      fiscalYear: "2026년",
+      paymentMethod: "TRANSFER",
+      items: [{ spec: "A4", unitPrice: 3000 }],
+      draftApprovals: [{ position: "담당", name: "김담당" }],
+    });
   });
 
   it("updates purchase item receipts through the requester endpoint", async () => {

--- a/api/request/request.api.ts
+++ b/api/request/request.api.ts
@@ -7,6 +7,7 @@ import type {
   CreateAbsenceRequestDto,
   CreateLessonExchangeRequestDto,
   CreatePurchaseRequestDto,
+  GenerateExpenseDocumentRequestDto,
   LessonExchangeRequestListResponseDto,
   LessonExchangeRequestResponseDto,
   LessonExchangeRequestStatusQueryParamsDto,
@@ -232,6 +233,22 @@ export async function confirmPurchase(pathParams: RequestPathParamsDto) {
   const response = await authClient.patch<PurchaseRequestResponseDto>(
     `/api/v1/admin/purchase-requests/${pathParams.requestId}/confirm`,
   );
+  return response.data;
+}
+
+// 관리자 기준 지출증빙서류 DOCX를 생성하는 요청
+export async function generateExpenseDocument(
+  pathParams: RequestPathParamsDto,
+  body: GenerateExpenseDocumentRequestDto,
+) {
+  const response = await authClient.post<Blob>(
+    `/api/v1/admin/purchase-requests/${pathParams.requestId}/expense-document`,
+    body,
+    {
+      responseType: "blob",
+    },
+  );
+
   return response.data;
 }
 

--- a/api/request/request.dto.ts
+++ b/api/request/request.dto.ts
@@ -14,6 +14,12 @@ export type PurchaseRequestStatus =
   | "CONFIRMED"
   | "REJECTED";
 export type PaymentType = "PREPAID" | "ACTUAL";
+export type ExpenseDocumentPaymentMethod =
+  | "CASH"
+  | "CARD"
+  | "TRANSFER"
+  | "AUTO_TRANSFER"
+  | "OTHER";
 
 export interface RequestStatusQueryParamsDto {
   status?: RequestStatus;
@@ -234,4 +240,42 @@ export interface ApproveLessonExchangeRequestDto {
 
 export interface RejectRequestDto {
   note: string;
+}
+
+export interface ApprovalLineDto {
+  position?: string;
+  name?: string;
+}
+
+export interface ExpenseDocumentItemDto {
+  spec?: string;
+  unitPrice?: number;
+}
+
+export interface GenerateExpenseDocumentRequestDto {
+  fiscalYear?: string;
+  draftDocumentNumber?: string;
+  resolutionDocumentNumber?: string;
+  policyProject?: string;
+  unitProject?: string;
+  detailProject?: string;
+  budgetDetail?: string;
+  budgetBalance?: number;
+  projectBalance?: number;
+  requestDepartment?: string;
+  draftDate?: string;
+  completionDate?: string;
+  receiver?: string;
+  paymentMethod?: ExpenseDocumentPaymentMethod;
+  initiationDate?: string;
+  resolutionDate?: string;
+  paymentDate?: string;
+  bankAccount?: string;
+  businessNumber?: string;
+  accountHolder?: string;
+  note?: string;
+  items?: ExpenseDocumentItemDto[];
+  draftApprovals?: ApprovalLineDto[];
+  draftCooperations?: ApprovalLineDto[];
+  resolutionApprovals?: ApprovalLineDto[];
 }

--- a/api/user/user.api.test.ts
+++ b/api/user/user.api.test.ts
@@ -19,6 +19,7 @@ import {
   getTeacherContacts,
   getUsers,
   releaseUserClassroom,
+  releaseUserDepartment,
   removeUserPermission,
   updateUser,
   updateCurrentUser,
@@ -255,6 +256,22 @@ describe("user.api", () => {
     );
 
     await expect(releaseUserClassroom({ userId: 1 })).resolves.toBeUndefined();
+    expect(called).toBe(true);
+  });
+
+  it("releases a user's department with DELETE /department", async () => {
+    setAccessToken(VALID_ACCESS_TOKEN);
+
+    let called = false;
+
+    server.use(
+      http.delete(`${API_BASE_URL}/api/v1/users/1/department`, () => {
+        called = true;
+        return new HttpResponse(null, { status: 200 });
+      }),
+    );
+
+    await expect(releaseUserDepartment({ userId: 1 })).resolves.toBeUndefined();
     expect(called).toBe(true);
   });
 

--- a/api/user/user.api.ts
+++ b/api/user/user.api.ts
@@ -77,6 +77,11 @@ export async function releaseUserClassroom(pathParams: UserPathParamsDto) {
   await authClient.delete(`/api/v1/users/${pathParams.userId}/classroom`);
 }
 
+// 특정 사용자의 소속 부서를 해제하는 요청
+export async function releaseUserDepartment(pathParams: UserPathParamsDto) {
+  await authClient.delete(`/api/v1/users/${pathParams.userId}/department`);
+}
+
 // 특정 사용자를 삭제하는 요청
 export async function deleteUser(pathParams: UserPathParamsDto) {
   await authClient.delete(`/api/v1/users/${pathParams.userId}`);

--- a/components/admin/AdminDashboardPage.tsx
+++ b/components/admin/AdminDashboardPage.tsx
@@ -99,6 +99,7 @@ import {
   getUserPermissions,
   getUsers,
   releaseUserClassroom,
+  releaseUserDepartment,
   removeUserPermission,
   updateUser,
 } from "@/api/user/user.api";
@@ -1087,7 +1088,22 @@ export default function AdminDashboardPage() {
   const updateUserMutation = useMutation({
     mutationFn: async () => {
       const userId = selectedUserId ?? 0;
-      const updatedUser = await updateUser({ userId }, mapUpdateUserFormToPayload(userForm));
+      const previousDepartmentId =
+        typeof userDetailQuery.data?.department?.id === "number"
+          ? userDetailQuery.data.department.id
+          : typeof userDetailQuery.data?.departmentId === "number"
+            ? userDetailQuery.data.departmentId
+            : null;
+      const nextDepartmentId = userForm.departmentId ? (toNumber(userForm.departmentId) ?? null) : null;
+      const updatePayload =
+        previousDepartmentId !== null && nextDepartmentId === null
+          ? {
+              ...mapUpdateUserFormToPayload(userForm),
+              departmentId: undefined,
+            }
+          : mapUpdateUserFormToPayload(userForm);
+
+      const updatedUser = await updateUser({ userId }, updatePayload);
       const previousClassroomId =
         typeof userDetailQuery.data?.classroom?.id === "number"
           ? userDetailQuery.data.classroom.id
@@ -1105,6 +1121,10 @@ export default function AdminDashboardPage() {
         } else {
           await assignUserClassroom({ userId }, { classroomId: nextClassroomId });
         }
+      }
+
+      if (previousDepartmentId !== null && nextDepartmentId === null) {
+        await releaseUserDepartment({ userId });
       }
 
       return getUserDetail({ userId });

--- a/components/staff/class-management/class-journal/ClassJournalListPageClient.tsx
+++ b/components/staff/class-management/class-journal/ClassJournalListPageClient.tsx
@@ -2,12 +2,18 @@
 
 import Link from "next/link";
 import { IconEdit } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "react-toastify";
 import styled from "styled-components";
-import { getDailySchedules } from "@/api/dailySchedule/dailySchedule.api";
+import {
+  getDailySchedules,
+  getJournalSheetLink,
+} from "@/api/dailySchedule/dailySchedule.api";
+import { FileUploadProgressNotice } from "@/components/common/FileUploadProgress";
 import { ClassJournalSearch } from "@/components/staff/class-management/class-journal/ClassJournalSearch";
 import { useAuthSession } from "@/hooks/useAuthSession";
+import { extractApiErrorMessage } from "@/lib/extractApiErrorMessage";
 import { colors, layout, radii, spacing, typography } from "@/styles/tokens";
 import { buildClassJournalHref } from "@/utils/classJournalHref";
 import { mapClassJournalListItem } from "@/utils/mapClassJournalListItem";
@@ -23,6 +29,24 @@ export default function ClassJournalListPageClient() {
   const pageParam = Number(searchParams.get("page"));
   const isAuthenticated = authStatus === "authenticated";
   const requestedPage = Number.isInteger(pageParam) && pageParam >= 1 ? pageParam : 1;
+
+  const journalSheetLinkMutation = useMutation({
+    mutationFn: getJournalSheetLink,
+    onSuccess: ({ url }) => {
+      if (!url) {
+        toast.error("수업 일지 출력 링크를 불러오지 못했습니다.");
+        return;
+      }
+
+      const openedWindow = window.open(url, "_blank", "noopener,noreferrer");
+      if (!openedWindow) {
+        window.location.assign(url);
+      }
+    },
+    onError: (error) => {
+      toast.error(extractApiErrorMessage(error, "수업 일지 출력 링크 조회에 실패했습니다."));
+    },
+  });
 
   const { data: schedulePage } = useQuery({
     queryKey: [
@@ -63,7 +87,17 @@ export default function ClassJournalListPageClient() {
       <HeaderRow>
         <Title>수업 일지</Title>
         <ActionGroup $isVisible={isAuthenticated} aria-hidden={!isAuthenticated}>
-          <ActionButton type="button" disabled={!isAuthenticated}>
+          {journalSheetLinkMutation.isPending ? (
+            <FileUploadProgressNotice message="스프레드시트 불러오는 중..." />
+          ) : null}
+          <ActionButton
+            type="button"
+            disabled={!isAuthenticated || journalSheetLinkMutation.isPending}
+            onClick={() => {
+              if (!isAuthenticated || journalSheetLinkMutation.isPending) return;
+              journalSheetLinkMutation.mutate();
+            }}
+          >
             수업 일지 출력
           </ActionButton>
           <ActionLink


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1.  관리자 페이지의 사용자 관리 섹션에서, 사용자 부서 해제 API를 연동하였습니다.
2. 수업 일지 출력 버튼에 스프레드시트 링크 반환 API를 연동해 두었습니다.

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #197 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
